### PR TITLE
Restore suggestion behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/prosemirror-typerighter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/prosemirror-typerighter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A plugin to represent validation ranges in Prosemirror",
   "main": "dist/index.js",
   "module": "dist/index.m.js",

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -79,14 +79,30 @@ export const requestMatchesForDirtyRangesCommand = (
  * over a match decoration) to allow the positioning of e.g. tooltips.
  */
 export const indicateHoverCommand = (
-  matchId: string | undefined,
-  hoverInfo: IStateHoverInfo | undefined
+  matchId: string,
+  hoverInfo?: IStateHoverInfo
 ): Command => (state, dispatch) => {
   if (dispatch) {
     dispatch(
       state.tr.setMeta(
         PROSEMIRROR_TYPERIGHTER_ACTION,
         newHoverIdReceived(matchId, hoverInfo)
+      )
+    );
+  }
+  return true;
+};
+
+/**
+ * Indicate that the user is no longer hovering over a
+ * prosemirror-typerighter tooltip.
+ */
+export const stopHoverCommand = (): Command => (state, dispatch) => {
+  if (dispatch) {
+    dispatch(
+      state.tr.setMeta(
+        PROSEMIRROR_TYPERIGHTER_ACTION,
+        newHoverIdReceived(undefined, undefined)
       )
     );
   }
@@ -301,6 +317,7 @@ export const createBoundCommands = <TMatch extends IMatch>(
       requestMatchesForDirtyRangesCommand
     ),
     indicateHover: bindCommand(indicateHoverCommand),
+    stopHover: bindCommand(stopHoverCommand),
     setDebugState: bindCommand(setDebugStateCommand),
     setRequestOnDocModified: bindCommand(setRequestOnDocModifiedState),
     applyMatcherResponse: bindCommand(applyMatcherResponseCommand),

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -78,9 +78,7 @@ class Controls extends Component<IProps, IState> {
                     checked={requestMatchesOnDocModified}
                     className="Input"
                     onClick={() =>
-                      setRequestOnDocModified(
-                        !requestMatchesOnDocModified
-                      )
+                      setRequestOnDocModified(!requestMatchesOnDocModified)
                     }
                   />
                 </div>

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -11,9 +11,10 @@ interface IMatchProps<TMatch extends IMatch> {
 class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
   public ref: HTMLDivElement | null = null;
   public render({
-    match: { matchId, category, message, suggestions },
+    match: { matchId, category, message, suggestions, replacement },
     applySuggestions
   }: IMatchProps<TMatch>) {
+    const suggestionsToRender = replacement ? [replacement] : suggestions || [];
     return (
       <div className="MatchWidget__container">
         <div className="MatchWidget" ref={_ => (this.ref = _)}>
@@ -29,7 +30,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
               <SuggestionList
                 applySuggestions={applySuggestions}
                 matchId={matchId}
-                suggestions={suggestions}
+                suggestions={suggestionsToRender}
               />
             </div>
           )}

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -13,7 +13,8 @@ interface IProps {
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   applyAutoFixableSuggestions: () => void;
   selectMatch: (matchId: string) => void;
-  indicateHover: (matchId: string | undefined, _: any) => void;
+  indicateHover: (matchId: string, _?: any) => void;
+  stopHover: () => void;
   contactHref: string;
 }
 
@@ -38,6 +39,7 @@ class Sidebar extends Component<
       applyAutoFixableSuggestions,
       selectMatch,
       indicateHover,
+      stopHover,
       contactHref
     } = this.props;
     const { currentMatches = [], requestsInFlight, selectedMatch } = this.state
@@ -90,6 +92,7 @@ class Sidebar extends Component<
                     applySuggestions={applySuggestions}
                     selectMatch={selectMatch}
                     indicateHover={indicateHover}
+                    stopHover={stopHover}
                   />
                 </li>
               ))}

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -10,7 +10,8 @@ interface IProps {
   output: IMatch;
   applySuggestions: (suggestions: ApplySuggestionOptions) => void;
   selectMatch: (matchId: string) => void;
-  indicateHover: (blockId: string | undefined, _?: any) => void;
+  indicateHover: (blockId: string, _?: any) => void;
+  stopHover: ()  =>  void;
   selectedMatch: string | undefined;
 }
 
