### PR TITLE
Move side effects to validation service

### DIFF
--- a/src/ts/components/ValidationControls.tsx
+++ b/src/ts/components/ValidationControls.tsx
@@ -1,9 +1,10 @@
 import { Component, h } from "preact";
 import Store, { STORE_EVENT_NEW_STATE } from "../store";
 import { IPluginState } from "../state";
+import { IBaseValidationOutput } from "../interfaces/IValidation";
 
 interface IProps {
-  store: Store;
+  store: Store<IBaseValidationOutput>;
   setDebugState: (debug: boolean) => void;
   validateDocument: () => void;
 }
@@ -11,7 +12,7 @@ interface IProps {
 /**
  * A sidebar to display current validations and allow users to apply suggestions.
  */
-class ValidationControls extends Component<IProps, IPluginState> {
+class ValidationControls extends Component<IProps, IPluginState<IBaseValidationOutput>> {
   public componentWillMount() {
     this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
   }
@@ -42,7 +43,7 @@ class ValidationControls extends Component<IProps, IPluginState> {
       </div>
     );
   }
-  private handleNotify = (state: IPluginState) => {
+  private handleNotify = (state: IPluginState<IBaseValidationOutput>) => {
     this.setState(state);
   };
 }

--- a/src/ts/components/ValidationOverlay.tsx
+++ b/src/ts/components/ValidationOverlay.tsx
@@ -2,7 +2,7 @@ import clamp from 'lodash/clamp';
 import ValidationOutput from './ValidationOutputContainer';
 import { Component, h } from 'preact';
 import { IStateHoverInfo, selectValidationById, IPluginState } from '../state';
-import { IValidationOutput } from '../interfaces/IValidation';
+import { IValidationOutput, IBaseValidationOutput } from '../interfaces/IValidation';
 import Store, { STORE_EVENT_NEW_STATE } from '../store';
 import { ApplySuggestionOptions } from '../commands';
 
@@ -14,7 +14,7 @@ interface IState {
   isVisible: boolean;
 }
 interface IProps {
-  store: Store;
+  store: Store<IBaseValidationOutput>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }
 
@@ -70,7 +70,7 @@ class ValidationOverlay extends Component<IProps, IState> {
 
   private handleMouseOver = (e: MouseEvent) => e.stopPropagation();
 
-  private handleNotify = (state: IPluginState) => {
+  private handleNotify = (state: IPluginState<IBaseValidationOutput>) => {
     const newState = {
       isVisible: false,
       left: 0,

--- a/src/ts/components/ValidationSidebar.tsx
+++ b/src/ts/components/ValidationSidebar.tsx
@@ -3,9 +3,10 @@ import Store, { STORE_EVENT_NEW_STATE } from "../store";
 import { ApplySuggestionOptions } from "../commands";
 import { IPluginState } from "../state";
 import ValidationSidebarOutput from "./ValidationSidebarOutput";
+import { IBaseValidationOutput } from "../interfaces/IValidation";
 
 interface IProps {
-  store: Store;
+  store: Store<IBaseValidationOutput>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   selectValidation: (validationId: string) => void;
   indicateHover: (validationId: string, _: any) => void;
@@ -16,7 +17,7 @@ interface IProps {
  */
 class ValidationSidebar extends Component<
   IProps,
-  { pluginState: IPluginState | undefined; groupResults: boolean }
+  { pluginState: IPluginState<IBaseValidationOutput> | undefined; groupResults: boolean }
 > {
   public componentWillMount() {
     this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNewState);
@@ -67,7 +68,7 @@ class ValidationSidebar extends Component<
       </div>
     );
   }
-  private handleNewState = (pluginState: IPluginState) => {
+  private handleNewState = (pluginState: IPluginState<IBaseValidationOutput>) => {
     this.setState({
       pluginState: {
         ...pluginState,

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -5,13 +5,14 @@ import Store from "./store";
 import ValidationSidebar from "./components/ValidationSidebar";
 import ValidationControls from "./components/ValidationControls";
 import { Commands } from "./commands";
+import { IBaseValidationOutput } from "./interfaces/IValidation";
 
 /**
  * Scaffolding for an example view.
  */
 const createView = (
   view: EditorView,
-  store: Store,
+  store: Store<IBaseValidationOutput>,
   commands: Commands,
   sidebarNode: Element,
   controlsNode: Element

--- a/src/ts/services/ValidationAPIService.ts
+++ b/src/ts/services/ValidationAPIService.ts
@@ -3,48 +3,73 @@ import {
   IBaseValidationOutput
 } from "../interfaces/IValidation";
 import { IValidationAPIAdapter } from "../interfaces/IValidationAPIAdapter";
-import Store, { STORE_EVENT_NEW_VALIDATION } from "../store";
+import Store, {
+  STORE_EVENT_NEW_VALIDATION,
+  STORE_EVENT_DOCUMENT_DIRTIED
+} from "../store";
 import { Commands } from "../commands";
+import { selectValidationsInFlight } from "../state";
 
 /**
  * An example validation service. Calls to validate() begin validations
  * for ranges, configured via the supplied adapter. Validation results and
  * errors dispatch the appropriate Prosemirror commands.
  */
-class ValidationService<TValidationMeta extends IBaseValidationOutput> {
+class ValidationService<TValidationOutput extends IBaseValidationOutput> {
+  // The current throttle duration, which increases during backoff.
+  private currentThrottle: number;
+
   constructor(
-    private store: Store<TValidationMeta>,
+    private store: Store<TValidationOutput>,
     private commands: Commands,
-    private adapter: IValidationAPIAdapter<TValidationMeta>
+    private adapter: IValidationAPIAdapter<TValidationOutput>,
+    // The initial throttle duration for pending validation requests.
+    private initialThrottle = 2000,
+    // The maximum possible throttle duration on backoff.
+    private maxThrottle = 16000
   ) {
+    this.currentThrottle = initialThrottle;
     this.store.on(STORE_EVENT_NEW_VALIDATION, validationInFlight => {
       // If we have a new validation, send it to the validation service.
       this.validate(validationInFlight.validationInput, validationInFlight.id);
     });
+    this.store.on(STORE_EVENT_DOCUMENT_DIRTIED, () => this.requestValidation());
   }
+
+  /**
+   * Request a validation. If we already have validations in flight,
+   * defer it until the next throttle window.
+   */
+  public requestValidation() {
+    const pluginState = this.store.getState();
+    if (!pluginState || selectValidationsInFlight(pluginState).length) {
+      this.scheduleValidation();
+    }
+    this.commands.validateDirtyRangesCommand();
+  }
+
+  /**
+   * Schedule a validation for the next throttle tick.
+   */
+  private scheduleValidation = () =>
+    setTimeout(this.requestValidation, this.currentThrottle);
 
   /**
    * Validate a Prosemirror node, restricting checks to ranges if they're supplied.
    */
-  public async validate(validationInput: IValidationInput, id: string) {
+  private async validate(validationInput: IValidationInput, id: string) {
     try {
       const validationOutputs = await this.adapter(validationInput);
       this.commands.applyValidationResult({
         id,
         validationOutputs
       });
-      return validationOutputs;
     } catch (e) {
       this.commands.applyValidationError({
         validationInput,
         id,
         message: e.message
       });
-      return {
-        validationInput,
-        message: e.message,
-        id
-      };
     }
   }
 }

--- a/src/ts/store.ts
+++ b/src/ts/store.ts
@@ -1,18 +1,22 @@
 import { IPluginState, IValidationInFlight } from "./state";
 import { ArgumentTypes } from "./utils/types";
 import { IBaseValidationOutput } from "./interfaces/IValidation";
+import { Plugin } from "prosemirror-state";
 
 export const STORE_EVENT_NEW_VALIDATION = "STORE_EVENT_NEW_VALIDATION";
 export const STORE_EVENT_NEW_STATE = "STORE_EVENT_NEW_STATE";
+export const STORE_EVENT_DOCUMENT_DIRTIED = "STORE_EVENT_DOCUMENT_DIRTIED";
 
 type STORE_EVENT_NEW_VALIDATION = typeof STORE_EVENT_NEW_VALIDATION;
 type STORE_EVENT_NEW_STATE = typeof STORE_EVENT_NEW_STATE;
+type STORE_EVENT_DOCUMENT_DIRTIED = typeof STORE_EVENT_DOCUMENT_DIRTIED;
 
 interface IStoreEvents {
   [STORE_EVENT_NEW_VALIDATION]: (v: IValidationInFlight) => void;
   [STORE_EVENT_NEW_STATE]: <TValidationMeta extends IBaseValidationOutput>(
     state: IPluginState<TValidationMeta>
   ) => void;
+  [STORE_EVENT_DOCUMENT_DIRTIED]: () => void;
 }
 
 type EventNames = keyof IStoreEvents;
@@ -20,13 +24,21 @@ type EventNames = keyof IStoreEvents;
 /**
  * A store to allow consumers to subscribe to validator state updates.
  */
-class Store<TValidationMeta extends IBaseValidationOutput> {
+class Store<TValidationOutput extends IBaseValidationOutput> {
+  private state: IPluginState<TValidationOutput> | undefined;
   private subscribers: {
     [EventName in EventNames]: Array<IStoreEvents[EventName]>
   } = {
     [STORE_EVENT_NEW_STATE]: [],
-    [STORE_EVENT_NEW_VALIDATION]: []
+    [STORE_EVENT_NEW_VALIDATION]: [],
+    [STORE_EVENT_DOCUMENT_DIRTIED]: []
   };
+
+  constructor() {
+    this.on("STORE_EVENT_NEW_STATE", (_: IPluginState<TValidationOutput>) =>
+      this.updateState(_)
+    );
+  }
 
   /**
    * Notify our subscribers of a state change.
@@ -68,6 +80,20 @@ class Store<TValidationMeta extends IBaseValidationOutput> {
     (this.subscribers[eventName] as Array<IStoreEvents[EventName]>).push(
       listener as IStoreEvents[EventName]
     );
+  }
+
+  /**
+   * Get the current plugin state.
+   */
+  public getState() {
+    return this.state;
+  }
+
+  /**
+   * Update the store's reference to the plugin state.
+   */
+  private updateState(state: IPluginState<TValidationOutput>) {
+    this.state = state;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "removeComments": true,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "strictNullChecks": true,
+    "strict": true,
     "target": "es6",
     "esModuleInterop": true,
     "jsx": "react",


### PR DESCRIPTION
This lets us allow consuming code to make decisions about how it handles the validation side effect -- debouncing, backoff, etc.