### PR TITLE
Add devtools to pages html

### DIFF
--- a/pages/dist/index.html
+++ b/pages/dist/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Document</title>
     <link rel="stylesheet" href="./styles.css" />
+    <script src="https://unpkg.com/prosemirror-dev-tools@1.4.0/dist/umd/prosemirror-dev-tools.min.js"></script>
     <style>
 
       body {


### PR DESCRIPTION
Adds the lovely [prosemirror-dev-tools](https://github.com/d4rkr00t/prosemirror-dev-tools) to the gh-pages index page.