### PR TITLE
Simplify validation response

### DIFF
--- a/pages/dist/styles.css
+++ b/pages/dist/styles.css
@@ -1,86 +1,79 @@
+@charset "UTF-8";
 .ProseMirror {
-  position: relative;
-}
+  position: relative; }
 
 .ProseMirror {
   word-wrap: break-word;
   white-space: pre-wrap;
   -webkit-font-variant-ligatures: none;
-  font-variant-ligatures: none;
-}
+  font-variant-ligatures: none; }
 
 .ProseMirror pre {
-  white-space: pre-wrap;
-}
+  white-space: pre-wrap; }
 
 .ProseMirror li {
-  position: relative;
-}
+  position: relative; }
 
-.ProseMirror-hideselection *::selection { background: transparent; }
-.ProseMirror-hideselection *::-moz-selection { background: transparent; }
-.ProseMirror-hideselection { caret-color: transparent; }
+.ProseMirror-hideselection *::selection {
+  background: transparent; }
+
+.ProseMirror-hideselection *::-moz-selection {
+  background: transparent; }
+
+.ProseMirror-hideselection {
+  caret-color: transparent; }
 
 .ProseMirror-selectednode {
-  outline: 2px solid #8cf;
-}
+  outline: 2px solid #8cf; }
 
 /* Make sure li selections wrap around markers */
-
 li.ProseMirror-selectednode {
-  outline: none;
-}
+  outline: none; }
 
 li.ProseMirror-selectednode:after {
   content: "";
   position: absolute;
   left: -32px;
-  right: -2px; top: -2px; bottom: -2px;
+  right: -2px;
+  top: -2px;
+  bottom: -2px;
   border: 2px solid #8cf;
-  pointer-events: none;
-}
+  pointer-events: none; }
+
 .ProseMirror-textblock-dropdown {
-  min-width: 3em;
-}
+  min-width: 3em; }
 
 .ProseMirror-menu {
   margin: 0 -4px;
-  line-height: 1;
-}
+  line-height: 1; }
 
 .ProseMirror-tooltip .ProseMirror-menu {
   width: -webkit-fit-content;
   width: fit-content;
-  white-space: pre;
-}
+  white-space: pre; }
 
 .ProseMirror-menuitem {
   margin-right: 3px;
-  display: inline-block;
-}
+  display: inline-block; }
 
 .ProseMirror-menuseparator {
   border-right: 1px solid #ddd;
-  margin-right: 3px;
-}
+  margin-right: 3px; }
 
 .ProseMirror-menu-dropdown, .ProseMirror-menu-dropdown-menu {
   font-size: 90%;
-  white-space: nowrap;
-}
+  white-space: nowrap; }
 
 .ProseMirror-menu-dropdown {
   vertical-align: 1px;
   cursor: pointer;
   position: relative;
-  padding-right: 15px;
-}
+  padding-right: 15px; }
 
 .ProseMirror-menu-dropdown-wrap {
   padding: 1px 0 1px 4px;
   display: inline-block;
-  position: relative;
-}
+  position: relative; }
 
 .ProseMirror-menu-dropdown:after {
   content: "";
@@ -90,35 +83,29 @@ li.ProseMirror-selectednode:after {
   opacity: .6;
   position: absolute;
   right: 4px;
-  top: calc(50% - 2px);
-}
+  top: calc(50% - 2px); }
 
 .ProseMirror-menu-dropdown-menu, .ProseMirror-menu-submenu {
   position: absolute;
   background: white;
   color: #666;
   border: 1px solid #aaa;
-  padding: 2px;
-}
+  padding: 2px; }
 
 .ProseMirror-menu-dropdown-menu {
   z-index: 15;
-  min-width: 6em;
-}
+  min-width: 6em; }
 
 .ProseMirror-menu-dropdown-item {
   cursor: pointer;
-  padding: 2px 8px 2px 4px;
-}
+  padding: 2px 8px 2px 4px; }
 
 .ProseMirror-menu-dropdown-item:hover {
-  background: #f2f2f2;
-}
+  background: #f2f2f2; }
 
 .ProseMirror-menu-submenu-wrap {
   position: relative;
-  margin-right: -4px;
-}
+  margin-right: -4px; }
 
 .ProseMirror-menu-submenu-label:after {
   content: "";
@@ -128,33 +115,27 @@ li.ProseMirror-selectednode:after {
   opacity: .6;
   position: absolute;
   right: 4px;
-  top: calc(50% - 4px);
-}
+  top: calc(50% - 4px); }
 
 .ProseMirror-menu-submenu {
   display: none;
   min-width: 4em;
   left: 100%;
-  top: -3px;
-}
+  top: -3px; }
 
 .ProseMirror-menu-active {
   background: #eee;
-  border-radius: 4px;
-}
+  border-radius: 4px; }
 
 .ProseMirror-menu-active {
   background: #eee;
-  border-radius: 4px;
-}
+  border-radius: 4px; }
 
 .ProseMirror-menu-disabled {
-  opacity: .3;
-}
+  opacity: .3; }
 
 .ProseMirror-menu-submenu-wrap:hover .ProseMirror-menu-submenu, .ProseMirror-menu-submenu-wrap-active .ProseMirror-menu-submenu {
-  display: block;
-}
+  display: block; }
 
 .ProseMirror-menubar {
   border-top-left-radius: inherit;
@@ -163,64 +144,58 @@ li.ProseMirror-selectednode:after {
   min-height: 1em;
   color: #666;
   padding: 1px 6px;
-  top: 0; left: 0; right: 0;
+  top: 0;
+  left: 0;
+  right: 0;
   border-bottom: 1px solid silver;
   background: white;
   z-index: 10;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
-  overflow: visible;
-}
+  overflow: visible; }
 
 .ProseMirror-icon {
   display: inline-block;
   line-height: .8;
-  vertical-align: -2px; /* Compensate for padding */
+  vertical-align: -2px;
+  /* Compensate for padding */
   padding: 2px 8px;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 .ProseMirror-menu-disabled.ProseMirror-icon {
-  cursor: default;
-}
+  cursor: default; }
 
 .ProseMirror-icon svg {
   fill: currentColor;
-  height: 1em;
-}
+  height: 1em; }
 
 .ProseMirror-icon span {
-  vertical-align: text-top;
-}
-/* Add space around the hr to make clicking it easier */
+  vertical-align: text-top; }
 
