### PR TITLE
Refine validation inputs and outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@babel/preset-env": "^7.2.0",
     "@types/fetch-mock": "^6.0.4",
     "@types/jest": "^23.3.2",
-    "@types/uuid": "^3.4.4",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^23.6.0",
     "eslint": "^4.13.1",
@@ -73,7 +72,6 @@
     "prosemirror-state": "^1.0.0",
     "prosemirror-tables": "^0.7.8",
     "prosemirror-utils": "^0.6.7",
-    "prosemirror-view": "^1.6.7",
-    "uuid": "^3.1.0"
+    "prosemirror-view": "^1.6.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,12 +66,14 @@
     "@types/prosemirror-schema-list": "^1.0.1",
     "@types/prosemirror-state": "^1.2.0",
     "@types/prosemirror-view": "^1.3.0",
+    "@types/uuid": "^3.4.4",
     "lodash": "^4.17.11",
     "preact": "^8.3.1",
     "prosemirror": "^0.11.1",
     "prosemirror-state": "^1.0.0",
     "prosemirror-tables": "^0.7.8",
     "prosemirror-utils": "^0.6.7",
-    "prosemirror-view": "^1.6.7"
+    "prosemirror-view": "^1.6.7",
+    "uuid": "^3.3.2"
   }
 }

--- a/src/ts/adapters/languageTool.ts
+++ b/src/ts/adapters/languageTool.ts
@@ -1,4 +1,3 @@
-import v4 from 'uuid/v4';
 import { IValidationInput } from "../interfaces/IValidation";
 import IValidationAPIAdapter from "../interfaces/IValidationAPIAdapter";
 import { ILTResponse } from "./interfaces/ILanguageTool";
