### PR TITLE
Add matched text to the Matcher models, and display it in the sidebar matches.

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -56,7 +56,7 @@ if (editorElement && sidebarElement && controlsElement) {
   const validationService = new MatcherService(
     store,
     commands,
-    new TyperighterWsAdapter("http://localhost:9000")
+    new TyperighterAdapter("http://localhost:9000")
   );
   createView(
     view,

--- a/src/css/SidebarMatch.scss
+++ b/src/css/SidebarMatch.scss
@@ -1,5 +1,8 @@
 .SidebarMatch__container {
   padding: ($gutter-width / 2) ;
+  &:hover {
+    background-color: #f6f6f6;
+  }
 }
 
 .SidebarMatch__list-item:last-child {
@@ -15,6 +18,15 @@
 .SidebarMatch__header-label {
   display: flex;
   width: 100%;
+}
+
+.SidebarMatch__header-match-text {
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.SidebarMatch__header-description {
+  font-size: 14px;
 }
 
 .SidebarMatch__header-meta {

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -8,12 +8,10 @@ interface IMatchProps<TMatch extends IMatch> {
   match: TMatch;
 }
 
-class Match<TMatch extends IMatch> extends Component<
-  IMatchProps<TMatch>
-> {
-  public ref: HTMLDivElement | undefined;
+class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
+  public ref: HTMLDivElement | null = null;
   public render({
-    match: { matchId, category, annotation, suggestions },
+    match: { matchId, category, message, suggestions },
     applySuggestions
   }: IMatchProps<TMatch>) {
     return (
@@ -25,7 +23,7 @@ class Match<TMatch extends IMatch> extends Component<
           >
             {category.name}
           </div>
-          <div className="MatchWidget__annotation">{annotation}</div>
+          <div className="MatchWidget__annotation">{message}</div>
           {suggestions && applySuggestions && (
             <div className="MatchWidget__suggestion-list">
               <SuggestionList

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -51,7 +51,8 @@ class SidebarMatch extends Component<IProps, IState> {
         >
           <div className="SidebarMatch__header-label">
             <div className="SidebarMatch__header-description">
-              {output.annotation}
+              <strong>{output.matchedText}</strong>&nbsp;
+              {output.message}
             </div>
             <div className="SidebarMatch__header-meta">
               <div

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -44,28 +44,24 @@ class SidebarMatch extends Component<IProps, IState> {
         style={{ borderLeft: `2px solid ${color}` }}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
+        onClick={this.scrollToRange}
+        title="Click to scroll to this match"
       >
         <div
           className={"SidebarMatch__header"}
           onClick={hasSuggestions ? this.toggleOpen : undefined}
         >
           <div className="SidebarMatch__header-label">
-            <div className="SidebarMatch__header-description">
-              <strong>{output.matchedText}</strong>&nbsp;
-              {output.message}
+            <div>
+              <div className="SidebarMatch__header-match-text">
+                {output.matchedText}
+              </div>
+              <div className="SidebarMatch__header-description">
+                {output.message}
+              </div>
             </div>
             <div className="SidebarMatch__header-meta">
-              <div
-                className="SidebarMatch__header-range"
-                onClick={this.scrollToRange}
-              >
-                <span className="Button">{output.from}-{output.to}</span>
-                
-              </div>
-              <div
-                className="SidebarMatch__header-category"
-                style={{ color }}
-              >
+              <div className="SidebarMatch__header-category" style={{ color }}>
                 {titleCase(output.category.name)}
               </div>
               {hasSuggestions && (

--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -38,12 +38,12 @@ export interface IMatchRequestError {
   message: string;
 }
 
-
 export interface IMatch<TSuggestion = ISuggestion> {
   matchId: string;
   from: number;
   to: number;
-  annotation: string;
+  matchedText: string;
+  message: string;
   category: ICategory;
   suggestions?: TSuggestion[];
   replacement?: TSuggestion;
@@ -55,9 +55,7 @@ export interface IBlockResult {
   id: string;
 }
 
-export interface IMatcherResponse<
-  TBlockMatch extends IMatch = IMatch
-> {
+export interface IMatcherResponse<TBlockMatch extends IMatch = IMatch> {
   blocks: IBlock[];
   categoryIds: string[];
   matches: TBlockMatch[];
@@ -73,9 +71,3 @@ export type IMatchLibrary = Array<
   }>
 >;
 
-export const Operations: {
-  [key: string]: "ANNOTATE" | "REPLACE";
-} = {
-  ANNOTATE: "ANNOTATE",
-  REPLACE: "REPLACE"
-};

--- a/src/ts/services/adapters/RegexAdapter.ts
+++ b/src/ts/services/adapters/RegexAdapter.ts
@@ -22,7 +22,7 @@ const regexAdapter = async (
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
       text: result[0],
-      annotation:
+      message:
         "This word has three letters. Consider a larger, grander word.",
       id: v4(),
       category: {
@@ -44,7 +44,7 @@ const regexAdapter = async (
       from: input.from + result.index,
       to: input.from + result.index + result[0].length,
       text: result[0],
-      annotation:
+      message:
         "This word has six letters. Consider a smaller, less fancy word.",
       id: input.id,
       category: {

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -22,7 +22,8 @@ export const convertTyperighterResponse = (
     matchId: v4(),
     from: match.fromPos,
     to: match.toPos,
-    annotation: match.shortMessage,
+    matchedText: match.matchedText,
+    message: match.shortMessage,
     category: match.rule.category,
     suggestions: match.suggestions,
     replacement: match.rule.replacement,
@@ -43,8 +44,7 @@ class TyperighterAdapter implements IMatcherAdapter {
     inputs: IBlock[],
     categoryIds: string[],
     onMatchesReceived: TMatchesReceivedCallback,
-    onRequestError: TRequestErrorCallback,
-    onRequestComplete: TRequestCompleteCallback
+    onRequestError: TRequestErrorCallback
   ) => {
     inputs.map(async input => {
       const body = {

--- a/src/ts/services/adapters/interfaces/ITyperighter.ts
+++ b/src/ts/services/adapters/interfaces/ITyperighter.ts
@@ -17,6 +17,7 @@ export interface ITypeRighterBlockResponse {
 export interface ITypeRighterMatch {
   fromPos: number;
   toPos: number;
+  matchedText: string;
   message: string;
   shortMessage: string;
   rule: ITypeRighterRule;

--- a/src/ts/services/test/MatcherService.spec.ts
+++ b/src/ts/services/test/MatcherService.spec.ts
@@ -22,6 +22,7 @@ const createResponse = (strs: string[]): ITypeRighterResponse => ({
     fromPos: 0,
     toPos: str.length,
     id: createBlockId(0, 0, 5),
+    matchedText: str,
     message: "It's just a bunch of numbers, mate",
     shortMessage: "It's just a bunch of numbers, mate",
     rule: {

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -120,5 +120,5 @@ export const selectAllAutoFixableMatches = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
 ): TMatch[] =>
   state.currentMatches.filter(
-    _ => _.replacement && _.replacement.text === _.annotation
+    _ => _.replacement && _.replacement.text === _.message
   );

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -134,7 +134,10 @@ describe("Action handlers", () => {
         {
           ...state,
           debug: true,
-          dirtiedRanges: [{ from: 5, to: 10 }, { from: 28, to: 35 }],
+          dirtiedRanges: [
+            { from: 5, to: 10 },
+            { from: 28, to: 35 }
+          ],
           decorations: new DecorationSet(),
           requestPending: true
         },
@@ -432,7 +435,8 @@ describe("Action handlers", () => {
         matchId: "match-id",
         from: 0,
         to: 5,
-        annotation: "Annotation",
+        matchedText: "block text",
+        message: "Annotation",
         category: {
           id: "1",
           name: "cat",
@@ -463,7 +467,8 @@ describe("Action handlers", () => {
         matchId: "match-id",
         from: 0,
         to: 5,
-        annotation: "Annotation",
+        matchedText: "block text",
+        message: "Annotation",
         category: {
           id: "1",
           name: "cat",
@@ -499,7 +504,8 @@ describe("Action handlers", () => {
           matchId: "match-id",
           from: 1,
           to: 7,
-          annotation: "Annotation",
+          matchedText: "block text",
+          message: "Annotation",
           category: {
             id: "1",
             name: "cat",
@@ -541,7 +547,8 @@ describe("Action handlers", () => {
             text: "example",
             from: 1,
             to: 1,
-            annotation: "example",
+            matchedText: "block text",
+            message: "example",
             suggestions: [],
             category: {
               id: "1",

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -76,7 +76,8 @@ export const createMatcherResponse = (
   matches: [
     {
       category,
-      annotation: "annotation",
+      matchedText: "block text",
+      message: "annotation",
       from: wordFrom,
       to: wordTo,
       matchId: createMatchId(0, wordFrom, wordTo, 0),
@@ -96,7 +97,8 @@ export const createMatch = (
   }
 ): IMatch => ({
   category,
-  annotation: "annotation",
+  matchedText: "block text",
+  message: "annotation",
   from,
   to,
   matchId: createMatchId(0, from, to, 0),


### PR DESCRIPTION
This PR adds matched text to the Matcher models, and display it in the sidebar matches, as so:

<img width="397" alt="Screenshot 2019-12-09 at 17 22 33" src="https://user-images.githubusercontent.com/7767575/70457703-849e0d80-1aa8-11ea-9ecd-8ecd7b69dca9.png">

In future, we can imagine displaying a diff or 'old -> new' or similar.