@@ -111,7 +112,7 @@ class SidebarMatch extends Component<IProps, IState> {
   };
 
   private handleMouseLeave = () => {
-    this.props.indicateHover(undefined);
+    this.props.stopHover();
   };
 }
 

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -79,24 +79,23 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
 
       const tr = newState.tr;
 
-      if (newPluginState.requestMatchesOnDocModified) {
-        const newDirtiedRanges = trs.reduce(
-          (acc, range) =>
-            acc.concat(getReplaceStepRangesFromTransaction(range)),
-          [] as IRange[]
-        );
-        if (newDirtiedRanges.length) {
+      const newDirtiedRanges = trs.reduce(
+        (acc, range) => acc.concat(getReplaceStepRangesFromTransaction(range)),
+        [] as IRange[]
+      );
+      if (newDirtiedRanges.length) {
+        if (newPluginState.requestMatchesOnDocModified) {
           // We wait a tick here, as applyNewDirtiedRanges must run
           // before the newly dirtied range is available in the state.
           // @todo -- this is a bit of a hack, it can be done better.
           setTimeout(() => store.emit(STORE_EVENT_NEW_DIRTIED_RANGES));
-
-          return tr.setMeta(
-            PROSEMIRROR_TYPERIGHTER_ACTION,
-            applyNewDirtiedRanges(newDirtiedRanges)
-          );
         }
+        return tr.setMeta(
+          PROSEMIRROR_TYPERIGHTER_ACTION,
+          applyNewDirtiedRanges(newDirtiedRanges)
+        );
       }
+
       const blockStates = selectNewBlockInFlight(
         oldPluginState,
         newPluginState

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -17,7 +17,7 @@ import Store, {
   STORE_EVENT_NEW_MATCHES,
   STORE_EVENT_NEW_DIRTIED_RANGES
 } from "./state/store";
-import { indicateHoverCommand } from "./commands";
+import { indicateHoverCommand, stopHoverCommand } from "./commands";
 
 /**
  * @module createTyperighterPlugin
@@ -37,7 +37,7 @@ interface IPluginOptions<TMatch extends IMatch> {
   /**
    * The initial set of matches to apply to the document, if any.
    */
-  matches?: TMatch[]
+  matches?: TMatch[];
 }
 
 /**
@@ -141,15 +141,21 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
             return false;
           }
 
-          indicateHoverCommand(
-            newMatchId,
-            getStateHoverInfoFromEvent(
-              // We're very sure that this is a mouseevent, but Typescript isn't.
-              event as MouseEvent,
-              view.dom,
-              matchDecoration
-            )
-          )(view.state, view.dispatch);
+          const hoverInfo = getStateHoverInfoFromEvent(
+            // We're very sure that this is a mouseevent, but Typescript isn't.
+            event as MouseEvent,
+            view.dom,
+            matchDecoration
+          );
+
+          if (newMatchId && hoverInfo) {
+            indicateHoverCommand(newMatchId, hoverInfo)(
+              view.state,
+              view.dispatch
+            );
+          } else {
+            stopHoverCommand()(view.state, view.dispatch);
+          }
 
           return false;
         }

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -36,7 +36,10 @@ const createView = (
   render(
     <MatchOverlay
       store={store}
-      applySuggestions={commands.applySuggestions}
+      applySuggestions={(suggestionOpts) => {
+        commands.applySuggestions(suggestionOpts)
+        commands.stopHover();
+      }}
       containerElement={wrapperElement}
     />,
     overlayNode

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -49,6 +49,7 @@ const createView = (
       applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
       selectMatch={commands.selectMatch}
       indicateHover={commands.indicateHover}
+      stopHover={commands.stopHover}
       contactHref={contactHref}
     />,
     sidebarNode


### PR DESCRIPTION
_Co-authored-by: @SHession, @tjsilver_ 

## What does this change?

Suggestions were removed in #64. This PR adds them back, and improves UI behaviour –
- When suggestions are applied, the tooltip they came from is closed.
- When the document is changed, matches touched by those changes are removed.

![suggestion-towne](https://user-images.githubusercontent.com/7767575/88382955-71bf1b80-cda1-11ea-8330-5a6496cad00b.gif)

## How to test

Launch the plugin and check the behaviours listed above occur for matches that have suggestions.

Examples from the current Guardian sheet include 'lowlives', which gives a single suggestion.

## How can we measure success?

The behaviour above should be reflected in the UI.
