### PR TITLE
Correct tooltip positioning for decorations that break across lines

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -158,9 +158,17 @@ hr {
   margin-top: 3px;
 }
 
-.MatchDecoration,
-.MatchDecoration__height-marker {
+.MatchDecoration {
   border-bottom: 2px solid $match-color;
+}
+
+.MatchDecoration__height-marker {
+  &:before {
+    // We insert a unicode zero width space character here to ensure the
+    // height marker has content. As a result, it grows to match the line-height.
+    // See https://stackoverflow.com/questions/14217902/how-to-set-empty-span-height-equal-to-default-line-height
+    content: "\200b";
+  }
 }
 
 .MatchDecoration--is-correct {
@@ -196,5 +204,4 @@ hr {
 }
 
 .TyperighterPlugin__container {
-  position: relative;
 }

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -123,12 +123,12 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
 
           // Get our height marker, which tells us the height of a single line
           // for the given match.
-          const heightMarker = document.querySelector(
-            `[${DECORATION_ATTRIBUTE_HEIGHT_MARKER_ID}="${newMatchId}"]`
+          const matchDecoration = document.querySelector(
+            `[${DECORATION_ATTRIBUTE_ID}="${newMatchId}"]`
           );
           if (
             newMatchId &&
-            (!heightMarker || !(heightMarker instanceof HTMLElement))
+            (!matchDecoration || !(matchDecoration instanceof HTMLElement))
           ) {
             // tslint:disable-next-line no-console
             console.warn(
@@ -143,7 +143,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
               // We're very sure that this is a mouseevent, but Typescript isn't.
               event as MouseEvent,
               view.dom,
-              heightMarker
+              matchDecoration
             )
           )(view.state, view.dispatch);
 

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -72,13 +72,13 @@ export interface IStateHoverInfo {
   // The height of the element.
   height: number;
   // The x coordinate of the mouse position relative to the element
-  mouseOffsetX: number;
+  mouseClientX: number;
   // The y coordinate of the mouse position relative to the element
-  mouseOffsetY: number;
+  mouseClientY: number;
   // The height the element would have if it occupied a single line.
   // Useful when determining where to put a tooltip if the user
   // is hovering over a span that covers several lines.
-  heightOfSingleLine: number;
+  markerClientRects: DOMRectList | ClientRectList;
 }
 
 export interface IBlockInFlight {

--- a/src/ts/utils/dom.ts
+++ b/src/ts/utils/dom.ts
@@ -1,4 +1,4 @@
-import { IStateHoverInfo } from "../state/actions";
+import { IStateHoverInfo } from "../state/reducer";
 
 /**
  * Find the first ancestor node of the given node that matches the selector.
@@ -45,8 +45,8 @@ export function getStateHoverInfoFromEvent(
     left: containerLeft,
     top: containerTop
   } = containerElement.getBoundingClientRect();
-  const mouseOffsetX = event.clientX - elementLeft;
-  const mouseOffsetY = event.clientY - elementTop;
+  const mouseOffsetX = event.clientX;
+  const mouseOffsetY = event.clientY;
   const { offsetLeft, offsetTop, offsetHeight: height } = event.target;
   return {
     left: elementLeft - containerLeft,
@@ -54,8 +54,8 @@ export function getStateHoverInfoFromEvent(
     offsetLeft,
     offsetTop,
     height,
-    mouseOffsetX,
-    mouseOffsetY,
-    heightOfSingleLine: heightMarkerElement.offsetHeight
+    mouseClientX: mouseOffsetX,
+    mouseClientY: mouseOffsetY,
+    markerClientRects: event.target.getClientRects()
   };
 }


### PR DESCRIPTION
This PR corrects tooltip positioning for decorations that break across lines. To solve this problem, we use `getClientRects()`, which returns the bounding boxes for each part of the decoration.

![tr-tooltips](https://user-images.githubusercontent.com/7767575/69875231-a0d5c980-12b4-11ea-8824-4f4c07f97def.gif)