@@ -37,7 +36,7 @@ const createLanguageToolAdapter: IValidationAPIAdapter = (
   }
   const validationData: ILTResponse = await response.json();
   return validationData.matches.map(match => ({
-    id: v4(),
+    id: input.id,
     str: match.sentence,
     from: input.from + match.offset,
     to: input.from + match.offset + match.length,

--- a/src/ts/adapters/languageTool.ts
+++ b/src/ts/adapters/languageTool.ts
@@ -1,3 +1,4 @@
+import v4 from "uuid/v4";
 import { IValidationInput } from "../interfaces/IValidation";
 import IValidationAPIAdapter from "../interfaces/IValidationAPIAdapter";
 import { ILTResponse } from "./interfaces/ILanguageTool";
@@ -36,7 +37,7 @@ const createLanguageToolAdapter: IValidationAPIAdapter = (
   }
   const validationData: ILTResponse = await response.json();
   return validationData.matches.map(match => ({
-    id: input.id,
+    id: v4(),
     str: match.sentence,
     from: input.from + match.offset,
     to: input.from + match.offset + match.length,

--- a/src/ts/adapters/regex.ts
+++ b/src/ts/adapters/regex.ts
@@ -1,3 +1,4 @@
+import v4 from "uuid/v4";
 import { IValidationInput, IValidationOutput } from "../interfaces/IValidation";
 
 /**
@@ -17,7 +18,7 @@ const regexAdapter = async (input: IValidationInput) => {
       annotation:
         "This word has three letters. Consider a larger, grander word.",
       type: "3 letter word",
-      id: input.id,
+      id: v4(),
       suggestions: ["replace", "with", "grand", "word"]
     });
   }

--- a/src/ts/adapters/regex.ts
+++ b/src/ts/adapters/regex.ts
@@ -1,5 +1,4 @@
 import { IValidationInput, IValidationOutput } from "../interfaces/IValidation";
-import v4 from "uuid/v4";
 
 /**
  * An example adapter that applies a regex to find three letter words in the document.
@@ -15,7 +14,8 @@ const regexAdapter = async (input: IValidationInput) => {
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
       str: result[0],
-      annotation: "This word has three letters. Consider a larger, grander word.",
+      annotation:
+        "This word has three letters. Consider a larger, grander word.",
       type: "3 letter word",
       id: v4(),
       suggestions: ["replace", "with", "grand", "word"]
@@ -27,9 +27,10 @@ const regexAdapter = async (input: IValidationInput) => {
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
       str: result[0],
-      annotation: "This word has six letters. Consider a smaller, less fancy word.",
+      annotation:
+        "This word has six letters. Consider a smaller, less fancy word.",
       type: "6 letter word",
-      id: v4(),
+      id: input.id,
       suggestions: ["replace", "with", "bijou", "word"]
     });
   }

--- a/src/ts/adapters/regex.ts
+++ b/src/ts/adapters/regex.ts
@@ -17,7 +17,7 @@ const regexAdapter = async (input: IValidationInput) => {
       annotation:
         "This word has three letters. Consider a larger, grander word.",
       type: "3 letter word",
-      id: v4(),
+      id: input.id,
       suggestions: ["replace", "with", "grand", "word"]
     });
   }

--- a/src/ts/adapters/typerighter.ts
+++ b/src/ts/adapters/typerighter.ts
@@ -1,4 +1,3 @@
-import v4 from "uuid/v4";
 import { IValidationInput } from "../interfaces/IValidation";
 import IValidationAPIAdapter from "../interfaces/IValidationAPIAdapter";
 import { ITypeRighterResponse } from "./interfaces/ITyperighter";
@@ -27,7 +26,7 @@ const createTyperighterAdapter: IValidationAPIAdapter = (
   }
   const validationData: ITypeRighterResponse = await response.json();
   return validationData.results.map(match => ({
-    id: v4(),
+    id: input.id,
     str: input.str,
     from: input.from + match.fromPos,
     to: input.from + match.toPos,

--- a/src/ts/adapters/typerighter.ts
+++ b/src/ts/adapters/typerighter.ts
@@ -1,3 +1,4 @@
+import v4 from "uuid/v4";
 import { IValidationInput } from "../interfaces/IValidation";
 import IValidationAPIAdapter from "../interfaces/IValidationAPIAdapter";
 import { ITypeRighterResponse } from "./interfaces/ITyperighter";
@@ -26,7 +27,7 @@ const createTyperighterAdapter: IValidationAPIAdapter = (
   }
   const validationData: ITypeRighterResponse = await response.json();
   return validationData.results.map(match => ({
-    id: input.id,
+    id: v4(),
     str: input.str,
     from: input.from + match.fromPos,
     to: input.from + match.toPos,

--- a/src/ts/createValidationPlugin.ts
+++ b/src/ts/createValidationPlugin.ts
@@ -18,7 +18,10 @@ import { getReplaceStepRangesFromTransaction } from "./utils/prosemirror";
 import { getStateHoverInfoFromEvent } from "./utils/dom";
 import { IRange } from "./interfaces/IValidation";
 import { Node } from "prosemirror-model";
-import Store, { STORE_EVENT_NEW_STATE, STORE_EVENT_NEW_VALIDATION } from "./store";
+import Store, {
+  STORE_EVENT_NEW_STATE,
+  STORE_EVENT_NEW_VALIDATION
+} from "./store";
 import { indicateHoverCommand } from "./commands";
 
 /**
@@ -128,8 +131,13 @@ const createValidatorPlugin = (options: IPluginOptions = {}) => {
           applyNewDirtiedRanges(newDirtiedRanges)
         );
       }
-      const newValidationsInFlight = selectNewValidationInFlight(newPluginState, oldPluginState);
-      newValidationsInFlight.forEach(_ => store.emit(STORE_EVENT_NEW_VALIDATION, _))
+      const newValidationsInFlight = selectNewValidationInFlight(
+        oldPluginState,
+        newPluginState
+      );
+      newValidationsInFlight.forEach(_ =>
+        store.emit(STORE_EVENT_NEW_VALIDATION, _)
+      );
     },
     props: {
       decorations: state => {
@@ -176,7 +184,7 @@ const createValidatorPlugin = (options: IPluginOptions = {}) => {
       localView = view;
       return {
         // Update our store with the new state.
-        update: (_) =>
+        update: _ =>
           store.emit(STORE_EVENT_NEW_STATE, plugin.getState(view.state))
       };
     }

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -1,33 +1,39 @@
-export interface IRange { from: number; to: number }
+export interface IRange {
+  from: number;
+  to: number;
+}
 
-export interface IValidationInput { str: string; from: number; to: number }
+export interface IValidationInput {
+  id: string;
+  str: string;
+  from: number;
+  to: number;
+}
 
 export type IValidationOutput = IValidationInput & {
   annotation: string;
   suggestions?: string[];
   type: string;
-  id: string;
 };
 
 export interface IValidationError {
   validationInput: IValidationInput;
-  id: string;
   message: string;
 }
 
 export interface IValidationResponse {
-  // The validation outputs.
   validationOutputs: IValidationOutput[];
-  // The ID of the validation request.
-  id: string;
+  validationInput: IValidationInput;
 }
 
-export type IValidationLibrary = Array<Array<{
-  regExp: RegExp;
-  annotation: string;
-  operation: "ANNOTATE" | "REPLACE";
-  type: string;
-}>>;
+export type IValidationLibrary = Array<
+  Array<{
+    regExp: RegExp;
+    annotation: string;
+    operation: "ANNOTATE" | "REPLACE";
+    type: string;
+  }>
+>;
 
 export const Operations: {
   [key: string]: "ANNOTATE" | "REPLACE";

--- a/src/ts/services/ValidationAPIService.ts
+++ b/src/ts/services/ValidationAPIService.ts
@@ -16,34 +16,29 @@ class ValidationService {
   ) {
     this.store.on(STORE_EVENT_NEW_VALIDATION, validationInFlight => {
       // If we have a new validation, send it to the validation service.
-      this.validate(validationInFlight.validationInput, validationInFlight.id);
+      this.validate(validationInFlight.validationInput);
     });
   }
 
   /**
    * Validate a Prosemirror node, restricting checks to ranges if they're supplied.
    */
-  public async validate(
-    validationInput: IValidationInput,
-    id: string
-  ) {
+  public async validate(validationInput: IValidationInput) {
     try {
       const validationOutputs = await this.adapter(validationInput);
       this.commands.applyValidationResult({
-        id,
-        validationOutputs
+        validationOutputs,
+        validationInput
       });
       return validationOutputs;
     } catch (e) {
       this.commands.applyValidationError({
         validationInput,
-        id,
         message: e.message
       });
       return {
         validationInput,
-        message: e.message,
-        id
+        message: e.message
       };
     }
   }

--- a/src/ts/test/__snapshots__/validationAPIService.spec.ts.snap
+++ b/src/ts/test/__snapshots__/validationAPIService.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`ValidationAPIService should handle validation errors 1`] = `
 Object {
-  "id": "id",
   "message": "Error fetching validations. The server responded with status code 400: Bad Request",
   "validationInput": Object {
     "from": 0,
-    "str": "1234567890",
+    "id": "0-from:0-to:10",
+    "str": "str",
     "to": 10,
   },
 }

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -24,3 +24,29 @@ export const validationLibrary: IValidationLibrary = [
     }
   ]
 ];
+
+export const createValidationInput = (
+  from: number,
+  to: number,
+  str = "str"
+) => ({
+  str,
+  from,
+  to,
+  id: `0-from:${from}-to:${to}`
+});
+
+export const createValidationOutput = (
+  from: number,
+  to: number,
+  str = "str",
+  suggestions = [] as string[]
+) => ({
+  from,
+  to,
+  type: "type",
+  annotation: "annotation",
+  str,
+  id: `0-from:${from}-to:${to}`,
+  suggestions
+});

--- a/src/ts/test/prosemirror.spec.ts
+++ b/src/ts/test/prosemirror.spec.ts
@@ -17,18 +17,23 @@ describe("Prosemirror utils", () => {
         p("Paragraph 2"),
         p(ul(li("List item 1"), li("List item 2")))
       );
-      expect(createValidationInputsForDocument(node)).toEqual([
-        { from: 1, to: 13, str: "Paragraph 1" },
-        { from: 14, to: 26, str: "Paragraph 2" },
+      const tr = new Transaction(node);
+      tr.doc = node;
+      tr.time = 0;
+      expect(createValidationInputsForDocument(tr)).toEqual([
+        { from: 1, to: 13, str: "Paragraph 1", id: "0-from:1-to:13" },
+        { from: 14, to: 26, str: "Paragraph 2", id: "0-from:14-to:26" },
         {
           from: 29,
           to: 41,
-          str: "List item 1"
+          str: "List item 1",
+          id: "0-from:29-to:41"
         },
         {
           from: 42,
           to: 54,
-          str: "List item 2"
+          str: "List item 2",
+          id: "0-from:42-to:54"
         }
       ]);
     });

--- a/src/ts/test/state.spec.ts
+++ b/src/ts/test/state.spec.ts
@@ -184,7 +184,7 @@ describe("State management", () => {
           )
         ).toEqual(state);
       });
-      it.only("should add incoming validations to the state", () => {
+      it("should add incoming validations to the state", () => {
         const { state, tr } = createInitialData();
         let localState = validationPluginReducer(
           tr,

--- a/src/ts/test/state.spec.ts
+++ b/src/ts/test/state.spec.ts
@@ -26,8 +26,10 @@ import { expandRangesToParentBlockNode } from "../utils/range";
 import { createDoc, p } from "./helpers/prosemirror";
 import { Mapping } from "prosemirror-transform";
 import { IValidationOutput } from "../interfaces/IValidation";
-
-jest.mock("uuid/v4", () => () => "uuid");
+import {
+  createValidationOutput,
+  createValidationInput
+} from "./helpers/fixtures";
 
 const initialDocToValidate = createDoc(p("Example text to validate"));
 const createInitialTr = () => {
@@ -84,17 +86,12 @@ describe("State management", () => {
           ...state,
           validationsInFlight: [
             {
-              id: "0",
-              mapping: {
-                from: 0,
-                maps: [],
-                mirror: undefined,
-                to: 0
-              },
+              mapping: new Mapping(),
               validationInput: {
                 from: 1,
                 str: "Example text to validate",
-                to: 26
+                to: 26,
+                id: "0-from:1-to:26"
               }
             }
           ]
@@ -128,9 +125,9 @@ describe("State management", () => {
               validationInput: {
                 str: "Example text to validate",
                 from: 1,
-                to: 25
+                to: 25,
+                id: "0-from:1-to:25"
               },
-              id: "0",
               mapping: new Mapping()
             }
           ]
@@ -162,12 +159,11 @@ describe("State management", () => {
           validationPending: false,
           validationsInFlight: [
             {
-              validationInput: {
-                str: "Example text to validate",
-                from: 1,
-                to: 25
-              },
-              id: "0",
+              validationInput: createValidationInput(
+                1,
+                25,
+                "Example text to validate"
+              ),
               mapping: new Mapping()
             }
           ]
@@ -183,12 +179,12 @@ describe("State management", () => {
             state,
             validationRequestSuccess({
               validationOutputs: [],
-              id: "0"
+              validationInput: createValidationInput(0, 25)
             })
           )
         ).toEqual(state);
       });
-      it("should add incoming validations to the state", () => {
+      it.only("should add incoming validations to the state", () => {
         const { state, tr } = createInitialData();
         let localState = validationPluginReducer(
           tr,
@@ -205,29 +201,11 @@ describe("State management", () => {
             tr,
             localState,
             validationRequestSuccess({
-              validationOutputs: [
-                {
-                  from: 1,
-                  to: 3,
-                  type: "type",
-                  annotation: "annotation",
-                  str: "str",
-                  id: "0"
-                }
-              ],
-              id: "0"
+              validationOutputs: [createValidationOutput(1, 25)],
+              validationInput: createValidationInput(1, 25)
             })
           ).currentValidations
-        ).toMatchObject([
-          {
-            annotation: "annotation",
-            from: 1,
-            id: "0",
-            str: "str",
-            to: 3,
-            type: "type"
-          }
-        ]);
+        ).toMatchObject([createValidationOutput(1, 25)]);
       });
       it("should create decorations for the incoming validations", () => {
         const { state, tr } = createInitialData();
@@ -236,20 +214,54 @@ describe("State management", () => {
             tr,
             state,
             validationRequestSuccess({
-              validationOutputs: [
-                {
-                  id: "id",
-                  str: "Example text to validate",
-                  from: 5,
-                  to: 10,
-                  annotation: "Summat ain't right",
-                  type: "EXAMPLE_TYPE"
-                }
-              ],
-              id: "0"
+              validationOutputs: [createValidationOutput(5, 10)],
+              validationInput: createValidationInput(5, 10)
             })
           )
         ).toMatchSnapshot();
+      });
+      it("should remove decorations that no longer apply to the validated range", () => {
+        const { state, tr } = createInitialData();
+        const validationInput = createValidationInput(
+          0,
+          26,
+          "Example text to validate"
+        );
+        const validationOutput = createValidationOutput(1, 7, "Example");
+        const incomingValidationOutput = createValidationOutput(
+          5,
+          10,
+          "Example text to validate"
+        );
+        expect(
+          validationPluginReducer(
+            tr,
+            {
+              ...state,
+              validationsInFlight: [
+                {
+                  mapping: new Mapping(),
+                  validationInput
+                }
+              ],
+              currentValidations: [validationOutput],
+              decorations: new DecorationSet().add(
+                initialDocToValidate,
+                createDecorationForValidationRange(validationOutput)
+              )
+            },
+            validationRequestSuccess({
+              validationOutputs: [incomingValidationOutput],
+              validationInput
+            })
+          )
+        ).toMatchObject({
+          currentValidations: [incomingValidationOutput],
+          decorations: new DecorationSet().add(
+            initialDocToValidate,
+            createDecorationForValidationRange(incomingValidationOutput)
+          )
+        });
       });
       it("should not apply validations if the ranges they apply to have since been dirtied", () => {
         const { state, tr } = createInitialData(initialDocToValidate, 1337);
@@ -273,17 +285,8 @@ describe("State management", () => {
             tr,
             localState,
             validationRequestSuccess({
-              validationOutputs: [
-                {
-                  from: 1,
-                  to: 3,
-                  type: "type",
-                  annotation: "annotation",
-                  str: "str",
-                  id: "0"
-                }
-              ],
-              id: "0"
+              validationOutputs: [createValidationOutput(1, 3)],
+              validationInput: createValidationInput(1, 3)
             })
           )
         ).toEqual({
@@ -304,23 +307,21 @@ describe("State management", () => {
               ...state,
               validationsInFlight: [
                 {
-                  validationInput: {
-                    str: "Example text to validate",
-                    from: 1,
-                    to: 25
-                  },
-                  id: "0",
+                  validationInput: createValidationInput(
+                    1,
+                    25,
+                    "Example text to validate"
+                  ),
                   mapping: new Mapping()
                 }
               ]
             },
             validationRequestError({
-              validationInput: {
-                str: "Example text to validate",
-                from: 1,
-                to: 25
-              },
-              id: "0",
+              validationInput: createValidationInput(
+                1,
+                25,
+                "Example text to validate"
+              ),
               message: "Too many requests"
             })
           )
@@ -537,16 +538,16 @@ describe("State management", () => {
             {
               validationsInFlight: [
                 {
-                  id: "1"
+                  validationInput: { id: "1" }
                 },
                 {
-                  id: "2"
+                  validationInput: { id: "2" }
                 }
               ]
             } as any,
             "1"
           )
-        ).toEqual({ id: "1" });
+        ).toEqual({ validationInput: { id: "1" } });
       });
     });
     describe("selectNewValidationInFlight", () => {
@@ -556,38 +557,68 @@ describe("State management", () => {
             {
               validationsInFlight: [
                 {
-                  id: "1"
+                  validationInput: { id: "1" }
                 },
                 {
-                  id: "2"
+                  validationInput: { id: "2" }
                 }
               ]
             } as any,
             {
               validationsInFlight: [
                 {
-                  id: "1"
+                  validationInput: { id: "1" }
                 },
                 {
-                  id: "2"
+                  validationInput: { id: "2" }
+                },
+
+                {
+                  validationInput: { id: "3" }
                 },
                 {
-                  id: "3"
-                },
-                {
-                  id: "4"
+                  validationInput: { id: "4" }
                 }
               ]
             } as any
           )
         ).toEqual([
           {
-            id: "1"
+            validationInput: { id: "3" }
           },
           {
-            id: "2"
+            validationInput: { id: "4" }
           }
         ]);
+      });
+      it("shouldn't include validations missing in the new state but present in the old state", () => {
+        expect(
+          selectNewValidationInFlight(
+            {
+              validationsInFlight: [
+                {
+                  validationInput: { id: "1" }
+                },
+                {
+                  validationInput: { id: "2" }
+                },
+                {
+                  validationInput: { id: "3" }
+                }
+              ]
+            } as any,
+            {
+              validationsInFlight: [
+                {
+                  validationInput: { id: "1" }
+                },
+                {
+                  validationInput: { id: "2" }
+                }
+              ]
+            } as any
+          )
+        ).toEqual([]);
       });
     });
     describe("selectSuggestionAndRange", () => {

--- a/src/ts/test/validationAPIService.spec.ts
+++ b/src/ts/test/validationAPIService.spec.ts
@@ -41,7 +41,7 @@ const createOutput = (str: string, offset: number = 0) => {
   const from = offset;
   const to = offset + str.length;
   return {
-    id: `0-from:${from}-to:${to}`,
+    id: "id",
     from,
     to,
     str,
@@ -64,6 +64,8 @@ const commands = {
 };
 
 const store = new Store();
+
+jest.mock("uuid/v4", () => () => "id");
 
 describe("ValidationAPIService", () => {
   afterEach(() => {

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -1,7 +1,8 @@
-import { Node } from 'prosemirror-model';
-import { Transaction } from 'prosemirror-state';
-import { ReplaceAroundStep, ReplaceStep } from 'prosemirror-transform';
-import { IValidationInput } from '../interfaces/IValidation';
+import { Node } from "prosemirror-model";
+import { Transaction } from "prosemirror-state";
+import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
+import { IValidationInput } from "../interfaces/IValidation";
+import { createValidationInput } from "./validation";
 
 export const MarkTypes = {
   legal: "legal",
@@ -34,20 +35,23 @@ export const findChildren = (
   return flatten(node, descend).filter(child => predicate(child.node));
 };
 
-export const createValidationInputsForDocument = (node: Node): IValidationInput[] => {
+export const createValidationInputsForDocument = (
+  tr: Transaction
+): IValidationInput[] => {
   const ranges = [] as IValidationInput[];
-  node.descendants((descNode, pos) => {
+  tr.doc.descendants((descNode, pos) => {
     if (!findChildren(descNode, _ => _.type.isBlock, false).length) {
-      ranges.push({
-        str: descNode.textContent,
-        from: pos + 1,
-        to: pos + descNode.nodeSize
-      })
+      ranges.push(
+        createValidationInput(tr, {
+          from: pos + 1,
+          to: pos + descNode.nodeSize
+        })
+      );
       return false;
     }
   });
   return ranges;
-}
+};
 
 /**
  * Get all of the ranges of any replace steps in the given transaction.

--- a/src/ts/utils/validation.ts
+++ b/src/ts/utils/validation.ts
@@ -1,0 +1,11 @@
+import { Transaction } from "prosemirror-state";
+import { IRange } from "../interfaces/IValidation";
+
+export const createValidationInput = (tr: Transaction, range: IRange) => {
+  const str = tr.doc.textBetween(range.from, range.to);
+  return {
+    str,
+    ...range,
+    id: `${tr.time}-from:${range.from}-to:${range.to}`
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,6 +635,12 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/uuid@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  dependencies:
+    "@types/node" "*"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -635,12 +635,6 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/uuid@^3.4.4":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
-  dependencies:
-    "@types/node" "*"
-
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -4804,7 +4798,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.1.0, uuid@^3.3.2:
+uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 


### PR DESCRIPTION
This PR adds an ID to the validation input definition, which is the correct place to put it.

The ID is derived from the transaction timestamp and the range to which the input applies, which is a) deterministic and b) unique for each input.

This is nice, because it allows us to see the range at a glance when looking at logs etc., whilst keeping our action creators pure (no need for v4() or similar).

There are a few other changes in this PR that squash bugs relating to validation requests etc. -- as this is largely a one-person operation I lacked the discipline to split them out into a separate PR!