### PR TITLE
Allow users to batch-apply suggestions

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -55,7 +55,7 @@ if (editorElement && sidebarElement && controlsElement) {
   const validationService = new ValidationService(
     store,
     commands,
-    new TyperighterAdapter("http://localhost:9000")
+    new TyperighterAdapter("http://localhost:9000/check", "http://localhost:9000/categories")
   );
   (window as any).editor = view;
   createView(

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -58,6 +58,10 @@ hr {
   margin-left: auto;
 }
 
+.pull-right {
+  float: right;
+}
+
 .Button {
   padding: 1px 4px;
   border: 1px solid lightgrey;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -159,10 +159,6 @@ hr {
   border-bottom: 2px solid $validation-color;
 }
 
-.ValidationDecoration--is-hovering {
-  background-color: $validation-color-hover;
-}
-
 .ValidationDebugDirty {
   background-color: $validation-debug-color-dirty;
 }

--- a/src/css/validationSidebarOutput.scss
+++ b/src/css/validationSidebarOutput.scss
@@ -2,10 +2,6 @@
   padding: ($gutter-width / 2) ;
 }
 
-.ValidationSidebarOutput__container--is-selected {
-  border-left: 2px solid $validation-color;
-}
-
 .ValidationSidebarOutput__list-item:last-child {
   border-bottom: none;
 }

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -247,7 +247,12 @@ const maybeApplySuggestions = (
     const tr = state.tr;
     suggestionsToApply.forEach(
       ({ from, to, text }) =>
-        text && tr.replaceWith(from, to, state.schema.text(text))
+        text &&
+        tr.replaceWith(
+          tr.mapping.map(from),
+          tr.mapping.map(to),
+          state.schema.text(text)
+        )
     );
     dispatch(tr);
   }

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -2,10 +2,10 @@ import { Transaction, EditorState } from "prosemirror-state";
 import {
   VALIDATION_PLUGIN_ACTION,
   newHoverIdReceived,
-  selectValidationById,
+  selectValidationByMatchId,
   IPluginState,
   validationRequestForDocument,
-  selectValidation,
+  selectMatch,
   setDebugState,
   setValidateOnModifyState,
   IStateHoverInfo,
@@ -96,13 +96,13 @@ export const selectValidationCommand = <
   getState: GetState<TValidationOutput>
 ): Command => (state, dispatch) => {
   const pluginState = getState(state);
-  const output = selectValidationById(pluginState, validationId);
+  const output = selectValidationByMatchId(pluginState, validationId);
   if (!output) {
     return false;
   }
   if (dispatch) {
     dispatch(
-      state.tr.setMeta(VALIDATION_PLUGIN_ACTION, selectValidation(validationId))
+      state.tr.setMeta(VALIDATION_PLUGIN_ACTION, selectMatch(validationId))
     );
   }
   return true;
@@ -177,7 +177,7 @@ export const applyValidationErrorCommand = (
 };
 
 export type ApplySuggestionOptions = Array<{
-  validationId: string;
+  matchId: string;
   text: string;
 }>;
 
@@ -193,7 +193,7 @@ export const applySuggestionsCommand = <
   const pluginState = getState(state);
   const outputsAndSuggestions = suggestionOptions
     .map(opt => {
-      const validation = selectValidationById(pluginState, opt.validationId);
+      const validation = selectValidationByMatchId(pluginState, opt.matchId);
       return validation
         ? {
             from: validation.from,

--- a/src/ts/components/Suggestion.tsx
+++ b/src/ts/components/Suggestion.tsx
@@ -4,35 +4,37 @@ import { ISuggestion } from "../interfaces/IValidation";
 import WikiSuggestion from "./WikiSuggestion";
 
 interface IProps {
-  validationId: string;
+  matchId: string;
   suggestion: ISuggestion;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }
 
-const Suggestion = ({
-  validationId,
-  suggestion,
-  applySuggestions
-}: IProps) => {
+const Suggestion = ({ matchId, suggestion, applySuggestions }: IProps) => {
   const boundApplySuggestions = () =>
     applySuggestions &&
     applySuggestions([
       {
-        validationId,
+        matchId,
         text: suggestion.text
       }
     ]);
   switch (suggestion.type) {
     case "TEXT_SUGGESTION": {
       return (
-        <div class="ValidationWidget__suggestion" onClick={boundApplySuggestions}>
+        <div
+          class="ValidationWidget__suggestion"
+          onClick={boundApplySuggestions}
+        >
           {suggestion.text}
         </div>
       );
     }
     case "WIKI_SUGGESTION": {
       return (
-        <WikiSuggestion {...suggestion} applySuggestion={boundApplySuggestions} />
+        <WikiSuggestion
+          {...suggestion}
+          applySuggestion={boundApplySuggestions}
+        />
       );
     }
   }

--- a/src/ts/components/SuggestionList.tsx
+++ b/src/ts/components/SuggestionList.tsx
@@ -6,13 +6,13 @@ import { ApplySuggestionOptions } from "../commands";
 
 interface IProps {
   suggestions: ISuggestion[];
-  validationId: string;
+  matchId: string;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }
 
 const SuggestionList = ({
   suggestions,
-  validationId,
+  matchId,
   applySuggestions
 }: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -24,7 +24,7 @@ const SuggestionList = ({
         <p>No suggestions found.</p>
       ) : (
         <Suggestion
-          validationId={validationId}
+          matchId={matchId}
           suggestion={firstSuggestion}
           applySuggestions={applySuggestions}
         />
@@ -42,7 +42,7 @@ const SuggestionList = ({
         <Fragment>
           {otherSuggestions.map(suggestion => (
             <Suggestion
-              validationId={validationId}
+              matchId={matchId}
               suggestion={suggestion}
               applySuggestions={applySuggestions}
             />

--- a/src/ts/components/ValidationOutput.tsx
+++ b/src/ts/components/ValidationOutput.tsx
@@ -30,7 +30,7 @@ class ValidationOutput<
             <div className="ValidationWidget__suggestion-list">
               <SuggestionList
                 applySuggestions={applySuggestions}
-                validationId={id}
+                matchId={id}
                 suggestions={suggestions}
               />
             </div>

--- a/src/ts/components/ValidationOutput.tsx
+++ b/src/ts/components/ValidationOutput.tsx
@@ -13,7 +13,7 @@ class ValidationOutput<
 > extends Component<IValidationOutputProps<TValidationOutput>> {
   public ref: HTMLDivElement | undefined;
   public render({
-    validationOutput: { validationId: id, category, annotation, suggestions },
+    validationOutput: { matchId, category, annotation, suggestions },
     applySuggestions
   }: IValidationOutputProps<TValidationOutput>) {
     return (
@@ -30,7 +30,7 @@ class ValidationOutput<
             <div className="ValidationWidget__suggestion-list">
               <SuggestionList
                 applySuggestions={applySuggestions}
-                matchId={id}
+                matchId={matchId}
                 suggestions={suggestions}
               />
             </div>

--- a/src/ts/components/ValidationOverlay.tsx
+++ b/src/ts/components/ValidationOverlay.tsx
@@ -1,6 +1,6 @@
 import ValidationOutput from "./ValidationOutput";
 import { Component, h } from "preact";
-import { IStateHoverInfo, selectValidationById, IPluginState } from "../state/state";
+import { IStateHoverInfo, selectValidationByMatchId, IPluginState } from "../state/state";
 import { IValidationOutput } from "../interfaces/IValidation";
 import Store, { STORE_EVENT_NEW_STATE, IStoreEvents } from "../store";
 import { ApplySuggestionOptions } from "../commands";
@@ -89,7 +89,7 @@ class ValidationOverlay<
       top: 0
     };
     if (state.hoverId && state.hoverInfo) {
-      const validationOutput = selectValidationById(state, state.hoverId);
+      const validationOutput = selectValidationByMatchId(state, state.hoverId);
       return this.setState({
         hoverInfo: state.hoverInfo,
         validationOutput,

--- a/src/ts/components/ValidationSidebar.tsx
+++ b/src/ts/components/ValidationSidebar.tsx
@@ -8,8 +8,8 @@ import { IValidationOutput } from "../interfaces/IValidation";
 interface IProps {
   store: Store<IValidationOutput>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
-  selectValidation: (validationId: string) => void;
-  indicateHover: (validationId: string | undefined, _: any) => void;
+  selectValidation: (matchId: string) => void;
+  indicateHover: (matchId: string | undefined, _: any) => void;
 }
 
 /**
@@ -32,8 +32,8 @@ class ValidationSidebar extends Component<
       currentValidations = [],
       validationsInFlight = [],
       validationPending = false,
-      selectedValidation
-    } = this.state.pluginState || { selectedValidation: undefined };
+      selectedMatch
+    } = this.state.pluginState || { selectedMatch: undefined };
     const hasValidations = !!(currentValidations && currentValidations.length);
     const percentRemaining = this.getPercentRemaining();
     return (
@@ -61,7 +61,7 @@ class ValidationSidebar extends Component<
                 <li className="Sidebar__list-item">
                   <ValidationSidebarOutput
                     output={output}
-                    selectedValidation={selectedValidation}
+                    selectedMatch={selectedMatch}
                     applySuggestions={applySuggestions}
                     selectValidation={selectValidation}
                     indicateHover={indicateHover}
@@ -80,9 +80,7 @@ class ValidationSidebar extends Component<
     );
   }
 
-  private handleNewState = (
-    pluginState: IPluginState<IValidationOutput>
-  ) => {
+  private handleNewState = (pluginState: IPluginState<IValidationOutput>) => {
     this.setState({
       pluginState: {
         ...pluginState,

--- a/src/ts/components/ValidationSidebar.tsx
+++ b/src/ts/components/ValidationSidebar.tsx
@@ -4,10 +4,12 @@ import { ApplySuggestionOptions } from "../commands";
 import { IPluginState, selectPercentRemaining } from "../state/state";
 import ValidationSidebarOutput from "./ValidationSidebarOutput";
 import { IValidationOutput } from "../interfaces/IValidation";
+import { selectAllAutoFixableValidations } from "../state/state";
 
 interface IProps {
   store: Store<IValidationOutput>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
+  applyAutoFixableSuggestions: () => void;
   selectValidation: (matchId: string) => void;
   indicateHover: (matchId: string | undefined, _: any) => void;
 }
@@ -27,7 +29,12 @@ class ValidationSidebar extends Component<
   }
 
   public render() {
-    const { applySuggestions, selectValidation, indicateHover } = this.props;
+    const {
+      applySuggestions,
+      applyAutoFixableSuggestions,
+      selectValidation,
+      indicateHover
+    } = this.props;
     const {
       currentValidations = [],
       validationsInFlight = [],
@@ -35,6 +42,7 @@ class ValidationSidebar extends Component<
       selectedMatch
     } = this.state.pluginState || { selectedMatch: undefined };
     const hasValidations = !!(currentValidations && currentValidations.length);
+    const noOfAutoFixableSuggestions = this.getNoOfAutoFixableSuggestions();
     const percentRemaining = this.getPercentRemaining();
     return (
       <div className="Sidebar__section">
@@ -53,6 +61,14 @@ class ValidationSidebar extends Component<
               }}
             />
           </span>
+          {!!noOfAutoFixableSuggestions && (
+            <button
+              class="Button flex-align-right"
+              onClick={applyAutoFixableSuggestions}
+            >
+              Fix all ({noOfAutoFixableSuggestions})
+            </button>
+          )}
         </div>
         <div className="Sidebar__content">
           {hasValidations && (
@@ -97,6 +113,14 @@ class ValidationSidebar extends Component<
       return 0;
     }
     return selectPercentRemaining(state);
+  };
+
+  private getNoOfAutoFixableSuggestions = () => {
+    const state = this.state.pluginState;
+    if (!state) {
+      return 0;
+    }
+    return selectAllAutoFixableValidations(state).length;
   };
 }
 

--- a/src/ts/components/ValidationSidebarOutput.tsx
+++ b/src/ts/components/ValidationSidebarOutput.tsx
@@ -8,9 +8,9 @@ import SuggestionList from "./SuggestionList";
 interface IProps {
   output: IValidationOutput;
   applySuggestions: (suggestions: ApplySuggestionOptions) => void;
-  selectValidation: (validationId: string) => void;
+  selectValidation: (matchId: string) => void;
   indicateHover: (validationId: string | undefined, _?: any) => void;
-  selectedValidation: string | undefined;
+  selectedMatch: string | undefined;
 }
 
 interface IState {
@@ -26,13 +26,13 @@ class ValidationSidebarOutput extends Component<IProps, IState> {
   };
 
   public render() {
-    const { output, applySuggestions, selectedValidation } = this.props;
+    const { output, applySuggestions, selectedMatch } = this.props;
     const color = `#${output.category.colour}`;
     const hasSuggestions = !!output.suggestions;
     return (
       <div
         className={`ValidationSidebarOutput__container ${
-          selectedValidation === output.validationId
+          selectedMatch === output.matchId
             ? "ValidationSidebarOutput__container--is-selected"
             : ""
         }`}
@@ -75,7 +75,7 @@ class ValidationSidebarOutput extends Component<IProps, IState> {
               <div className="ValidationSidebarOutput__suggestion-list">
                 <SuggestionList
                   applySuggestions={applySuggestions}
-                  validationId={output.validationId}
+                  matchId={output.matchId}
                   suggestions={output.suggestions}
                 />
               </div>
@@ -92,9 +92,9 @@ class ValidationSidebarOutput extends Component<IProps, IState> {
   private scrollToRange = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.selectValidation(this.props.output.validationId);
+    this.props.selectValidation(this.props.output.matchId);
     const decorationElement = document.querySelector(
-      `[${DECORATION_ATTRIBUTE_ID}="${this.props.output.validationId}"]`
+      `[${DECORATION_ATTRIBUTE_ID}="${this.props.output.matchId}"]`
     );
     if (decorationElement) {
       decorationElement.scrollIntoView({
@@ -104,7 +104,7 @@ class ValidationSidebarOutput extends Component<IProps, IState> {
   };
 
   private handleMouseOver = () => {
-    this.props.indicateHover(this.props.output.validationId);
+    this.props.indicateHover(this.props.output.matchId);
   };
 
   private handleMouseLeave = () => {

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -45,6 +45,7 @@ const createView = (
     <ValidationSidebar
       store={store}
       applySuggestions={commands.applySuggestions}
+      applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
       selectValidation={commands.selectValidation}
       indicateHover={commands.indicateHover}
     />,

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -18,6 +18,7 @@ export interface ICategory {
 
 export interface IValidationOutput<TSuggestion = ISuggestion>
   extends IValidationInput {
+  matchId: string;
   validationId: string;
   annotation: string;
   category: ICategory;

--- a/src/ts/interfaces/IValidation.ts
+++ b/src/ts/interfaces/IValidation.ts
@@ -23,6 +23,7 @@ export interface IValidationOutput<TSuggestion = ISuggestion>
   annotation: string;
   category: ICategory;
   suggestions?: TSuggestion[];
+  autoApplyFirstSuggestion?: boolean;
 }
 
 export type ISuggestion = ITextSuggestion | IWikiSuggestion;

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -47,7 +47,8 @@ class TyperighterAdapter implements IValidationAPIAdapter {
         onValidationReceived({
           validationSetId,
           validationId: input.validationId,
-          validationOutputs: validationData.results.map(match => ({
+          validationOutputs: validationData.results.map((match, index) => ({
+            matchId: `${input.validationId}--match-${index}`,
             validationId: input.validationId,
             inputString: input.inputString,
             from: input.from + match.fromPos,

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -55,7 +55,8 @@ class TyperighterAdapter implements IValidationAPIAdapter {
             to: input.from + match.toPos,
             annotation: match.shortMessage,
             category: match.rule.category,
-            suggestions: match.suggestions
+            suggestions: match.suggestions,
+            autoApplyFirstSuggestion: match.rule.autoApplyFirstSuggestion
           }))
         });
       } catch (e) {

--- a/src/ts/services/adapters/TyperighterWsAdapter.ts
+++ b/src/ts/services/adapters/TyperighterWsAdapter.ts
@@ -88,7 +88,8 @@ class TyperighterWsAdapter extends TyperighterAdapter
           return onValidationReceived({
             validationSetId,
             validationId: socketMessage.id,
-            validationOutputs: socketMessage.results.map(match => ({
+            validationOutputs: socketMessage.results.map((match, index) => ({
+              matchId: `${socketMessage.id}--match-${index}`,
               validationId: socketMessage.id,
               inputString: socketMessage.input,
               from: match.fromPos,

--- a/src/ts/services/adapters/interfaces/ITyperighter.ts
+++ b/src/ts/services/adapters/interfaces/ITyperighter.ts
@@ -27,6 +27,8 @@ export interface ITypeRighterRule {
   category: ITypeRighterCategory;
   description: string;
   id: string;
+  suggestions: ISuggestion[];
+  autoApplyFirstSuggestion: boolean;
   issueType: string;
 }
 

--- a/src/ts/state/state.ts
+++ b/src/ts/state/state.ts
@@ -253,7 +253,7 @@ export const selectAllAutoFixableValidations = <
   TValidationMeta extends IValidationOutput
 >(
   state: IPluginState<TValidationMeta>
-): TValidationMeta[] | undefined =>
+): TValidationMeta[] =>
   state.currentValidations.filter(_ => _.autoApplyFirstSuggestion);
 
 export const selectValidationsInFlightForSet = <

--- a/src/ts/state/state.ts
+++ b/src/ts/state/state.ts
@@ -111,22 +111,22 @@ const VALIDATION_PLUGIN_ACTION = "VALIDATION_PLUGIN_ACTION";
  * Action types.
  */
 
-const VALIDATION_REQUEST_FOR_DIRTY_RANGES = "VAlIDATION_REQUEST_START";
-const VALIDATION_REQUEST_FOR_DOCUMENT = "VALIDATION_REQUEST_FOR_DOCUMENT";
-const VALIDATION_REQUEST_SUCCESS = "VALIDATION_REQUEST_SUCCESS";
-const VALIDATION_REQUEST_ERROR = "VALIDATION_REQUEST_ERROR";
-const NEW_HOVER_ID = "NEW_HOVER_ID";
-const SELECT_VALIDATION = "SELECT_VALIDATION";
-const APPLY_NEW_DIRTY_RANGES = "HANDLE_NEW_DIRTY_RANGES";
-const SET_DEBUG_STATE = "SET_DEBUG_STATE";
-const SET_VALIDATE_ON_MODIFY_STATE = "SET_VALIDATE_ON_MODIFY_STATE";
+const VALIDATION_REQUEST_FOR_DIRTY_RANGES = "VAlIDATION_REQUEST_START" as const;
+const VALIDATION_REQUEST_FOR_DOCUMENT = "VALIDATION_REQUEST_FOR_DOCUMENT" as const;
+const VALIDATION_REQUEST_SUCCESS = "VALIDATION_REQUEST_SUCCESS" as const;
+const VALIDATION_REQUEST_ERROR = "VALIDATION_REQUEST_ERROR" as const;
+const NEW_HOVER_ID = "NEW_HOVER_ID" as const;
+const SELECT_VALIDATION = "SELECT_VALIDATION" as const;
+const APPLY_NEW_DIRTY_RANGES = "HANDLE_NEW_DIRTY_RANGES" as const;
+const SET_DEBUG_STATE = "SET_DEBUG_STATE" as const;
+const SET_VALIDATE_ON_MODIFY_STATE = "SET_VALIDATE_ON_MODIFY_STATE" as const;
 
 /**
  * Action creators.
  */
 
 export const validationRequestForDirtyRanges = (validationSetId: string) => ({
-  type: VALIDATION_REQUEST_FOR_DIRTY_RANGES as typeof VALIDATION_REQUEST_FOR_DIRTY_RANGES,
+  type: VALIDATION_REQUEST_FOR_DIRTY_RANGES,
   payload: { validationSetId }
 });
 type ActionValidationRequestForDirtyRanges = ReturnType<
@@ -134,7 +134,7 @@ type ActionValidationRequestForDirtyRanges = ReturnType<
 >;
 
 export const validationRequestForDocument = (validationSetId: string) => ({
-  type: VALIDATION_REQUEST_FOR_DOCUMENT as typeof VALIDATION_REQUEST_FOR_DOCUMENT,
+  type: VALIDATION_REQUEST_FOR_DOCUMENT,
   payload: { validationSetId }
 });
 type ActionValidationRequestForDocument = ReturnType<
@@ -146,7 +146,7 @@ export const validationRequestSuccess = <
 >(
   response: IValidationResponse<TValidationMeta>
 ) => ({
-  type: VALIDATION_REQUEST_SUCCESS as typeof VALIDATION_REQUEST_SUCCESS,
+  type: VALIDATION_REQUEST_SUCCESS,
   payload: { response }
 });
 // tslint:disable-next-line:interface-over-type-literal
@@ -158,7 +158,7 @@ type ActionValidationResponseReceived<
 };
 
 export const validationRequestError = (validationError: IValidationError) => ({
-  type: VALIDATION_REQUEST_ERROR as typeof VALIDATION_REQUEST_ERROR,
+  type: VALIDATION_REQUEST_ERROR,
   payload: { validationError }
 });
 type ActionValidationRequestError = ReturnType<typeof validationRequestError>;
@@ -167,31 +167,31 @@ export const newHoverIdReceived = (
   hoverId: string | undefined,
   hoverInfo?: IStateHoverInfo | undefined
 ) => ({
-  type: NEW_HOVER_ID as typeof NEW_HOVER_ID,
+  type: NEW_HOVER_ID,
   payload: { hoverId, hoverInfo }
 });
 type ActionNewHoverIdReceived = ReturnType<typeof newHoverIdReceived>;
 
 export const applyNewDirtiedRanges = (ranges: IRange[]) => ({
-  type: APPLY_NEW_DIRTY_RANGES as typeof APPLY_NEW_DIRTY_RANGES,
+  type: APPLY_NEW_DIRTY_RANGES,
   payload: { ranges }
 });
 type ActionHandleNewDirtyRanges = ReturnType<typeof applyNewDirtiedRanges>;
 
 export const selectMatch = (matchId: string) => ({
-  type: SELECT_VALIDATION as typeof SELECT_VALIDATION,
+  type: SELECT_VALIDATION,
   payload: { matchId }
 });
 type ActionSelectValidation = ReturnType<typeof selectMatch>;
 
 export const setDebugState = (debug: boolean) => ({
-  type: SET_DEBUG_STATE as typeof SET_DEBUG_STATE,
+  type: SET_DEBUG_STATE,
   payload: { debug }
 });
 type ActionSetDebugState = ReturnType<typeof setDebugState>;
 
 export const setValidateOnModifyState = (validateOnModify: boolean) => ({
-  type: SET_VALIDATE_ON_MODIFY_STATE as typeof SET_VALIDATE_ON_MODIFY_STATE,
+  type: SET_VALIDATE_ON_MODIFY_STATE,
   payload: { validateOnModify }
 });
 type ActionSetValidateOnModifyState = ReturnType<
@@ -246,8 +246,15 @@ export const selectValidationByMatchId = <
 >(
   state: IPluginState<TValidationMeta>,
   matchId: string
-): IValidationOutput | undefined =>
+): TValidationMeta | undefined =>
   state.currentValidations.find(validation => validation.matchId === matchId);
+
+export const selectAllAutoFixableValidations = <
+  TValidationMeta extends IValidationOutput
+>(
+  state: IPluginState<TValidationMeta>
+): TValidationMeta[] | undefined =>
+  state.currentValidations.filter(_ => _.autoApplyFirstSuggestion);
 
 export const selectValidationsInFlightForSet = <
   TValidationMeta extends IValidationOutput

--- a/src/ts/state/test/__snapshots__/state.spec.ts.snap
+++ b/src/ts/state/test/__snapshots__/state.spec.ts.snap
@@ -15,7 +15,7 @@ Object {
   "hoverInfo": undefined,
   "initialThrottle": 100,
   "maxThrottle": 1000,
-  "selectedValidation": undefined,
+  "selectedMatch": undefined,
   "trHistory": Array [
     Transaction {
       "curSelection": undefined,

--- a/src/ts/state/test/state.spec.ts
+++ b/src/ts/state/test/state.spec.ts
@@ -16,7 +16,9 @@ import {
   validationRequestError,
   validationRequestForDirtyRanges,
   validationRequestSuccess,
-  newHoverIdReceived
+  newHoverIdReceived,
+  selectAllAutoFixableValidations,
+  createInitialState
 } from "../state";
 import {
   createDebugDecorationFromRange,
@@ -100,6 +102,39 @@ const getValidationsInFlight = (
     }))
   }
 });
+
+const getExampleValidation = (id: string) =>
+  ({
+    matchId: `match-id-${id}`,
+    validationId: `validation-id-${id}`,
+    annotation: `annotation-${id}`,
+    category: {
+      id: `category-${id}`,
+      name: "Category 1",
+      colour: "puce"
+    },
+    inputString: `inputString-${id}`,
+    suggestions: [],
+    autoApplyFirstSuggestion: true,
+    from: 0,
+    to: 5
+  } as IValidationOutput);
+
+const exampleValidation2: IValidationOutput = {
+  matchId: "match-id-2",
+  validationId: "validation-id-2",
+  annotation: "annotation-2",
+  category: {
+    id: "category-2",
+    name: "Category 1",
+    colour: "puce"
+  },
+  inputString: "inputString-2",
+  suggestions: [],
+  autoApplyFirstSuggestion: true,
+  from: 0,
+  to: 5
+};
 
 describe("State management", () => {
   describe("Action handlers", () => {
@@ -399,17 +434,17 @@ describe("State management", () => {
             createDecorationForValidationRange(output, false, true)
           )
         };
-        expect(
-          reducer(tr, localState, newHoverIdReceived("match-id"))
-        ).toEqual({
-          ...localState,
-          decorations: new DecorationSet().add(
-            tr.doc,
-            createDecorationForValidationRange(output, true, true)
-          ),
-          hoverId: "match-id",
-          hoverInfo: undefined
-        });
+        expect(reducer(tr, localState, newHoverIdReceived("match-id"))).toEqual(
+          {
+            ...localState,
+            decorations: new DecorationSet().add(
+              tr.doc,
+              createDecorationForValidationRange(output, true, true)
+            ),
+            hoverId: "match-id",
+            hoverInfo: undefined
+          }
+        );
       });
       it("should remove hover decorations", () => {
         const { state, tr } = createInitialData();
@@ -565,6 +600,22 @@ describe("State management", () => {
             "3"
           )
         ).toEqual(undefined);
+      });
+    });
+    describe("selectAllAutoFixableValidations", () => {
+      it("should select all auto fixable validations, and ignore others", () => {
+        const validation1 = getExampleValidation("1");
+        const validation2 = getExampleValidation("2");
+        const validation3 = {
+          ...getExampleValidation("3"),
+          autoApplyFirstSuggestion: false
+        };
+        expect(
+          selectAllAutoFixableValidations({
+            ...createInitialData().state,
+            currentValidations: [validation1, validation2, validation3]
+          })
+        ).toEqual([validation1, validation2]);
       });
     });
     describe("selectValidationInFlightById", () => {

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -3,7 +3,7 @@ import {
   IValidationOutput,
   ISuggestion
 } from "../../interfaces/IValidation";
-import { createValidationId } from "../../utils/validation";
+import { createValidationId, createMatchId } from "../../utils/validation";
 
 export const validationLibrary: IValidationLibrary = [
   [
@@ -57,5 +57,6 @@ export const createValidationOutput = (
   annotation: "annotation",
   inputString,
   validationId: createValidationId(0, from, to),
+  matchId: createMatchId(0, from, to, 0),
   suggestions
 });

--- a/src/ts/test/validationAPIService.spec.ts
+++ b/src/ts/test/validationAPIService.spec.ts
@@ -34,6 +34,7 @@ const createOutput = (id: string, inputString: string, offset: number = 0) => {
   const to = offset + inputString.length;
   return {
     validationId: id,
+    matchId: "0-from:0-to:10--match-0",
     from,
     to,
     inputString,
@@ -75,7 +76,10 @@ describe("ValidationAPIService", () => {
     const service = new ValidationAPIService(
       store,
       commands as any,
-      new TyperighterAdapter("http://endpoint/check", "http://endpoint/categories")
+      new TyperighterAdapter(
+        "http://endpoint/check",
+        "http://endpoint/categories"
+      )
     );
     fetchMock.post("http://endpoint/check", createResponse(["1234567890"]));
 
@@ -103,7 +107,10 @@ describe("ValidationAPIService", () => {
     const service = new ValidationAPIService(
       store,
       commands as any,
-      new TyperighterAdapter("http://endpoint/check", "http://endpoint/categories")
+      new TyperighterAdapter(
+        "http://endpoint/check",
+        "http://endpoint/categories"
+      )
     );
     fetchMock.post("http://endpoint/check", 400);
 

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -109,9 +109,10 @@ export const createDecorationForValidationRange = (
         DecorationClassMap[DECORATION_VALIDATION_IS_SELECTED]
       }`
     : DecorationClassMap[DECORATION_VALIDATION];
+  const opacity = isSelected ? "30" : "07";
   const style = `background-color: #${
     output.category.colour
-  }07; border-bottom: 2px solid #${output.category.colour}`;
+  }${opacity}; border-bottom: 2px solid #${output.category.colour}`;
 
   const decorationArray = [
     Decoration.inline(

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -5,7 +5,7 @@ import { IRange, IValidationOutput } from "../interfaces/IValidation";
 
 // Our decoration types.
 export const DECORATION_VALIDATION = "DECORATION_VALIDATION";
-export const DECORATION_VALIDATION_IS_HOVERING =
+export const DECORATION_VALIDATION_IS_SELECTED =
   "DECORATION_VALIDATION_IS_HOVERING";
 export const DECORATION_VALIDATION_HEIGHT_MARKER =
   "DECORATION_VALIDATION_HEIGHT_MARKER";
@@ -17,7 +17,7 @@ export const DecorationClassMap = {
   [DECORATION_INFLIGHT]: "ValidationDebugInflight",
   [DECORATION_VALIDATION]: "ValidationDecoration",
   [DECORATION_VALIDATION_HEIGHT_MARKER]: "ValidationDecoration__height-marker",
-  [DECORATION_VALIDATION_IS_HOVERING]: "ValidationDecoration--is-hovering"
+  [DECORATION_VALIDATION_IS_SELECTED]: "ValidationDecoration--is-selected"
 };
 
 export const DECORATION_ATTRIBUTE_ID = "data-validation-id";
@@ -101,17 +101,18 @@ const createHeightMarkerElement = (id: string) => {
  */
 export const createDecorationForValidationRange = (
   output: IValidationOutput,
-  isHovering = false,
+  isSelected = false,
   addHeightMarker = true
 ) => {
-  const className = isHovering
+  const className = isSelected
     ? `${DecorationClassMap[DECORATION_VALIDATION]} ${
-        DecorationClassMap[DECORATION_VALIDATION_IS_HOVERING]
+        DecorationClassMap[DECORATION_VALIDATION_IS_SELECTED]
       }`
     : DecorationClassMap[DECORATION_VALIDATION];
   const style = `background-color: #${
     output.category.colour
   }07; border-bottom: 2px solid #${output.category.colour}`;
+
   const decorationArray = [
     Decoration.inline(
       output.from,
@@ -119,22 +120,27 @@ export const createDecorationForValidationRange = (
       {
         class: className,
         style,
-        [DECORATION_ATTRIBUTE_ID]: output.validationId
+        [DECORATION_ATTRIBUTE_ID]: output.matchId
       } as any,
       {
         type: DECORATION_VALIDATION,
-        id: output.validationId,
+        id: output.matchId,
         inclusiveStart: true
       } as any
     )
   ];
+
   return addHeightMarker
     ? [
         ...decorationArray,
-        Decoration.widget(output.from, createHeightMarkerElement(output.validationId), {
-          type: DECORATION_VALIDATION_HEIGHT_MARKER,
-          id: output.validationId
-        } as any)
+        Decoration.widget(
+          output.from,
+          createHeightMarkerElement(output.matchId),
+          {
+            type: DECORATION_VALIDATION_HEIGHT_MARKER,
+            id: output.matchId
+          } as any
+        )
       ]
     : decorationArray;
 };

--- a/src/ts/utils/validation.ts
+++ b/src/ts/utils/validation.ts
@@ -12,3 +12,10 @@ export const createValidationInput = (tr: Transaction, range: IRange) => {
 
 export const createValidationId = (time: number, from: number, to: number) =>
   `${time}-from:${from}-to:${to}`;
+
+export const createMatchId = (
+  time: number,
+  from: number,
+  to: number,
+  index: number = 0
+) => `${createValidationId(time, from, to)}--match-${index}`;


### PR DESCRIPTION
Allow users to batch-apply suggestions if `autoApplyFirstSuggestion` is set on incoming rules.

![autocorrect](https://user-images.githubusercontent.com/7767575/68531353-26df9f80-0309-11ea-91d5-22136c6aac17.gif)

Currently, there's no confirm step, but it's likely we'll want make the changes about to be applied clear to the user, and ask them to confirm, as although the normal rules for undo/redo apply, this  operation changes things the author isn't guaranteed to see.

There's also a minor refactor to user defined settings for an upcoming PR, as it's likely we'll want to toggle the availability of this feature.