+/* Add space around the hr to make clicking it easier */
 .ProseMirror-example-setup-style hr {
   padding: 2px 10px;
   border: none;
-  margin: 1em 0;
-}
+  margin: 1em 0; }
 
 .ProseMirror-example-setup-style hr:after {
   content: "";
   display: block;
   height: 1px;
   background-color: silver;
-  line-height: 2px;
-}
+  line-height: 2px; }
 
 .ProseMirror ul, .ProseMirror ol {
-  padding-left: 30px;
-}
+  padding-left: 30px; }
 
 .ProseMirror blockquote {
   padding-left: 1em;
   border-left: 3px solid #eee;
-  margin-left: 0; margin-right: 0;
-}
+  margin-left: 0;
+  margin-right: 0; }
 
 .ProseMirror-example-setup-style img {
-  cursor: default;
-}
+  cursor: default; }
 
 .ProseMirror-prompt {
   background: white;
@@ -229,38 +204,35 @@ li.ProseMirror-selectednode:after {
   position: fixed;
   border-radius: 3px;
   z-index: 11;
-  box-shadow: -.5px 2px 5px rgba(0, 0, 0, .2);
-}
+  box-shadow: -0.5px 2px 5px rgba(0, 0, 0, 0.2); }
 
 .ProseMirror-prompt h5 {
   margin: 0;
   font-weight: normal;
   font-size: 100%;
-  color: #444;
-}
+  color: #444; }
 
 .ProseMirror-prompt input[type="text"],
 .ProseMirror-prompt textarea {
   background: #eee;
   border: none;
-  outline: none;
-}
+  outline: none; }
 
 .ProseMirror-prompt input[type="text"] {
-  padding: 0 4px;
-}
+  padding: 0 4px; }
 
 .ProseMirror-prompt-close {
   position: absolute;
-  left: 2px; top: 1px;
+  left: 2px;
+  top: 1px;
   color: #666;
-  border: none; background: transparent; padding: 0;
-}
+  border: none;
+  background: transparent;
+  padding: 0; }
 
 .ProseMirror-prompt-close:after {
   content: "✕";
-  font-size: 12px;
-}
+  font-size: 12px; }
 
 .ProseMirror-invalid {
   background: #ffc;
@@ -268,40 +240,34 @@ li.ProseMirror-selectednode:after {
   border-radius: 4px;
   padding: 5px 10px;
   position: absolute;
-  min-width: 10em;
-}
+  min-width: 10em; }
 
 .ProseMirror-prompt-buttons {
   margin-top: 5px;
-  display: none;
-}
+  display: none; }
+
 :root {
   --validation-color: #3dcde6;
   --validation-color-hover: #3dcde624;
   --validation-gray: #a0a0a0;
   --validation-debug-color-dirty: #f7a85e66;
-  --validation-debug-color-inflight: #f7a85ea1;
-}
+  --validation-debug-color-inflight: #f7a85ea1; }
 
 .Button {
   padding: 1px 4px;
   border: 1px solid lightgrey;
   border-radius: 3px;
   font-size: 16px;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 .Button:hover {
-  background-color: #eee;
-}
+  background-color: #eee; }
 
 .Input[type=checkbox] {
-  margin-left: calc(var(--gutter-width));
-}
+  margin-left: calc(var(--gutter-width)); }
 
 .Button:active, .Button:focus {
-  outline: none;
-}
+  outline: none; }
 
 .ValidationWidget {
   display: inline-block;
@@ -311,52 +277,43 @@ li.ProseMirror-selectednode:after {
   font-style: normal;
   font-weight: normal;
   background-color: white;
-  box-shadow: #4e56643b 0px 0px 1px 0px,
-    #3f48573a 0px 2px 7px 0px;
+  box-shadow: #4e56643b 0px 0px 1px 0px, #3f48573a 0px 2px 7px 0px;
   border-radius: 3px;
   width: 200px;
   transition: opacity 0.1s, transform 0.1s;
   transform: translate3d(0, -3px, 0);
   z-index: 1;
-  overflow: hidden;
-}
+  overflow: hidden; }
 
 .ValidationWidget__container {
-  position: relative;
-}
+  position: relative; }
 
 .ValidationWidget__container--is-hovering .ValidationWidget {
   opacity: 1;
-  transform: translate3d(0, 0, 0);
-}
+  transform: translate3d(0, 0, 0); }
 
 .ValidationWidget__type {
   color: var(--validation-gray);
   font-variant: small-caps;
   text-transform: lowercase;
-  letter-spacing: 0.3px;
-}
+  letter-spacing: 0.3px; }
 
 .ValidationWidget__annotation,
 .ValidationWidget__suggestion,
 .ValidationWidget__type {
-  padding: var(--gutter-width);
-}
+  padding: var(--gutter-width); }
 
 .ValidationWidget__annotation {
-  padding-top: 0;
-}
+  padding-top: 0; }
 
 .ValidationWidget__label {
   display: block;
   margin-bottom: 2px;
-  transition: background-color 0.1s;
-}
+  transition: background-color 0.1s; }
 
 .ValidationWidget__suggestion-list {
   display: block;
-  margin-top: 3px;
-}
+  margin-top: 3px; }
 
 .ValidationWidget__suggestion {
   display: block;
@@ -364,95 +321,78 @@ li.ProseMirror-selectednode:after {
   cursor: pointer;
   color: var(--validation-color);
   font-weight: 700;
-  font-size: 16px;
-}
+  font-size: 16px; }
 
 .ValidationWidget__suggestion:hover {
   background-color: var(--validation-color);
-  color: white;
-}
+  color: white; }
+
 .ValidationWidget__suggestion + .ValidationWidget__suggestion {
-  margin-top: 3px;
-}
+  margin-top: 3px; }
 
 .ValidationDecoration {
-  border-bottom: 2px solid var(--validation-color);
-}
+  border-bottom: 2px solid var(--validation-color); }
 
 .ValidationDecoration--is-hovering {
-  background-color: var(--validation-color-hover);
-}
+  background-color: var(--validation-color-hover); }
 
 .ValidationDebugDirty {
-  background-color: var(--validation-debug-color-dirty);
-}
+  background-color: var(--validation-debug-color-dirty); }
 
 .ValidationDebugInflight {
-  background-color: var(--validation-debug-color-inflight);
-}
+  background-color: var(--validation-debug-color-inflight); }
 
 .ValidationPlugin__overlay {
   position: absolute;
   top: 0;
-  left: 0;
-}
+  left: 0; }
 
 .ValidationPlugin__decoration-container {
-  position: absolute;
-}
+  position: absolute; }
 
 .ValidationPlugin__container {
-  position: relative;
-}
+  position: relative; }
+
 .Sidebar__section {
   background-color: white;
   border-radius: 4px;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  margin: 0 calc(var(--gutter-width) / 2);
-}
+  margin: 0 calc(var(--gutter-width) / 2); }
 
 .Sidebar__container + .Sidebar__container {
-  margin-top: var(--gutter-width);
-}
+  margin-top: var(--gutter-width); }
 
 .Sidebar__header {
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
   padding: calc(var(--gutter-width)) calc(var(--gutter-width) / 2);
   font-weight: 500;
   display: flex;
-  justify-content: space-between;
-}
+  justify-content: space-between; }
 
 .Sidebar__header-option {
   font-weight: 400;
-  font-size: 14px;
-}
+  font-size: 14px; }
 
 .Sidebar__awaiting-validation {
   padding: calc(var(--gutter-width) / 2);
-  color: gray;
-}
+  color: gray; }
 
 .Sidebar__list {
   margin: 0;
   padding: 0;
-  list-style: none;
-}
+  list-style: none; }
 
 .Sidebar__awaiting-validation {
   padding: calc(var(--gutter-width) / 2);
-  color: gray;
-}
+  color: gray; }
 
 .Sidebar__list {
   margin: 0;
   padding: 0;
-  list-style: none;
-}
+  list-style: none; }
 
 .Sidebar__list-item {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-}
