### PR TITLE
Genericise base validation object

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepublishOnly": "yarn build",
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "format": "prettier --write './src/**/*.js'",
+    "format": "prettier --write './src/**/*.ts'",
     "publish-pages": "git subtree push --prefix pages/dist origin gh-pages",
     "build:doc": "typedoc --options ./build/typedoc.js ./src/ts/createValidationPlugin.ts"
   },

--- a/pages/dist/bundle.js
+++ b/pages/dist/bundle.js
@@ -19583,7 +19583,7 @@ const createValidationInputsForDocument = (node) => {
     node.descendants((descNode, pos) => {
         if (!findChildren(descNode, _ => _.type.isBlock, false).length) {
             ranges.push({
-                str: descNode.textContent,
+                inputString: descNode.textContent,
                 from: pos + 1,
                 to: pos + descNode.nodeSize
             });
@@ -20736,7 +20736,7 @@ const handleNewDirtyRanges = (tr, state, { payload: { ranges: dirtiedRanges } })
 };
 const handleValidationRequestForDirtyRanges = (tr, state, { payload: { expandRanges } }) => {
     const ranges = expandRanges(state.dirtiedRanges, tr.doc);
-    const validationInputs = ranges.map(range => (Object.assign({ str: tr.doc.textBetween(range.from, range.to) }, range)));
+    const validationInputs = ranges.map(range => (Object.assign({ inputString: tr.doc.textBetween(range.from, range.to) }, range)));
     return handleValidationRequestStart(validationInputs)(tr, state);
 };
 const handleValidationRequestForDocument = (tr, state) => {
@@ -22536,7 +22536,7 @@ const regexAdapter = (input) => __awaiter(undefined, void 0, void 0, function* (
         outputs.push({
             from: input.from + result.index,
             to: input.from + result.index + result[0].length,
-            str: result[0],
+            inputString: result[0],
             annotation: "This word has three letters. Consider a larger, grander word.",
             type: "3 letter word",
             id: v4_1(),
@@ -22547,7 +22547,7 @@ const regexAdapter = (input) => __awaiter(undefined, void 0, void 0, function* (
         outputs.push({
             from: input.from + result.index,
             to: input.from + result.index + result[0].length,
-            str: result[0],
+            inputString: result[0],
             annotation: "This word has six letters. Consider a smaller, less fancy word.",
             type: "6 letter word",
             id: v4_1(),

--- a/pages/dist/bundle.js
+++ b/pages/dist/bundle.js
@@ -15641,7 +15641,9 @@ const removeDecorationsFromRanges = (decorationSet, ranges, types = [DECORATION_
     if (!decorations.length) {
         return acc;
     }
-    const decorationsToRemove = flatten_1(decorations.map(decoration => decorationSet.find(decoration.from, decoration.to, predicate)).filter(_ => !!_));
+    const decorationsToRemove = flatten_1(decorations
+        .map(decoration => decorationSet.find(decoration.from, decoration.to, predicate))
+        .filter(_ => !!_));
     return acc.remove(decorationsToRemove);
 }, decorationSet);
 const getNewDecorationsForCurrentValidations = (outputs, decorationSet, doc) => {
@@ -15679,8 +15681,6 @@ const createDecorationForValidationRange = (output, isHovering = false, addHeigh
         : decorationArray;
 };
 const createDecorationsForValidationRanges = (ranges) => flatten_1(ranges.map(_ => createDecorationForValidationRange(_)));
-
-//# sourceMappingURL=decoration.js.map
 
 /**
  * The base implementation of `_.clamp` which doesn't coerce arguments.
@@ -19597,7 +19597,6 @@ const getReplaceStepRangesFromTransaction = (tr) => getReplaceTransactions(tr).m
     to: step.to
 }));
 const getReplaceTransactions = (tr) => tr.steps.filter(step => step instanceof dist_17 || step instanceof dist_18);
-//# sourceMappingURL=prosemirror.js.map
 
 var asyncTag = '[object AsyncFunction]';
 var funcTag = '[object Function]';
@@ -20689,7 +20688,7 @@ const validationPluginReducer = (tr, incomingState, action) => {
         case VALIDATION_REQUEST_FOR_DIRTY_RANGES:
             return handleValidationRequestForDirtyRanges(tr, state, action);
         case VALIDATION_REQUEST_FOR_DOCUMENT:
-            return handleValidationRequestForDocument(tr, state, action);
+            return handleValidationRequestForDocument(tr, state);
         case VALIDATION_REQUEST_SUCCESS:
             return handleValidationRequestSuccess(tr, state, action);
         case VALIDATION_REQUEST_ERROR:
@@ -20793,8 +20792,6 @@ const handleSetDebugState = (_, state, { payload: { debug } }) => {
     return Object.assign({}, state, { debug });
 };
 
-//# sourceMappingURL=state.js.map
-
 function getStateHoverInfoFromEvent(event, containerElement, heightMarkerElement) {
     if (!event.target ||
         !(event.target instanceof HTMLElement) ||
@@ -20845,8 +20842,6 @@ class Store {
         this.subscribers[eventName].push(listener);
     }
 }
-
-//# sourceMappingURL=store.js.map
 
 const compact = (value) => !!value;
 //# sourceMappingURL=array.js.map
@@ -20917,11 +20912,12 @@ const createBoundCommands = (view, getState) => {
         setDebugState: bindCommand(setDebugStateCommand)
     };
 };
+//# sourceMappingURL=commands.js.map
 
 const createValidatorPlugin = (options = {}) => {
     const { expandRanges = expandRangesToParentBlockNode, throttleInMs = 2000, maxThrottle = 8000 } = options;
-    let localView;
     const store = new Store();
+    let localView;
     const requestValidation = () => {
         const pluginState = plugin.getState(localView.state);
         if (pluginState.validationsInFlight.length) {
@@ -20980,7 +20976,7 @@ const createValidatorPlugin = (options = {}) => {
         view(view) {
             localView = view;
             return {
-                update: (_) => store.emit(STORE_EVENT_NEW_STATE, plugin.getState(view.state))
+                update: _ => store.emit(STORE_EVENT_NEW_STATE, plugin.getState(view.state))
             };
         }
     });
@@ -22532,7 +22528,7 @@ const regexAdapter = (input) => __awaiter(undefined, void 0, void 0, function* (
     const threeLetterExpr = /\b[a-zA-Z]{3}\b/g;
     const sixLetterExpr = /\b[a-zA-Z]{6}\b/g;
     let result;
-    while ((result = threeLetterExpr.exec(input.str))) {
+    while ((result = threeLetterExpr.exec(input.inputString))) {
         outputs.push({
             from: input.from + result.index,
             to: input.from + result.index + result[0].length,
@@ -22543,7 +22539,7 @@ const regexAdapter = (input) => __awaiter(undefined, void 0, void 0, function* (
             suggestions: ["replace", "with", "grand", "word"]
         });
     }
-    while ((result = sixLetterExpr.exec(input.str))) {
+    while ((result = sixLetterExpr.exec(input.inputString))) {
         outputs.push({
             from: input.from + result.index,
             to: input.from + result.index + result[0].length,

--- a/pages/dist/bundle.js
+++ b/pages/dist/bundle.js
@@ -15682,6 +15682,8 @@ const createDecorationForValidationRange = (output, isHovering = false, addHeigh
 };
 const createDecorationsForValidationRanges = (ranges) => flatten_1(ranges.map(_ => createDecorationForValidationRange(_)));
 
+//# sourceMappingURL=decoration.js.map
+
 /**
  * The base implementation of `_.clamp` which doesn't coerce arguments.
  *
@@ -19597,6 +19599,7 @@ const getReplaceStepRangesFromTransaction = (tr) => getReplaceTransactions(tr).m
     to: step.to
 }));
 const getReplaceTransactions = (tr) => tr.steps.filter(step => step instanceof dist_17 || step instanceof dist_18);
+//# sourceMappingURL=prosemirror.js.map
 
 var asyncTag = '[object AsyncFunction]';
 var funcTag = '[object Function]';
@@ -20842,6 +20845,8 @@ class Store {
         this.subscribers[eventName].push(listener);
     }
 }
+
+//# sourceMappingURL=store.js.map
 
 const compact = (value) => !!value;
 //# sourceMappingURL=array.js.map

--- a/pages/dist/worker.js
+++ b/pages/dist/worker.js
@@ -15484,7 +15484,7 @@ function* applyLibraryToValidationMap(validationLibrary) {
                 type: rule.type,
                 from: match.index,
                 to: match.index + match.item.length,
-                str: match.item
+                inputString: match.item
             }))
                 .filter(match => match));
         }

--- a/src/ts/adapters/interfaces/ILanguageTool.ts
+++ b/src/ts/adapters/interfaces/ILanguageTool.ts
@@ -1,42 +1,42 @@
 export interface ILTResponse {
-	language: unknown
-	matches: ILTMatch[]
-	software: unknown
-	warnings: unknown
+  language: unknown;
+  matches: ILTMatch[];
+  software: unknown;
+  warnings: unknown;
 }
 
 export interface ILTMatch {
-	context: {
-		text: string,
-		offset: number,
-		length: number
-	},
-	length: number,
-	message: string,
-	offset: number,
-	replacements: ILTReplacement[],
-	rule: ILTRule,
-	sentence: string,
-	shortMessage: string,
-	type: ILTType
+  context: {
+    text: string;
+    offset: number;
+    length: number;
+  };
+  length: number;
+  message: string;
+  offset: number;
+  replacements: ILTReplacement[];
+  rule: ILTRule;
+  sentence: string;
+  shortMessage: string;
+  type: ILTType;
 }
 
 export interface ILTReplacement {
-	value: string
+  value: string;
 }
 
 export interface ILTType {
-	typeName: string
+  typeName: string;
 }
 
 export interface ILTRule {
-	category: ILTCategory,
-	description: string,
-	id: string,
-	issueType: string
+  category: ILTCategory;
+  description: string;
+  id: string;
+  issueType: string;
 }
 
 export interface ILTCategory {
-	id: string,
-	name: string
+  id: string;
+  name: string;
 }

--- a/src/ts/adapters/languageTool.ts
+++ b/src/ts/adapters/languageTool.ts
@@ -15,7 +15,7 @@ const createLanguageToolAdapter: IValidationAPIAdapter = (
     JSON.stringify({
       annotation: [
         {
-          text: input.str
+          text: input.inputString
         }
       ]
     })
@@ -38,7 +38,7 @@ const createLanguageToolAdapter: IValidationAPIAdapter = (
   const validationData: ILTResponse = await response.json();
   return validationData.matches.map(match => ({
     id: v4(),
-    str: match.sentence,
+    inputString: match.sentence,
     from: input.from + match.offset,
     to: input.from + match.offset + match.length,
     annotation: match.message,

--- a/src/ts/adapters/languageTool.ts
+++ b/src/ts/adapters/languageTool.ts
@@ -1,12 +1,12 @@
-import v4 from 'uuid/v4';
+import v4 from "uuid/v4";
 import { IValidationInput } from "../interfaces/IValidation";
-import IValidationAPIAdapter from "../interfaces/IValidationAPIAdapter";
 import { ILTResponse } from "./interfaces/ILanguageTool";
+import IValidationAPIAdapterCreator from "../interfaces/IValidationAPIAdapter";
 
 /**
  * An adapter for the Typerighter service.
  */
-const createLanguageToolAdapter: IValidationAPIAdapter = (
+const createLanguageToolAdapter: IValidationAPIAdapterCreator = (
   apiUrl: string
 ) => async (input: IValidationInput) => {
   const body = new URLSearchParams();

--- a/src/ts/adapters/regex.ts
+++ b/src/ts/adapters/regex.ts
@@ -10,11 +10,11 @@ const regexAdapter = async (input: IValidationInput) => {
   const sixLetterExpr = /\b[a-zA-Z]{6}\b/g;
   let result;
   // tslint:disable-next-line no-conditional-assignment
-  while ((result = threeLetterExpr.exec(input.str))) {
+  while ((result = threeLetterExpr.exec(input.inputString))) {
     outputs.push({
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
-      str: result[0],
+      inputString: result[0],
       annotation: "This word has three letters. Consider a larger, grander word.",
       type: "3 letter word",
       id: v4(),
@@ -22,11 +22,11 @@ const regexAdapter = async (input: IValidationInput) => {
     });
   }
   // tslint:disable-next-line no-conditional-assignment
-  while ((result = sixLetterExpr.exec(input.str))) {
+  while ((result = sixLetterExpr.exec(input.inputString))) {
     outputs.push({
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
-      str: result[0],
+      inputString: result[0],
       annotation: "This word has six letters. Consider a smaller, less fancy word.",
       type: "6 letter word",
       id: v4(),

--- a/src/ts/adapters/regex.ts
+++ b/src/ts/adapters/regex.ts
@@ -15,7 +15,8 @@ const regexAdapter = async (input: IValidationInput) => {
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
       inputString: result[0],
-      annotation: "This word has three letters. Consider a larger, grander word.",
+      annotation:
+        "This word has three letters. Consider a larger, grander word.",
       type: "3 letter word",
       id: v4(),
       suggestions: ["replace", "with", "grand", "word"]
@@ -27,7 +28,8 @@ const regexAdapter = async (input: IValidationInput) => {
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
       inputString: result[0],
-      annotation: "This word has six letters. Consider a smaller, less fancy word.",
+      annotation:
+        "This word has six letters. Consider a smaller, less fancy word.",
       type: "6 letter word",
       id: v4(),
       suggestions: ["replace", "with", "bijou", "word"]

--- a/src/ts/adapters/typerighter.ts
+++ b/src/ts/adapters/typerighter.ts
@@ -15,7 +15,7 @@ const createTyperighterAdapter: IValidationAPIAdapter = (
       "Content-Type": "application/json"
     }),
     body: JSON.stringify({
-      text: input.str
+      text: input.inputString
     })
   });
   if (response.status !== 200) {
@@ -28,7 +28,7 @@ const createTyperighterAdapter: IValidationAPIAdapter = (
   const validationData: ITypeRighterResponse = await response.json();
   return validationData.results.map(match => ({
     id: v4(),
-    str: input.str,
+    inputString: input.inputString,
     from: input.from + match.fromPos,
     to: input.from + match.toPos,
     annotation: match.message,

--- a/src/ts/createValidationPlugin.ts
+++ b/src/ts/createValidationPlugin.ts
@@ -16,7 +16,7 @@ import { Plugin, Transaction, EditorState } from "prosemirror-state";
 import { expandRangesToParentBlockNode } from "./utils/range";
 import { getReplaceStepRangesFromTransaction } from "./utils/prosemirror";
 import { getStateHoverInfoFromEvent } from "./utils/dom";
-import { IRange, IDefaultValidationMeta } from "./interfaces/IValidation";
+import { IRange, IBaseValidationOutput } from "./interfaces/IValidation";
 import { Node } from "prosemirror-model";
 import Store, {
   STORE_EVENT_NEW_STATE,
@@ -58,7 +58,7 @@ interface IPluginOptions {
  * @param {IPluginOptions} options The plugin options object.
  * @returns {{plugin: Plugin, commands: ICommands}}
  */
-const createValidatorPlugin = <TValidationMeta extends IDefaultValidationMeta>(
+const createValidatorPlugin = <TValidationMeta extends IBaseValidationOutput>(
   options: IPluginOptions = {}
 ) => {
   const {

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -1,13 +1,16 @@
 export interface IRange { from: number; to: number }
 
-export interface IValidationInput { str: string; from: number; to: number }
+export interface IValidationInput { inputString: string; from: number; to: number }
 
-export type IValidationOutput = IValidationInput & {
+export interface IDefaultValidationMeta {
   annotation: string;
-  suggestions?: string[];
   type: string;
+}
+
+export type IValidationOutput<TValidationMeta = IDefaultValidationMeta> = IValidationInput & {
+  suggestions?: string[];
   id: string;
-};
+} & TValidationMeta;
 
 export interface IValidationError {
   validationInput: IValidationInput;

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -1,16 +1,25 @@
-export interface IRange { from: number; to: number }
+export interface IRange {
+  from: number;
+  to: number;
+}
 
-export interface IValidationInput { inputString: string; from: number; to: number }
+export interface IValidationInput {
+  inputString: string;
+  from: number;
+  to: number;
+}
 
 export interface IDefaultValidationMeta {
   annotation: string;
   type: string;
 }
 
-export type IValidationOutput<TValidationMeta = IDefaultValidationMeta> = IValidationInput & {
+export type IValidationOutput<
+  IValidationMeta = IDefaultValidationMeta
+> = IValidationInput & {
   suggestions?: string[];
   id: string;
-} & TValidationMeta;
+} & IValidationMeta;
 
 export interface IValidationError {
   validationInput: IValidationInput;
@@ -18,19 +27,21 @@ export interface IValidationError {
   message: string;
 }
 
-export interface IValidationResponse {
+export interface IValidationResponse<IValidationMeta = IDefaultValidationMeta> {
   // The validation outputs.
-  validationOutputs: IValidationOutput[];
+  validationOutputs: Array<IValidationOutput<IValidationMeta>>;
   // The ID of the validation request.
   id: string;
 }
 
-export type IValidationLibrary = Array<Array<{
-  regExp: RegExp;
-  annotation: string;
-  operation: "ANNOTATE" | "REPLACE";
-  type: string;
-}>>;
+export type IValidationLibrary = Array<
+  Array<{
+    regExp: RegExp;
+    annotation: string;
+    operation: "ANNOTATE" | "REPLACE";
+    type: string;
+  }>
+>;
 
 export const Operations: {
   [key: string]: "ANNOTATE" | "REPLACE";

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -9,13 +9,13 @@ export interface IValidationInput {
   to: number;
 }
 
-export interface IDefaultValidationMeta {
+export interface IBaseValidationOutput {
   annotation: string;
   type: string;
 }
 
 export type IValidationOutput<
-  IValidationMeta = IDefaultValidationMeta
+  IValidationMeta = IBaseValidationOutput
 > = IValidationInput & {
   suggestions?: string[];
   id: string;
@@ -27,7 +27,7 @@ export interface IValidationError {
   message: string;
 }
 
-export interface IValidationResponse<IValidationMeta = IDefaultValidationMeta> {
+export interface IValidationResponse<IValidationMeta = IBaseValidationOutput> {
   // The validation outputs.
   validationOutputs: Array<IValidationOutput<IValidationMeta>>;
   // The ID of the validation request.

--- a/src/ts/interfaces/IValidationAPIAdapter.ts
+++ b/src/ts/interfaces/IValidationAPIAdapter.ts
@@ -2,13 +2,21 @@
  * @module createValidationPlugin
  */
 
-import { IValidationInput, IValidationOutput } from "./IValidation";
+import {
+  IValidationInput,
+  IValidationOutput,
+  IDefaultValidationMeta
+} from "./IValidation";
 
 /**
  * @internal
  */
-export type IValidationAPIAdapter<TValidationMeta> = (input: IValidationInput) => Promise<Array<IValidationOutput<TValidationMeta>>>;
+export type IValidationAPIAdapter<TValidationMeta = IDefaultValidationMeta> = (
+  input: IValidationInput
+) => Promise<Array<IValidationOutput<TValidationMeta>>>;
 
-type IValidationAPIAdapterCreator<TValidationMeta> = (apiUrl: string) => IValidationAPIAdapter<TValidationMeta>;
+type IValidationAPIAdapterCreator<TValidationMeta = IDefaultValidationMeta> = (
+  apiUrl: string
+) => IValidationAPIAdapter<TValidationMeta>;
 
 export default IValidationAPIAdapterCreator;

--- a/src/ts/interfaces/IValidationAPIAdapter.ts
+++ b/src/ts/interfaces/IValidationAPIAdapter.ts
@@ -5,17 +5,17 @@
 import {
   IValidationInput,
   IValidationOutput,
-  IDefaultValidationMeta
+  IBaseValidationOutput
 } from "./IValidation";
 
 /**
  * @internal
  */
-export type IValidationAPIAdapter<TValidationMeta = IDefaultValidationMeta> = (
+export type IValidationAPIAdapter<TValidationMeta = IBaseValidationOutput> = (
   input: IValidationInput
 ) => Promise<Array<IValidationOutput<TValidationMeta>>>;
 
-type IValidationAPIAdapterCreator<TValidationMeta = IDefaultValidationMeta> = (
+type IValidationAPIAdapterCreator<TValidationMeta = IBaseValidationOutput> = (
   apiUrl: string
 ) => IValidationAPIAdapter<TValidationMeta>;
 

--- a/src/ts/interfaces/IValidationAPIAdapter.ts
+++ b/src/ts/interfaces/IValidationAPIAdapter.ts
@@ -7,8 +7,8 @@ import { IValidationInput, IValidationOutput } from "./IValidation";
 /**
  * @internal
  */
-export type IValidationAPIAdapter = (input: IValidationInput) => Promise<IValidationOutput[]>;
+export type IValidationAPIAdapter<TValidationMeta> = (input: IValidationInput) => Promise<Array<IValidationOutput<TValidationMeta>>>;
 
-type IValidationAPIAdapterCreator = (apiUrl: string) => IValidationAPIAdapter;
+type IValidationAPIAdapterCreator<TValidationMeta> = (apiUrl: string) => IValidationAPIAdapter<TValidationMeta>;
 
 export default IValidationAPIAdapterCreator;

--- a/src/ts/services/ValidationAPIService.ts
+++ b/src/ts/services/ValidationAPIService.ts
@@ -1,6 +1,6 @@
 import {
   IValidationInput,
-  IDefaultValidationMeta
+  IBaseValidationOutput
 } from "../interfaces/IValidation";
 import { IValidationAPIAdapter } from "../interfaces/IValidationAPIAdapter";
 import Store, { STORE_EVENT_NEW_VALIDATION } from "../store";
@@ -11,7 +11,7 @@ import { Commands } from "../commands";
  * for ranges, configured via the supplied adapter. Validation results and
  * errors dispatch the appropriate Prosemirror commands.
  */
-class ValidationService<TValidationMeta extends IDefaultValidationMeta> {
+class ValidationService<TValidationMeta extends IBaseValidationOutput> {
   constructor(
     private store: Store<TValidationMeta>,
     private commands: Commands,

--- a/src/ts/services/ValidationAPIService.ts
+++ b/src/ts/services/ValidationAPIService.ts
@@ -1,4 +1,7 @@
-import { IValidationInput } from "../interfaces/IValidation";
+import {
+  IValidationInput,
+  IDefaultValidationMeta
+} from "../interfaces/IValidation";
 import { IValidationAPIAdapter } from "../interfaces/IValidationAPIAdapter";
 import Store, { STORE_EVENT_NEW_VALIDATION } from "../store";
 import { Commands } from "../commands";
@@ -8,11 +11,11 @@ import { Commands } from "../commands";
  * for ranges, configured via the supplied adapter. Validation results and
  * errors dispatch the appropriate Prosemirror commands.
  */
-class ValidationService {
+class ValidationService<TValidationMeta extends IDefaultValidationMeta> {
   constructor(
-    private store: Store,
+    private store: Store<TValidationMeta>,
     private commands: Commands,
-    private adapter: IValidationAPIAdapter
+    private adapter: IValidationAPIAdapter<TValidationMeta>
   ) {
     this.store.on(STORE_EVENT_NEW_VALIDATION, validationInFlight => {
       // If we have a new validation, send it to the validation service.
@@ -23,10 +26,7 @@ class ValidationService {
   /**
    * Validate a Prosemirror node, restricting checks to ranges if they're supplied.
    */
-  public async validate(
-    validationInput: IValidationInput,
-    id: string
-  ) {
+  public async validate(validationInput: IValidationInput, id: string) {
     try {
       const validationOutputs = await this.adapter(validationInput);
       this.commands.applyValidationResult({

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -420,7 +420,7 @@ const handleValidationRequestForDirtyRanges: ActionHandler<
 > = (tr, state, { payload: { expandRanges } }) => {
   const ranges = expandRanges(state.dirtiedRanges, tr.doc);
   const validationInputs: IValidationInput[] = ranges.map(range => ({
-    str: tr.doc.textBetween(range.from, range.to),
+    inputString: tr.doc.textBetween(range.from, range.to),
     ...range
   }));
   return handleValidationRequestStart(validationInputs)(tr, state);

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -1,6 +1,6 @@
 import { Transaction } from "prosemirror-state";
 import { DecorationSet, Decoration } from "prosemirror-view";
-import { IRange, IDefaultValidationMeta } from "./interfaces/IValidation";
+import { IRange, IBaseValidationOutput } from "./interfaces/IValidation";
 import {
   IValidationError,
   IValidationInput,
@@ -65,7 +65,7 @@ export interface IValidationInFlight {
   id: string;
 }
 
-export interface IPluginState<TValidationMeta extends IDefaultValidationMeta> {
+export interface IPluginState<TValidationMeta extends IBaseValidationOutput> {
   // Is the plugin in debug mode? Debug mode adds marks to show dirtied
   // and expanded ranges.
   debug: boolean;
@@ -141,7 +141,7 @@ type ActionValidationRequestForDocument = ReturnType<
 >;
 
 export const validationRequestSuccess = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   response: IValidationResponse<TValidationMeta>
 ) => ({
@@ -150,7 +150,7 @@ export const validationRequestSuccess = <
 });
 // tslint:disable-next-line:interface-over-type-literal
 type ActionValidationResponseReceived<
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 > = {
   type: "VALIDATION_REQUEST_SUCCESS";
   payload: { response: IValidationResponse<TValidationMeta> };
@@ -189,7 +189,7 @@ export const setDebugState = (debug: boolean) => ({
 });
 type ActionSetDebugState = ReturnType<typeof setDebugState>;
 
-type Action<TValidationMeta extends IDefaultValidationMeta> =
+type Action<TValidationMeta extends IBaseValidationOutput> =
   | ActionNewHoverIdReceived
   | ActionValidationResponseReceived<TValidationMeta>
   | ActionValidationRequestForDirtyRanges
@@ -203,7 +203,7 @@ type Action<TValidationMeta extends IDefaultValidationMeta> =
  * Initial state.
  */
 export const createInitialState = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   doc: Node,
   throttleInMs: number,
@@ -230,7 +230,7 @@ export const createInitialState = <
  */
 
 export const selectValidationById = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   state: IPluginState<TValidationMeta>,
   id: string
@@ -238,7 +238,7 @@ export const selectValidationById = <
   state.currentValidations.find(validation => validation.id === id);
 
 export const selectValidationInFlightById = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   state: IPluginState<TValidationMeta>,
   id: string
@@ -246,14 +246,14 @@ export const selectValidationInFlightById = <
   state.validationsInFlight.find(_ => _.id === id);
 
 export const selectNewValidationInFlight = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   state: IPluginState<TValidationMeta>,
   oldState: IPluginState<TValidationMeta>
 ) => difference(state.validationsInFlight, oldState.validationsInFlight);
 
 export const selectSuggestionAndRange = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   state: IPluginState<TValidationMeta>,
   validationId: string,
@@ -278,9 +278,7 @@ export const selectSuggestionAndRange = <
  * Reducer.
  */
 
-const validationPluginReducer = <
-  TValidationMeta extends IDefaultValidationMeta
->(
+const validationPluginReducer = <TValidationMeta extends IBaseValidationOutput>(
   tr: Transaction,
   incomingState: IPluginState<TValidationMeta>,
   action?: Action<TValidationMeta>
@@ -338,7 +336,7 @@ const validationPluginReducer = <
 /**
  * Handle the selection of a hover id.
  */
-const handleSelectValidation = <TValidationMeta extends IDefaultValidationMeta>(
+const handleSelectValidation = <TValidationMeta extends IBaseValidationOutput>(
   _: unknown,
   state: IPluginState<TValidationMeta>,
   action: ActionSelectValidation
@@ -352,7 +350,7 @@ const handleSelectValidation = <TValidationMeta extends IDefaultValidationMeta>(
 /**
  * Handle the receipt of a new hover id.
  */
-const handleNewHoverId = <TValidationMeta extends IDefaultValidationMeta>(
+const handleNewHoverId = <TValidationMeta extends IBaseValidationOutput>(
   tr: Transaction,
   state: IPluginState<TValidationMeta>,
   action: ActionNewHoverIdReceived
@@ -396,7 +394,7 @@ const handleNewHoverId = <TValidationMeta extends IDefaultValidationMeta>(
   };
 };
 
-const handleNewDirtyRanges = <TValidationMeta extends IDefaultValidationMeta>(
+const handleNewDirtyRanges = <TValidationMeta extends IBaseValidationOutput>(
   tr: Transaction,
   state: IPluginState<TValidationMeta>,
   { payload: { ranges: dirtiedRanges } }: ActionHandleNewDirtyRanges
@@ -430,7 +428,7 @@ const handleNewDirtyRanges = <TValidationMeta extends IDefaultValidationMeta>(
  * Handle a validation request for the current set of dirty ranges.
  */
 const handleValidationRequestForDirtyRanges = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   tr: Transaction,
   state: IPluginState<TValidationMeta>,
@@ -448,7 +446,7 @@ const handleValidationRequestForDirtyRanges = <
  * Handle a validation request for the entire document.
  */
 const handleValidationRequestForDocument = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   tr: Transaction,
   state: IPluginState<TValidationMeta>
@@ -462,7 +460,7 @@ const handleValidationRequestForDocument = <
  * Handle a validation request for a given set of validation inputs.
  */
 const handleValidationRequestStart = (validationInputs: IValidationInput[]) => <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   tr: Transaction,
   state: IPluginState<TValidationMeta>
@@ -500,7 +498,7 @@ const handleValidationRequestStart = (validationInputs: IValidationInput[]) => <
  * any validations we've received.
  */
 const handleValidationRequestSuccess = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   tr: Transaction,
   state: IPluginState<TValidationMeta>,
@@ -559,7 +557,7 @@ const handleValidationRequestSuccess = <
  * Handle a validation request error.
  */
 const handleValidationRequestError = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   tr: Transaction,
   state: IPluginState<TValidationMeta>,
@@ -615,7 +613,7 @@ const handleValidationRequestError = <
   };
 };
 
-const handleSetDebugState = <TValidationMeta extends IDefaultValidationMeta>(
+const handleSetDebugState = <TValidationMeta extends IBaseValidationOutput>(
   _: Transaction,
   state: IPluginState<TValidationMeta>,
   { payload: { debug } }: ActionSetDebugState

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -1,5 +1,6 @@
 import { IPluginState, IValidationInFlight } from "./state";
 import { ArgumentTypes } from "./utils/types";
+import { IDefaultValidationMeta } from "./interfaces/IValidation";
 
 export const STORE_EVENT_NEW_VALIDATION = "STORE_EVENT_NEW_VALIDATION";
 export const STORE_EVENT_NEW_STATE = "STORE_EVENT_NEW_STATE";
@@ -9,7 +10,9 @@ type STORE_EVENT_NEW_STATE = typeof STORE_EVENT_NEW_STATE;
 
 interface IStoreEvents {
   [STORE_EVENT_NEW_VALIDATION]: (v: IValidationInFlight) => void;
-  [STORE_EVENT_NEW_STATE]: (state: IPluginState) => void;
+  [STORE_EVENT_NEW_STATE]: <TValidationMeta extends IDefaultValidationMeta>(
+    state: IPluginState<TValidationMeta>
+  ) => void;
 }
 
 type EventNames = keyof IStoreEvents;
@@ -17,7 +20,7 @@ type EventNames = keyof IStoreEvents;
 /**
  * A store to allow consumers to subscribe to validator state updates.
  */
-class Store {
+class Store<TValidationMeta extends IDefaultValidationMeta> {
   private subscribers: {
     [EventName in EventNames]: Array<IStoreEvents[EventName]>
   } = {

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -1,6 +1,6 @@
 import { IPluginState, IValidationInFlight } from "./state";
 import { ArgumentTypes } from "./utils/types";
-import { IDefaultValidationMeta } from "./interfaces/IValidation";
+import { IBaseValidationOutput } from "./interfaces/IValidation";
 
 export const STORE_EVENT_NEW_VALIDATION = "STORE_EVENT_NEW_VALIDATION";
 export const STORE_EVENT_NEW_STATE = "STORE_EVENT_NEW_STATE";
@@ -10,7 +10,7 @@ type STORE_EVENT_NEW_STATE = typeof STORE_EVENT_NEW_STATE;
 
 interface IStoreEvents {
   [STORE_EVENT_NEW_VALIDATION]: (v: IValidationInFlight) => void;
-  [STORE_EVENT_NEW_STATE]: <TValidationMeta extends IDefaultValidationMeta>(
+  [STORE_EVENT_NEW_STATE]: <TValidationMeta extends IBaseValidationOutput>(
     state: IPluginState<TValidationMeta>
   ) => void;
 }
@@ -20,7 +20,7 @@ type EventNames = keyof IStoreEvents;
 /**
  * A store to allow consumers to subscribe to validator state updates.
  */
-class Store<TValidationMeta extends IDefaultValidationMeta> {
+class Store<TValidationMeta extends IBaseValidationOutput> {
   private subscribers: {
     [EventName in EventNames]: Array<IStoreEvents[EventName]>
   } = {

--- a/src/ts/test/__snapshots__/validationAPIService.spec.ts.snap
+++ b/src/ts/test/__snapshots__/validationAPIService.spec.ts.snap
@@ -6,7 +6,7 @@ Object {
   "message": "Error fetching validations. The server responded with status code 400: Bad Request",
   "validationInput": Object {
     "from": 0,
-    "str": "1234567890",
+    "inputString": "1234567890",
     "to": 10,
   },
 }

--- a/src/ts/test/prosemirror.spec.ts
+++ b/src/ts/test/prosemirror.spec.ts
@@ -18,17 +18,17 @@ describe("Prosemirror utils", () => {
         p(ul(li("List item 1"), li("List item 2")))
       );
       expect(createValidationInputsForDocument(node)).toEqual([
-        { from: 1, to: 13, str: "Paragraph 1" },
-        { from: 14, to: 26, str: "Paragraph 2" },
+        { from: 1, to: 13, inputString: "Paragraph 1" },
+        { from: 14, to: 26, inputString: "Paragraph 2" },
         {
           from: 29,
           to: 41,
-          str: "List item 1"
+          inputString: "List item 1"
         },
         {
           from: 42,
           to: 54,
-          str: "List item 2"
+          inputString: "List item 2"
         }
       ]);
     });

--- a/src/ts/test/range.spec.ts
+++ b/src/ts/test/range.spec.ts
@@ -232,19 +232,19 @@ describe("Range utils", () => {
       const outputs = removeOverlappingRanges(
         [
           {
-            str: "one",
+            inputString: "one",
             from: 0,
             to: 2
           },
           {
-            str: "two",
+            inputString: "two",
             from: 5,
             to: 7
           }
         ],
         [
           {
-            str: "one",
+            inputString: "one",
             from: 1,
             to: 3
           }
@@ -252,7 +252,7 @@ describe("Range utils", () => {
       );
       expect(outputs).toEqual([
         {
-          str: "two",
+          inputString: "two",
           from: 5,
           to: 7
         }
@@ -262,19 +262,19 @@ describe("Range utils", () => {
       const outputs = removeOverlappingRanges(
         [
           {
-            str: "one",
+            inputString: "one",
             from: 0,
             to: 2
           },
           {
-            str: "two",
+            inputString: "two",
             from: 5,
             to: 7
           }
         ],
         [
           {
-            str: "three",
+            inputString: "three",
             from: 10,
             to: 12
           }
@@ -282,12 +282,12 @@ describe("Range utils", () => {
       );
       expect(outputs).toEqual([
         {
-          str: "one",
+          inputString: "one",
           from: 0,
           to: 2
         },
         {
-          str: "two",
+          inputString: "two",
           from: 5,
           to: 7
         }

--- a/src/ts/test/state.spec.ts
+++ b/src/ts/test/state.spec.ts
@@ -93,7 +93,7 @@ describe("State management", () => {
               },
               validationInput: {
                 from: 1,
-                str: "Example text to validate",
+                inputString: "Example text to validate",
                 to: 26
               }
             }
@@ -126,7 +126,7 @@ describe("State management", () => {
           validationsInFlight: [
             {
               validationInput: {
-                str: "Example text to validate",
+                inputString: "Example text to validate",
                 from: 1,
                 to: 25
               },
@@ -163,7 +163,7 @@ describe("State management", () => {
           validationsInFlight: [
             {
               validationInput: {
-                str: "Example text to validate",
+                inputString: "Example text to validate",
                 from: 1,
                 to: 25
               },
@@ -211,7 +211,7 @@ describe("State management", () => {
                   to: 3,
                   type: "type",
                   annotation: "annotation",
-                  str: "str",
+                  inputString: "str",
                   id: "0"
                 }
               ],
@@ -223,7 +223,7 @@ describe("State management", () => {
             annotation: "annotation",
             from: 1,
             id: "0",
-            str: "str",
+            inputString: "str",
             to: 3,
             type: "type"
           }
@@ -239,7 +239,7 @@ describe("State management", () => {
               validationOutputs: [
                 {
                   id: "id",
-                  str: "Example text to validate",
+                  inputString: "Example text to validate",
                   from: 5,
                   to: 10,
                   annotation: "Summat ain't right",
@@ -279,7 +279,7 @@ describe("State management", () => {
                   to: 3,
                   type: "type",
                   annotation: "annotation",
-                  str: "str",
+                  inputString: "str",
                   id: "0"
                 }
               ],
@@ -305,7 +305,7 @@ describe("State management", () => {
               validationsInFlight: [
                 {
                   validationInput: {
-                    str: "Example text to validate",
+                    inputString: "Example text to validate",
                     from: 1,
                     to: 25
                   },
@@ -316,7 +316,7 @@ describe("State management", () => {
             },
             validationRequestError({
               validationInput: {
-                str: "Example text to validate",
+                inputString: "Example text to validate",
                 from: 1,
                 to: 25
               },
@@ -360,7 +360,7 @@ describe("State management", () => {
         const output: IValidationOutput = {
           from: 0,
           to: 5,
-          str: "Example",
+          inputString: "Example",
           annotation: "Annotation",
           type: "Type",
           id: "exampleHoverId"
@@ -387,7 +387,7 @@ describe("State management", () => {
         const output: IValidationOutput = {
           from: 0,
           to: 5,
-          str: "Example",
+          inputString: "Example",
           annotation: "Annotation",
           type: "Type",
 
@@ -424,7 +424,7 @@ describe("State management", () => {
             id: "1",
             from: 1,
             to: 7,
-            str: "Example",
+            inputString: "Example",
             annotation: "Annotation",
             type: "Type"
           }
@@ -458,7 +458,7 @@ describe("State management", () => {
           ...state,
           currentValidations: [
             {
-              str: "example",
+              inputString: "example",
               from: 1,
               to: 1,
               annotation: "example",
@@ -605,7 +605,7 @@ describe("State management", () => {
             suggestions: ["example", "suggestion"],
             annotation: "Annotation",
             type: "Type",
-            str: "hai"
+            inputString: "hai"
           }
         ];
         expect(
@@ -629,7 +629,7 @@ describe("State management", () => {
             suggestions: ["example", "suggestion"],
             annotation: "Annotation",
             type: "Type",
-            str: "hai"
+            inputString: "hai"
           }
         ];
         expect(

--- a/src/ts/test/store.spec.ts
+++ b/src/ts/test/store.spec.ts
@@ -31,6 +31,8 @@ describe("store", () => {
   });
   it("should throw if a sub doesn't exist on removal", () => {
     const store = new Store();
-    expect(store.removeEventListener.bind(store, "STORE_EVENT_NEW_STATE", () => ({}))).toThrowError();
+    expect(
+      store.removeEventListener.bind(store, "STORE_EVENT_NEW_STATE", () => ({}))
+    ).toThrowError();
   });
 });

--- a/src/ts/test/validationAPIService.spec.ts
+++ b/src/ts/test/validationAPIService.spec.ts
@@ -36,12 +36,12 @@ const createResponse = (strs: string[]) => ({
   }))
 });
 
-const createOutput = (str: string, offset: number = 0) =>
+const createOutput = (inputString: string, offset: number = 0) =>
   ({
     id: "id",
     from: offset,
-    to: offset + str.length,
-    str,
+    to: offset + inputString.length,
+    inputString,
     type: "issueType",
     suggestions: [],
     annotation: "It's just a bunch of numbers, mate"
@@ -50,7 +50,7 @@ const createOutput = (str: string, offset: number = 0) =>
 const validationInput = {
   from: 0,
   to: 10,
-  str: "1234567890"
+  inputString: "1234567890"
 };
 
 const commands = {
@@ -99,7 +99,7 @@ describe("ValidationAPIService", () => {
       {
         from: 0,
         to: 10,
-        str: "1234567890"
+        inputString: "1234567890"
       },
       "id"
     );

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -55,9 +55,11 @@ export const removeDecorationsFromRanges = (
     }
     // Expand the range out to the range of the found decorations.
     const decorationsToRemove = flatten(
-      decorations.map(decoration =>
-        decorationSet.find(decoration.from, decoration.to, predicate)
-      ).filter(_ => !!_)
+      decorations
+        .map(decoration =>
+          decorationSet.find(decoration.from, decoration.to, predicate)
+        )
+        .filter(_ => !!_)
     );
     return acc.remove(decorationsToRemove);
   }, decorationSet);

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -39,7 +39,7 @@ export const createValidationInputsForDocument = (node: Node): IValidationInput[
   node.descendants((descNode, pos) => {
     if (!findChildren(descNode, _ => _.type.isBlock, false).length) {
       ranges.push({
-        str: descNode.textContent,
+        inputString: descNode.textContent,
         from: pos + 1,
         to: pos + descNode.nodeSize
       })

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -1,7 +1,7 @@
-import { Node } from 'prosemirror-model';
-import { Transaction } from 'prosemirror-state';
-import { ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform';
-import { IValidationInput } from '../interfaces/IValidation';
+import { Node } from "prosemirror-model";
+import { Transaction } from "prosemirror-state";
+import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
+import { IValidationInput } from "../interfaces/IValidation";
 
 export const MarkTypes = {
   legal: "legal",
@@ -34,7 +34,9 @@ export const findChildren = (
   return flatten(node, descend).filter(child => predicate(child.node));
 };
 
-export const createValidationInputsForDocument = (node: Node): IValidationInput[] => {
+export const createValidationInputsForDocument = (
+  node: Node
+): IValidationInput[] => {
   const ranges = [] as IValidationInput[];
   node.descendants((descNode, pos) => {
     if (!findChildren(descNode, _ => _.type.isBlock, false).length) {
@@ -42,12 +44,12 @@ export const createValidationInputsForDocument = (node: Node): IValidationInput[
         inputString: descNode.textContent,
         from: pos + 1,
         to: pos + descNode.nodeSize
-      })
+      });
       return false;
     }
   });
   return ranges;
-}
+};
 
 /**
  * Get all of the ranges of any replace steps in the given transaction.

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -5,7 +5,7 @@ import { findParentNode } from "prosemirror-utils";
 import {
   IRange,
   IValidationOutput,
-  IDefaultValidationMeta
+  IBaseValidationOutput
 } from "../interfaces/IValidation";
 import { IValidationInput } from "../interfaces/IValidation";
 import { Mapping } from "prosemirror-transform";
@@ -137,7 +137,7 @@ export const validationInputToRange = (input: IValidationInput): IRange => ({
  * Get the current set of validations for the given response.
  */
 export const getCurrentValidationsFromValidationResponse = <
-  TValidationMeta extends IDefaultValidationMeta
+  TValidationMeta extends IBaseValidationOutput
 >(
   input: IValidationInput,
   incomingOutputs: Array<IValidationOutput<TValidationMeta>>,

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -5,6 +5,7 @@ import { findParentNode } from "prosemirror-utils";
 import {
   IRange,
   IValidationOutput,
+  IDefaultValidationMeta
 } from "../interfaces/IValidation";
 import { IValidationInput } from "../interfaces/IValidation";
 import { Mapping } from "prosemirror-transform";
@@ -24,8 +25,10 @@ export const findOverlappingRangeIndex = (range: IRange, ranges: IRange[]) => {
   );
 };
 
-export const mapAndMergeRanges = <Range extends IRange>(ranges: Range[], mapping: Mapping): Range[] =>
-  mergeRanges(mapRanges(ranges, mapping));
+export const mapAndMergeRanges = <Range extends IRange>(
+  ranges: Range[],
+  mapping: Mapping
+): Range[] => mergeRanges(mapRanges(ranges, mapping));
 
 export const mapRanges = <Range extends IRange>(
   ranges: Range[],
@@ -57,7 +60,10 @@ export const removeOverlappingRanges = <
   );
 };
 
-export const mergeRange = <Range extends IRange>(range1: Range, range2: Range): Range => ({
+export const mergeRange = <Range extends IRange>(
+  range1: Range,
+  range2: Range
+): Range => ({
   ...range1,
   from: range1.from < range2.from ? range1.from : range2.from,
   to: range1.to > range2.to ? range1.to : range2.to
@@ -130,26 +136,22 @@ export const validationInputToRange = (input: IValidationInput): IRange => ({
 /**
  * Get the current set of validations for the given response.
  */
-export const getCurrentValidationsFromValidationResponse = (
+export const getCurrentValidationsFromValidationResponse = <
+  TValidationMeta extends IDefaultValidationMeta
+>(
   input: IValidationInput,
-  incomingOutputs: IValidationOutput[],
-  currentOutputs: IValidationOutput[],
+  incomingOutputs: Array<IValidationOutput<TValidationMeta>>,
+  currentOutputs: Array<IValidationOutput<TValidationMeta>>,
   mapping: Mapping
-): IValidationOutput[] => {
+): Array<IValidationOutput<TValidationMeta>> => {
   if (!incomingOutputs.length) {
     return currentOutputs;
   }
 
   // Map _all_ the things.
-  const mappedInputs = mapRanges(
-    [input],
-    mapping
-  );
+  const mappedInputs = mapRanges([input], mapping);
 
-  const newOutputs = mapAndMergeRanges(
-    incomingOutputs,
-    mapping
-  );
+  const newOutputs = mapAndMergeRanges(incomingOutputs, mapping);
 
   return removeOverlappingRanges(currentOutputs, mappedInputs).concat(
     newOutputs
@@ -159,7 +161,10 @@ export const getCurrentValidationsFromValidationResponse = (
 /**
  * Expand a range in a document to encompass the nearest ancestor block node.
  */
-export const expandRangeToParentBlockNode = (range: IRange, doc: Node): IRange | undefined => {
+export const expandRangeToParentBlockNode = (
+  range: IRange,
+  doc: Node
+): IRange | undefined => {
   try {
     const $fromPos = doc.resolve(range.from);
     const $toPos = doc.resolve(range.to);

--- a/src/ts/utils/types.ts
+++ b/src/ts/utils/types.ts
@@ -1,2 +1,6 @@
 // tslint:disable-next-line ban-types
-export type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any ? A : never;
+export type ArgumentTypes<F extends Function> = F extends (
+  ...args: infer A
+) => any
+  ? A
+  : never;


### PR DESCRIPTION
When handling the output of validation services, this plugin cares about ranges and (at the moment) suggestions, but consuming code might have a different set of data to store against a validation output. This PR adds a type parameter for the validation output that extends a base output.