### PR TITLE
Fix bug where multiple inputs did not map to outputs

### DIFF
--- a/pages/dist/bundle.js
+++ b/pages/dist/bundle.js
@@ -15708,10 +15708,10 @@ class ValidationService extends EventEmitter {
                 message
             });
         };
-        this.handleCompleteValidation = (id, validationInputs, validationOutputs) => {
+        this.handleCompleteValidation = (id, validationInput, validationOutputs) => {
             this.emit(ValidationEvents.VALIDATION_SUCCESS, {
                 id,
-                validationInputs,
+                validationInput,
                 validationOutputs
             });
         };
@@ -15721,7 +15721,7 @@ class ValidationService extends EventEmitter {
             const results = yield Promise.all(inputs.map((input) => __awaiter(this, void 0, void 0, function* () {
                 try {
                     const result = yield this.adapter(input);
-                    this.handleCompleteValidation(id, inputs, result);
+                    this.handleCompleteValidation(id, input, result);
                     return result;
                 }
                 catch (e) {
@@ -15800,6 +15800,8 @@ const createDecorationForValidationRange = (output, isHovering = false, addHeigh
         : decorationArray;
 };
 const createDecorationsForValidationRanges = (ranges) => flatten_1(ranges.map(_ => createDecorationForValidationRange(_)));
+
+//# sourceMappingURL=decoration.js.map
 
 /**
  * The base implementation of `_.clamp` which doesn't coerce arguments.
@@ -19685,7 +19687,7 @@ const mergeOutputsFromValidationResponse = (response, currentOutputs, trs) => {
     if (!initialTransaction && trs.length > 1) {
         return currentOutputs;
     }
-    const mappedInputs = mapRangeThroughTransactions(response.validationInputs, validationId, trs);
+    const mappedInputs = mapRangeThroughTransactions([response.validationInput], validationId, trs);
     const newOutputs = mapRangeThroughTransactions(response.validationOutputs, validationId, trs);
     return removeOverlappingRanges(currentOutputs, mappedInputs).concat(newOutputs);
 };
@@ -19734,7 +19736,6 @@ const mapRangeThroughTransactions = (ranges, time, trs) => compact_1(ranges.map(
     }), range)));
 }));
 const expandRangesToParentBlockNode = (ranges, doc) => getRangesOfParentBlockNodes(ranges, doc);
-//# sourceMappingURL=range.js.map
 
 const VALIDATION_PLUGIN_ACTION = "VALIDATION_PLUGIN_ACTION";
 const VALIDATION_REQUEST_START = "VAlIDATION_REQUEST_START";
@@ -20028,9 +20029,7 @@ const createValidatorPlugin = (options) => {
                 const newState = Object.assign({}, state, { decorations: state.decorations.map(tr.mapping, tr.doc), dirtiedRanges: mapAndMergeRanges(tr, state.dirtiedRanges), trHistory: state.trHistory.length > 25
                         ? state.trHistory.slice(1).concat(tr)
                         : state.trHistory.concat(tr) });
-                const action = tr.getMeta(VALIDATION_PLUGIN_ACTION);
-                const reducedState = validationPluginReducer(tr, newState, action);
-                return reducedState;
+                return validationPluginReducer(tr, newState, tr.getMeta(VALIDATION_PLUGIN_ACTION));
             }
         },
         appendTransaction(trs, oldState, newState) {

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -325,9 +325,11 @@ const createValidatorPlugin = (options: IPluginOptions) => {
               : state.trHistory.concat(tr)
         };
         // Apply our reducer.
-        const action: Action | undefined = tr.getMeta(VALIDATION_PLUGIN_ACTION);
-        const reducedState = validationPluginReducer(tr, newState, action);
-        return reducedState;
+        return validationPluginReducer(
+          tr,
+          newState,
+          tr.getMeta(VALIDATION_PLUGIN_ACTION)
+        );
       }
     },
 

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -16,7 +16,7 @@ export interface IValidationError {
 }
 
 export interface IValidationResponse {
-  validationInputs: IValidationInput[];
+  validationInput: IValidationInput;
   validationOutputs: IValidationOutput[];
   id: string;
 }

--- a/src/ts/services/ValidationAPIService.ts
+++ b/src/ts/services/ValidationAPIService.ts
@@ -31,7 +31,7 @@ class ValidationService extends EventEmitter implements IValidationService {
       inputs.map(async input => {
         try {
           const result = await this.adapter(input);
-          this.handleCompleteValidation(id, inputs, result);
+          this.handleCompleteValidation(id, input, result);
           return result;
         } catch (e) {
           this.handleError(input, id, e.message);
@@ -73,12 +73,12 @@ class ValidationService extends EventEmitter implements IValidationService {
    */
   private handleCompleteValidation = (
     id: string | number,
-    validationInputs: IValidationInput[],
+    validationInput: IValidationInput,
     validationOutputs: IValidationOutput[]
   ) => {
     this.emit(ValidationEvents.VALIDATION_SUCCESS, {
       id,
-      validationInputs,
+      validationInput,
       validationOutputs
     } as IValidationResponse);
   };

--- a/src/ts/test/state.spec.ts
+++ b/src/ts/test/state.spec.ts
@@ -134,7 +134,11 @@ describe("State management", () => {
             initialState,
             validationRequestSuccess({
               validationOutputs: [],
-              validationInputs: [],
+              validationInput: {
+                str: 'hai',
+                from: 0,
+                to: 25
+              },
               id: "1337"
             })
           )
@@ -150,11 +154,11 @@ describe("State management", () => {
             tr,
             initialState,
             validationRequestSuccess({
-              validationInputs: [{
+              validationInput: {
                 str: "Example text to validate",
                 from: 5,
                 to: 10,
-              }],
+              },
               validationOutputs: [
                 {
                   id: "id",

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -128,7 +128,7 @@ export const mergeOutputsFromValidationResponse = (
   }
 
   const mappedInputs = mapRangeThroughTransactions(
-    response.validationInputs,
+    [response.validationInput],
     validationId,
     trs
   );


### PR DESCRIPTION
A validation response should be a one-to-many relationship between a validation input and the corresponding outputs, but many inputs were added to the response. This led to odd behaviour. This PR fixes that issue.