+  border-bottom: 1px solid rgba(0, 0, 0, 0.2); }
 
 .Sidebar__loading-spinner {
   display: inline-block;
@@ -461,72 +401,53 @@ li.ProseMirror-selectednode:after {
   line-height: 1;
   animation-duration: 0.5s;
   animation-name: spin;
-  animation-iteration-count: infinite;
-}
+  animation-iteration-count: infinite; }
 
 @keyframes spin {
   from {
-    transform: rotate(0deg);
-  }
+    transform: rotate(0deg); }
   to {
-    transform: rotate(360deg);
-  }
-}
+    transform: rotate(360deg); } }
+
 .ValidationControls__row {
-	display: flex;
-	padding: calc(var(--gutter-width) / 2);
-}
-
-.ValidationControls__label {
-
-}
+  display: flex;
+  padding: calc(var(--gutter-width) / 2); }
 
 .ValidationControls__input {
-	min-width: 30px;
-	text-align: right;
-}
+  min-width: 30px;
+  text-align: right; }
+
 .ValidationSidebarOutput__container {
-  padding: calc(var(--gutter-width) / 2);
-}
+  padding: calc(var(--gutter-width) / 2); }
 
 .ValidationSidebarOutput__container--is-selected {
-  border-left: 2px solid var(--validation-color);
-}
-
-
+  border-left: 2px solid var(--validation-color); }
 
 .ValidationSidebarOutput__list-item:last-child {
-  border-bottom: none;
-}
+  border-bottom: none; }
 
 .ValidationSidebarOutput__header {
   display: flex;
   justify-content: space-between;
-  cursor: pointer;
-}
+  cursor: pointer; }
 
 .ValidationSidebarOutput__header-range {
   margin-left: calc(var(--gutter-width) / 2);
   font-size: 12px;
-  color: grey;
-}
+  color: grey; }
 
 .ValidationSidebarOutput__header-toggle-status {
   min-width: 20px;
   color: grey;
-  text-align: right;
-}
+  text-align: right; }
 
 .ValidationSidebarOutput__content {
   margin-top: calc(var(--gutter-width) / 2);
-  font-size: 14px;
-}
+  font-size: 14px; }
 
 .ValidationSidebarOutput__suggestion-list {
-  margin-top: calc(var(--gutter-width) / 2);
-}
+  margin-top: calc(var(--gutter-width) / 2); }
 
 .ValidationSidebarOutput__suggestion-list-title {
   font-style: italic;
-  margin-bottom: calc(var(--gutter-width) / 2);
-}
+  margin-bottom: calc(var(--gutter-width) / 2); }

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -4,7 +4,6 @@ import { Schema, DOMParser } from "prosemirror-model";
 import { marks, schema } from "prosemirror-schema-basic";
 import { addListNodes } from "prosemirror-schema-list";
 import { history } from "prosemirror-history";
-import { keymap } from "prosemirror-keymap";
 import { exampleSetup, buildMenuItems } from "prosemirror-example-setup";
 
 import "prosemirror-view/style/prosemirror.css";
@@ -18,6 +17,7 @@ import createValidatorPlugin from "../src/ts/createValidationPlugin";
 import createView from "../src/ts/createView";
 import regexAdapter from "../src/ts/adapters/regex";
 import { createBoundCommands } from "../src/ts/commands";
+import ValidationService from "../src/ts/services/ValidationAPIService";
 
 const mySchema = new Schema({
   nodes: addListNodes(schema.spec.nodes as any, "paragraph block*", "block"),
@@ -30,13 +30,12 @@ const doc = DOMParser.fromSchema(mySchema).parse(contentElement);
 if (contentElement && contentElement.parentElement) {
   contentElement.parentElement.removeChild(contentElement);
 }
+
 const historyPlugin = history();
 const editorElement = document.querySelector("#editor");
 const sidebarElement = document.querySelector("#sidebar");
-const controlsElement = document.querySelector('#controls');
-const { plugin: validatorPlugin, store, getState } = createValidatorPlugin({
-  adapter: regexAdapter
-});
+const controlsElement = document.querySelector("#controls");
+const { plugin: validatorPlugin, store, getState } = createValidatorPlugin();
 
 if (editorElement && sidebarElement && controlsElement) {
   const view = new EditorView(editorElement, {
@@ -55,10 +54,16 @@ if (editorElement && sidebarElement && controlsElement) {
   });
 
   const commands = createBoundCommands(view, getState);
+  const validationService = new ValidationService(
+    store,
+    commands,
+    regexAdapter
+  );
   (window as any).editor = view;
-  const debugButton = document.getElementById('debug-button');
+  const debugButton = document.getElementById("debug-button");
   if (debugButton) {
-    debugButton.onclick = () => commands.setDebugState(!!validatorPlugin.getState(view.state).debug)
+    debugButton.onclick = () =>
+      commands.setDebugState(!!validatorPlugin.getState(view.state).debug);
   }
   createView(view, store, commands, sidebarElement, controlsElement);
 }

--- a/src/ts/components/ValidationControls.tsx
+++ b/src/ts/components/ValidationControls.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from "preact";
-import Store from "../store";
+import Store, { STORE_EVENT_NEW_STATE } from "../store";
 import { IPluginState } from "../state";
 
 interface IProps {
@@ -13,7 +13,7 @@ interface IProps {
  */
 class ValidationControls extends Component<IProps, IPluginState> {
   public componentWillMount() {
-    this.props.store.subscribe(this.handleNotify);
+    this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
   }
 
   public render() {

--- a/src/ts/components/ValidationOverlay.tsx
+++ b/src/ts/components/ValidationOverlay.tsx
@@ -3,7 +3,7 @@ import ValidationOutput from './ValidationOutputContainer';
 import { Component, h } from 'preact';
 import { IStateHoverInfo, selectValidationById, IPluginState } from '../state';
 import { IValidationOutput } from '../interfaces/IValidation';
-import Store from '../store';
+import Store, { STORE_EVENT_NEW_STATE } from '../store';
 import { ApplySuggestionOptions } from '../commands';
 
 interface IState {
@@ -32,7 +32,7 @@ class ValidationOverlay extends Component<IProps, IState> {
   private decorationRef: ValidationOutput;
 
   public componentWillMount() {
-    this.props.store.subscribe(this.handleNotify);
+    this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
   }
 
   public componentDidUpdate() {

--- a/src/ts/components/ValidationSidebar.tsx
+++ b/src/ts/components/ValidationSidebar.tsx
@@ -19,7 +19,7 @@ class ValidationSidebar extends Component<
   { pluginState: IPluginState | undefined; groupResults: boolean }
 > {
   public componentWillMount() {
-    this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
+    this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNewState);
   }
 
   public render() {
@@ -67,8 +67,15 @@ class ValidationSidebar extends Component<
       </div>
     );
   }
-  private handleNotify = (pluginState: IPluginState) => {
-    this.setState({ pluginState });
+  private handleNewState = (pluginState: IPluginState) => {
+    this.setState({
+      pluginState: {
+        ...pluginState,
+        currentValidations: pluginState.currentValidations.sort((a, b) =>
+          a.from > b.from ? 1 : -1
+        )
+      }
+    });
   };
 }
 

--- a/src/ts/components/ValidationSidebar.tsx
+++ b/src/ts/components/ValidationSidebar.tsx
@@ -1,5 +1,5 @@
 import { Component, h } from "preact";
-import Store from "../store";
+import Store, { STORE_EVENT_NEW_STATE } from "../store";
 import { ApplySuggestionOptions } from "../commands";
 import { IPluginState } from "../state";
 import ValidationSidebarOutput from "./ValidationSidebarOutput";
@@ -16,20 +16,20 @@ interface IProps {
  */
 class ValidationSidebar extends Component<
   IProps,
-  IPluginState & { groupResults: boolean }
+  { pluginState: IPluginState | undefined; groupResults: boolean }
 > {
   public componentWillMount() {
-    this.props.store.subscribe(this.handleNotify);
+    this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
   }
 
   public render() {
     const { applySuggestions, selectValidation, indicateHover } = this.props;
     const {
-      currentValidations,
-      validationInFlight,
-      validationPending,
+      currentValidations = [],
+      validationsInFlight = [],
+      validationPending = false,
       selectedValidation
-    } = this.state;
+    } = this.state.pluginState || { selectedValidation: undefined };
     const hasValidations = !!(currentValidations && currentValidations.length);
     return (
       <div className="Sidebar__section">
@@ -37,10 +37,9 @@ class ValidationSidebar extends Component<
           <span>
             Validation results{" "}
             {hasValidations && <span>({currentValidations.length}) </span>}
-            {(validationInFlight ||
-              validationPending) && (
-                <span className="Sidebar__loading-spinner">|</span>
-              )}
+            {(validationsInFlight.length || validationPending) && (
+              <span className="Sidebar__loading-spinner">|</span>
+            )}
           </span>
         </div>
         <div className="Sidebar__content">
@@ -68,8 +67,8 @@ class ValidationSidebar extends Component<
       </div>
     );
   }
-  private handleNotify = (state: IPluginState) => {
-    this.setState(state);
+  private handleNotify = (pluginState: IPluginState) => {
+    this.setState({ pluginState });
   };
 }
 

--- a/src/ts/createValidationPlugin.ts
+++ b/src/ts/createValidationPlugin.ts
@@ -185,7 +185,7 @@ const createValidatorPlugin = (options: IPluginOptions = {}) => {
   return {
     plugin,
     store,
-    getState: plugin.getState
+    getState: plugin.getState.bind(plugin)
   };
 };
 

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -11,17 +11,15 @@ export type IValidationOutput = IValidationInput & {
 
 export interface IValidationError {
   validationInput: IValidationInput;
-  id: string | number;
+  id: string;
   message: string;
 }
 
 export interface IValidationResponse {
-  // The validation input that produced these outputs.
-  validationInput: IValidationInput;
   // The validation outputs.
   validationOutputs: IValidationOutput[];
   // The ID of the validation request.
-  id: string | number;
+  id: string;
 }
 
 export type IValidationLibrary = Array<Array<{

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -1,5 +1,5 @@
 import { Transaction } from "prosemirror-state";
-import { DecorationSet } from "prosemirror-view";
+import { DecorationSet, Decoration } from "prosemirror-view";
 import { IRange } from "./interfaces/IValidation";
 import {
   IValidationError,
@@ -17,17 +17,18 @@ import {
   DECORATION_VALIDATION
 } from "./utils/decoration";
 import {
-  mapRangeThroughTransactions,
-  mergeOutputsFromValidationResponse,
   mergeRanges,
   validationInputToRange,
   mapAndMergeRanges,
-  mapRanges
+  mapRanges,
+  mergeOutputsFromValidationResponse
 } from "./utils/range";
 import { ExpandRanges } from "./createValidationPlugin";
 import { createValidationInputsForDocument } from "./utils/prosemirror";
 import { Node } from "prosemirror-model";
 import { Mapping } from "prosemirror-transform";
+import difference from "lodash/difference";
+import without from "lodash/without";
 
 /**
  * Information about the span element the user is hovering over.
@@ -54,6 +55,12 @@ export interface IStateHoverInfo {
   // Useful when determining where to put a tooltip if the user
   // is hovering over a span that covers several lines.
   heightOfSingleLine: number;
+}
+
+export interface IValidationInFlight {
+  mapping: Mapping;
+  validationInput: IValidationInput;
+  id: string;
 }
 
 export interface IPluginState {
@@ -89,10 +96,7 @@ export interface IPluginState {
   // Is a validation currently in flight - that is, has a validation
   // been sent to the validation service and we're awaiting its
   // return?
-  validationsInFlight: Array<{
-    mapping: Mapping;
-    id: number;
-  }>;
+  validationsInFlight: IValidationInFlight[];
   // The current error status.
   error: string | undefined;
 }
@@ -192,7 +196,7 @@ export const createInitialState = (
   doc: Node,
   throttleInMs: number,
   maxThrottle: number
-) => ({
+): IPluginState => ({
   debug: false,
   currentThrottle: throttleInMs,
   initialThrottle: throttleInMs,
@@ -204,7 +208,7 @@ export const createInitialState = (
   hoverId: undefined,
   hoverInfo: undefined,
   trHistory: [],
-  validationInFlight: undefined,
+  validationsInFlight: [],
   validationPending: false,
   error: undefined
 });
@@ -218,6 +222,17 @@ export const selectValidationById = (
   id: string
 ): IValidationOutput | undefined =>
   state.currentValidations.find(validation => validation.id === id);
+
+export const selectValidationInFlightById = (
+  state: IPluginState,
+  id: string
+): IValidationInFlight | undefined =>
+  state.validationsInFlight.find(_ => _.id === id);
+
+export const selectNewValidationInFlight = (
+  state: IPluginState,
+  oldState: IPluginState
+) => difference(state.validationsInFlight, oldState.validationsInFlight);
 
 /**
  * Reducer.
@@ -233,8 +248,8 @@ const validationPluginReducer = (
     ...incomingState,
     // Map our decorations, dirtied ranges and validations through the new transaction.
     decorations: incomingState.decorations.map(tr.mapping, tr.doc),
-    dirtiedRanges: mapAndMergeRanges(tr, incomingState.dirtiedRanges),
-    currentValidations: mapRanges(tr, incomingState.currentValidations),
+    dirtiedRanges: mapAndMergeRanges(incomingState.dirtiedRanges, tr.mapping),
+    currentValidations: mapRanges(incomingState.currentValidations, tr.mapping),
     validationsInFlight: incomingState.validationsInFlight.map(_ => {
       // We create a new mapping here to preserve state immutability, as
       // appendMapping mutates an existing mapping.
@@ -242,7 +257,7 @@ const validationPluginReducer = (
       mapping.appendMapping(_.mapping);
       mapping.appendMapping(tr.mapping);
       return {
-        id: _.id,
+        ..._,
         mapping
       };
     })
@@ -433,10 +448,13 @@ const handleValidationRequestStart = (validationInputs: IValidationInput[]) => (
     // We reset the dirty ranges, as they've been expanded and sent for validation.
     dirtiedRanges: [],
     validationPending: false,
-    validationInFlight: state.validationsInFlight.concat({
-      id: tr.time,
-      mapping: new Mapping()
-    })
+    validationsInFlight: state.validationsInFlight.concat(
+      validationInputs.map(validationInput => ({
+        id: tr.time.toString(),
+        mapping: new Mapping(),
+        validationInput
+      }))
+    )
   };
 };
 
@@ -449,10 +467,15 @@ const handleValidationRequestSuccess: ActionHandler<
 > = (tr, state, action) => {
   const response = action.payload.response;
   if (response) {
+    const validationInFlight = selectValidationInFlightById(state, response.id);
+    if (!validationInFlight) {
+      return state;
+    }
     const currentValidations = mergeOutputsFromValidationResponse(
-      response,
+      validationInFlight.validationInput,
+      response.validationOutputs,
       state.currentValidations,
-      state.trHistory
+      validationInFlight.mapping
     );
     const decorations = createNewDecorationsForCurrentValidations(
       currentValidations,
@@ -471,7 +494,10 @@ const handleValidationRequestSuccess: ActionHandler<
 
     return {
       ...state,
-      validationInFlight: undefined,
+      validationsInFlight: without(
+        state.validationsInFlight,
+        validationInFlight
+      ),
       currentValidations,
       decorations: decorations.remove(decsToRemove)
     };
@@ -485,15 +511,28 @@ const handleValidationRequestSuccess: ActionHandler<
 const handleValidationRequestError: ActionHandler<
   ActionValidationRequestError
 > = (tr, state, action) => {
-  const decsToRemove = state.decorations.find(
-    undefined,
-    undefined,
-    _ => _.type === DECORATION_INFLIGHT
+  const validationInFlight = selectValidationInFlightById(
+    state,
+    action.payload.validationError.id
   );
-  const dirtiedRanges = mapRangeThroughTransactions(
-    [validationInputToRange(action.payload.validationError.validationInput)],
-    parseInt(String(action.payload.validationError.id), 10),
-    state.trHistory
+  const dirtiedRanges = validationInFlight
+    ? mapRanges(
+        [
+          validationInputToRange(action.payload.validationError.validationInput)
+        ],
+        validationInFlight.mapping
+      )
+    : [];
+  const decsToRemove = dirtiedRanges.reduce(
+    (acc, range) =>
+      acc.concat(
+        state.decorations.find(
+          range.from,
+          range.to,
+          _ => _.type === DECORATION_INFLIGHT
+        )
+      ),
+    [] as Decoration[]
   );
 
   // When we get errors, we map the ranges due to be validated back
@@ -515,7 +554,9 @@ const handleValidationRequestError: ActionHandler<
       ? mergeRanges(state.dirtiedRanges.concat(dirtiedRanges))
       : state.dirtiedRanges,
     decorations,
-    validationInFlight: undefined,
+    validationsInFlight: validationInFlight
+      ? without(state.validationsInFlight, validationInFlight)
+      : state.validationsInFlight,
     error: action.payload.validationError.message
   };
 };

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -1,48 +1,70 @@
-import { IPluginState } from "./state";
+import { IPluginState, IValidationInFlight } from "./state";
+import { ArgumentTypes } from "./utils/types";
 
-type Subscriber = (state: IPluginState, prevState: IPluginState) => void;
+export const STORE_EVENT_NEW_VALIDATION = "STORE_EVENT_NEW_VALIDATION";
+export const STORE_EVENT_NEW_STATE = "STORE_EVENT_NEW_STATE";
+
+type STORE_EVENT_NEW_VALIDATION = typeof STORE_EVENT_NEW_VALIDATION;
+type STORE_EVENT_NEW_STATE = typeof STORE_EVENT_NEW_STATE;
+
+interface IStoreEvents {
+  [STORE_EVENT_NEW_VALIDATION]: (v: IValidationInFlight) => void;
+  [STORE_EVENT_NEW_STATE]: (state: IPluginState) => void;
+}
+
+type EventNames = keyof IStoreEvents;
 
 /**
  * A store to allow consumers to subscribe to validator state updates.
  */
 class Store {
-  private subscribers: Subscriber[] = [];
-  private state: IPluginState;
+  private subscribers: {
+    [EventName in EventNames]: Array<IStoreEvents[EventName]>
+  } = {
+    [STORE_EVENT_NEW_STATE]: [],
+    [STORE_EVENT_NEW_VALIDATION]: []
+  };
 
   /**
    * Notify our subscribers of a state change.
    */
-  public notify(state: IPluginState, prevState: IPluginState) {
-    this.state = state;
-    this.subscribers.forEach(_ => _(state, prevState));
+  public emit<EventName extends EventNames>(
+    eventName: EventName,
+    ...args: ArgumentTypes<IStoreEvents[EventName]>
+  ) {
+    (this.subscribers[eventName] as Array<IStoreEvents[EventName]>).forEach(
+      (_: any) => _(...args)
+    );
   }
 
   /**
-   * Get the currently held state.
+   * Unsubscribe to a store event.
    */
-  public getState() {
-    return this.state;
-  }
-
-  /**
-   * 
-   * Subscribe to state updates.
-   */
-  public subscribe(subscriber: Subscriber) {
-    this.subscribers.push(subscriber);
-  }
-
-  /**
-   * Unsubscribe to state updates.
-   */
-  public unsubscribe(subscriber: Subscriber) {
-    const index = this.subscribers.indexOf(subscriber);
+  public removeEventListener<EventName extends EventNames>(
+    eventName: EventName,
+    listener: IStoreEvents[EventName]
+  ): void {
+    const index = (this.subscribers[eventName] as Array<
+      IStoreEvents[EventName]
+    >).indexOf(listener);
     if (index === -1) {
       throw new Error(
-        "[Store]: Attempted to unsubscribe, but no subscriber found"
+        `[Store]: Attempted to unsubscribe, but no subscriber found for event ${eventName}`
       );
     }
-    this.subscribers.splice(index, 1);
+    this.subscribers[eventName].splice(index, 1);
+  }
+
+  /**
+   * Subscribe to a store event.
+   */
+  public on<EventName extends EventNames>(
+    eventName: EventName,
+    listener: (...args: ArgumentTypes<IStoreEvents[EventName]>) => void
+  ): void {
+    (this.subscribers[eventName] as Array<IStoreEvents[EventName]>).push(
+      listener as IStoreEvents[EventName]
+    );
   }
 }
 

--- a/src/ts/test/__snapshots__/state.spec.ts.snap
+++ b/src/ts/test/__snapshots__/state.spec.ts.snap
@@ -3,56 +3,10 @@
 exports[`State management Action handlers validationRequestSuccess should create decorations for the incoming validations 1`] = `
 Object {
   "currentThrottle": 100,
-  "currentValidations": Array [
-    Object {
-      "annotation": "Summat ain't right",
-      "from": 5,
-      "id": "id",
-      "str": "Example text to validate",
-      "to": 10,
-      "type": "EXAMPLE_TYPE",
-    },
-  ],
+  "currentValidations": Array [],
   "debug": false,
   "decorations": DecorationSet {
-    "children": Array [
-      0,
-      26,
-      DecorationSet {
-        "children": Array [],
-        "local": Array [
-          Decoration {
-            "from": 4,
-            "to": 4,
-            "type": WidgetType {
-              "side": 0,
-              "spec": Object {
-                "id": "id",
-                "type": "DECORATION_VALIDATION_HEIGHT_MARKER",
-              },
-              "toDOM": <span
-                data-height-marker-id="id"
-              />,
-            },
-          },
-          Decoration {
-            "from": 4,
-            "to": 9,
-            "type": InlineType {
-              "attrs": Object {
-                "class": "ValidationDecoration",
-                "data-validation-id": "id",
-              },
-              "spec": Object {
-                "id": "id",
-                "inclusiveStart": true,
-                "type": "DECORATION_VALIDATION",
-              },
-            },
-          },
-        ],
-      },
-    ],
+    "children": Array [],
     "local": Array [],
   },
   "dirtiedRanges": Array [],
@@ -94,7 +48,7 @@ Object {
       "updated": 0,
     },
   ],
-  "validationInFlight": undefined,
   "validationPending": false,
+  "validationsInFlight": Array [],
 }
 `;

--- a/src/ts/test/__snapshots__/validationAPIService.spec.ts.snap
+++ b/src/ts/test/__snapshots__/validationAPIService.spec.ts.snap
@@ -1,15 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ValidationAPIService should handle validation errors 1`] = `
-Array [
-  Object {
-    "id": "id",
-    "message": "Error fetching validations. The server responded with status code 400: Bad Request",
-    "validationInput": Object {
-      "from": 0,
-      "str": "1234567890",
-      "to": 10,
-    },
+Object {
+  "id": "id",
+  "message": "Error fetching validations. The server responded with status code 400: Bad Request",
+  "validationInput": Object {
+    "from": 0,
+    "str": "1234567890",
+    "to": 10,
   },
-]
+}
 `;

--- a/src/ts/test/state.spec.ts
+++ b/src/ts/test/state.spec.ts
@@ -1,6 +1,12 @@
 import { Transaction } from "prosemirror-state";
 import { DecorationSet } from "prosemirror-view";
-import { IPluginState, selectValidation, setDebugState } from "../state";
+import {
+  IPluginState,
+  selectValidation,
+  setDebugState,
+  selectValidationInFlightById,
+  selectNewValidationInFlight
+} from "../state";
 import {
   newHoverIdReceived,
   selectValidationById,
@@ -39,7 +45,7 @@ const initialState: IPluginState = {
 
 describe("State management", () => {
   describe("Action handlers", () => {
-    describe("validationRequestStart", () => {
+    describe("validationRequestForDirtyRanges", () => {
       it("should remove the pending status and any dirtied ranges, and mark the validation as in flight", () => {
         const docToValidate = doc(p("Example text to validate"));
         const tr = new Transaction(docToValidate);
@@ -304,6 +310,66 @@ describe("State management", () => {
             "3"
           )
         ).toEqual(undefined);
+      });
+    });
+    describe("selectValidationInFlightById", () => {
+      it("should find a single validation in flight by its id", () => {
+        expect(
+          selectValidationInFlightById(
+            {
+              validationsInFlight: [
+                {
+                  id: "1"
+                },
+                {
+                  id: "2"
+                }
+              ]
+            } as any,
+            "1"
+          )
+        ).toEqual({ id: "1" });
+      });
+    });
+    describe("selectNewValidationInFlight", () => {
+      it("should find the new inflight validations given an old and a new state", () => {
+        expect(
+          selectNewValidationInFlight(
+            {
+              validationsInFlight: [
+                {
+                  id: "1"
+                },
+                {
+                  id: "2"
+                }
+              ]
+            } as any,
+            {
+              validationsInFlight: [
+                {
+                  id: "1"
+                },
+                {
+                  id: "2"
+                },
+                {
+                  id: "3"
+                },
+                {
+                  id: "4"
+                }
+              ]
+            } as any
+          )
+        ).toEqual([
+          {
+            id: "1"
+          },
+          {
+            id: "2"
+          }
+        ]);
       });
     });
   });

--- a/src/ts/test/validationAPIService.spec.ts
+++ b/src/ts/test/validationAPIService.spec.ts
@@ -47,13 +47,11 @@ const createOutput = (str: string, offset: number = 0) =>
     annotation: "It's just a bunch of numbers, mate"
   } as IValidationOutput);
 
-const validationInputs = [
-  {
-    from: 0,
-    to: 10,
-    str: "1234567890"
-  }
-];
+const validationInput = {
+  from: 0,
+  to: 10,
+  str: "1234567890"
+};
 
 const commands = {
   applyValidationResult: jest.fn(),
@@ -79,46 +77,15 @@ describe("ValidationAPIService", () => {
 
     expect.assertions(2);
 
-    const output = await service.validate(validationInputs, "id");
+    const output = await service.validate(validationInput, "id");
 
     expect(commands.applyValidationResult.mock.calls[0]).toEqual([
       {
         validationOutputs: [createOutput("1234567890")],
-        validationInput: { from: 0, str: "1234567890", to: 10 },
         id: "id"
       }
     ]);
     expect(output).toEqual([createOutput("1234567890")]);
-  });
-  it("should handle multiple validation inputs", async () => {
-    const service = new ValidationAPIService(
-      store,
-      commands as any,
-      createLanguageToolAdapter("endpoint/check")
-    );
-    const localValidationInputs = [
-      {
-        from: 0,
-        to: 10,
-        str: "1234567890"
-      },
-      {
-        from: 20,
-        to: 30,
-        str: "1234567890"
-      }
-    ];
-    fetchMock
-      .once("endpoint/check", createResponse(["1234567890"]))
-      .once("endpoint/check", createResponse(["1234567890"]), {
-        overwriteRoutes: false
-      });
-
-    const output = await service.validate(localValidationInputs, "id");
-    expect(output).toEqual([
-      createOutput("1234567890"),
-      createOutput("1234567890", 20)
-    ]);
   });
   it("should handle validation errors", async () => {
     const service = new ValidationAPIService(
@@ -129,26 +96,13 @@ describe("ValidationAPIService", () => {
     fetchMock.once("endpoint/check", 400);
 
     const output = await service.validate(
-      [
-        {
-          from: 0,
-          to: 10,
-          str: "1234567890"
-        }
-      ],
+      {
+        from: 0,
+        to: 10,
+        str: "1234567890"
+      },
       "id"
     );
     expect(output).toMatchSnapshot();
-  });
-  it("should handle requests with no inputs", async () => {
-    const service = new ValidationAPIService(
-      store,
-      commands as any,
-      createLanguageToolAdapter("endpoint/check")
-    );
-    fetchMock.once("endpoint/check", 400);
-
-    const output = await service.validate([], "id");
-    expect(output).toEqual([]);
   });
 });

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -129,8 +129,7 @@ export const mergeOutputsFromValidationResponse = (
   currentOutputs: IValidationOutput[],
   trs: Transaction[]
 ): IValidationOutput[] => {
-  const validationId = parseInt(response.id, 10);
-  const initialTransaction = trs.find(tr => tr.time === validationId);
+  const initialTransaction = trs.find(tr => tr.time === response.id);
   if (!initialTransaction && trs.length > 1) {
     return currentOutputs;
   }
@@ -138,13 +137,13 @@ export const mergeOutputsFromValidationResponse = (
   // Map _all_ the things.
   const mappedInputs = mapRangeThroughTransactions(
     [response.validationInput],
-    validationId,
+    response.id,
     trs
   );
 
   const newOutputs = mapRangeThroughTransactions(
     response.validationOutputs,
-    validationId,
+    response.id,
     trs
   );
 

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -1,7 +1,6 @@
 import clamp from "lodash/clamp";
-import compact from "lodash/compact";
 import { Node } from "prosemirror-model";
-import { Transaction, TextSelection } from "prosemirror-state";
+import { TextSelection } from "prosemirror-state";
 import { findParentNode } from "prosemirror-utils";
 import {
   IRange,
@@ -9,6 +8,7 @@ import {
   IValidationResponse
 } from "../interfaces/IValidation";
 import { IValidationInput } from "../interfaces/IValidation";
+import { Mapping } from "prosemirror-transform";
 
 export const findOverlappingRangeIndex = (range: IRange, ranges: IRange[]) => {
   return ranges.findIndex(
@@ -22,17 +22,17 @@ export const findOverlappingRangeIndex = (range: IRange, ranges: IRange[]) => {
   );
 };
 
-export const mapAndMergeRanges = (tr: Transaction, ranges: IRange[]) =>
-  mergeRanges(mapRanges(tr, ranges));
+export const mapAndMergeRanges = <Range extends IRange>(ranges: Range[], mapping: Mapping): Range[] =>
+  mergeRanges(mapRanges(ranges, mapping));
 
-export const mapRanges = <T extends IRange>(
-  tr: Transaction,
-  ranges: T[]
-): T[] =>
+export const mapRanges = <Range extends IRange>(
+  ranges: Range[],
+  mapping: Mapping
+): Range[] =>
   ranges.map(range => ({
     ...range,
-    from: tr.mapping.map(range.from),
-    to: tr.mapping.map(range.to)
+    from: mapping.map(range.from),
+    to: mapping.map(range.to)
   }));
 
 /**
@@ -55,12 +55,13 @@ export const removeOverlappingRanges = <
   );
 };
 
-export const mergeRange = (range1: IRange, range2: IRange): IRange => ({
+export const mergeRange = <Range extends IRange>(range1: Range, range2: Range): Range => ({
+  ...range1,
   from: range1.from < range2.from ? range1.from : range2.from,
   to: range1.to > range2.to ? range1.to : range2.to
 });
 
-export const mergeRanges = (ranges: IRange[]): IRange[] =>
+export const mergeRanges = <Range extends IRange>(ranges: Range[]): Range[] =>
   ranges.reduce(
     (acc, range) => {
       const index = findOverlappingRangeIndex(range, acc);
@@ -71,7 +72,7 @@ export const mergeRanges = (ranges: IRange[]): IRange[] =>
       newRange.splice(index, 1, mergeRange(range, acc[index]));
       return newRange;
     },
-    [] as IRange[]
+    [] as Range[]
   );
 
 /**
@@ -125,26 +126,24 @@ export const validationInputToRange = (input: IValidationInput): IRange => ({
 });
 
 export const mergeOutputsFromValidationResponse = (
-  response: IValidationResponse,
+  input: IValidationInput,
+  incomingOutputs: IValidationOutput[],
   currentOutputs: IValidationOutput[],
-  trs: Transaction[]
+  mapping: Mapping
 ): IValidationOutput[] => {
-  const initialTransaction = trs.find(tr => tr.time === response.id);
-  if (!initialTransaction && trs.length > 1) {
+  if (!incomingOutputs.length) {
     return currentOutputs;
   }
 
   // Map _all_ the things.
-  const mappedInputs = mapRangeThroughTransactions(
-    [response.validationInput],
-    response.id,
-    trs
+  const mappedInputs = mapRanges(
+    [input],
+    mapping
   );
 
-  const newOutputs = mapRangeThroughTransactions(
-    response.validationOutputs,
-    response.id,
-    trs
+  const newOutputs = mapAndMergeRanges(
+    incomingOutputs,
+    mapping
   );
 
   return removeOverlappingRanges(currentOutputs, mappedInputs).concat(
@@ -199,36 +198,6 @@ export const getRangesOfParentBlockNodes = (ranges: IRange[], doc: Node) => {
   );
   return mergeRanges(validationRanges);
 };
-
-export const mapRangeThroughTransactions = <T extends IRange>(
-  ranges: T[],
-  time: number,
-  trs: Transaction[]
-): T[] =>
-  compact(
-    ranges.map(range => {
-      const initialTransactionIndex = trs.findIndex(tr => tr.time === time);
-      // If we only have a single transaction in the history, we're dealing with
-      // an unaltered document, and so there's no mapping to do.
-      if (trs.length === 1) {
-        return range;
-      }
-
-      if (initialTransactionIndex === -1) {
-        return undefined;
-      }
-
-      return Object.assign(range, {
-        ...trs.slice(initialTransactionIndex).reduce(
-          (acc, tr) => ({
-            from: tr.mapping.map(acc.from),
-            to: tr.mapping.map(acc.to)
-          }),
-          range
-        )
-      });
-    })
-  );
 
 export const expandRangesToParentBlockNode = (ranges: IRange[], doc: Node) =>
   getRangesOfParentBlockNodes(ranges, doc);

--- a/src/ts/utils/types.ts
+++ b/src/ts/utils/types.ts
@@ -1,0 +1,2 @@
+// tslint:disable-next-line ban-types
+export type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any ? A : never;


### PR DESCRIPTION
The validation response interface required a validation input. This PR removes that requirement by looking the input up by ID.

In doing so, there were a few quality of life improvements - 

- The state now models multiple validations-in-flight, each containing a single validation input, to allow multiple inputs to return at different times; this is an obvious but necessary change to allow services to return validations chunk by chunk
- Validations-in-flight now contain their own mapping, which is updated on every transaction. This removes the need for the transaction history that was maintained in the previous implementation.