### PR TITLE
Make this plugin compatible with the Guardian's pan-domain authentication

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "guardian/devtools/dev-nginx"

--- a/build/README.md
+++ b/build/README.md
@@ -9,7 +9,9 @@ Install dependencies with `./scripts/setup.sh`.
 
 ## Development
 
-`npm run watch` builds the project locally, watches for file changes, and serves the project locally at https://typerighter-client.local.dev-gutools.co.uk/ – or http://localhost:5000, if your Typerighter service doesn't require pan-domain authentication.
+`npm run watch` builds the project locally, watches for file changes, and serves the project locally at https://typerighter-client.local.dev-gutools.co.uk/ – or http://localhost:5000, if your Typerighter service doesn't require [pan-domain authentication](https://github.com/guardian/pan-domain-authentication).
+
+If your Typerighter service does require pan-domain authentication, you will need to run and visit another .local.dev-gutools application alongside this service to supply an authenticated cookie for that domain.
 
 The plugin must be pointed to the address of a running Typerighter service to submit a document and receive matches. To modify this address, change the address passed to the `TyperighterAdapter` in `pages/index.ts`.
 

--- a/build/README.md
+++ b/build/README.md
@@ -5,13 +5,17 @@ It's still in its early stages! [There's a demo here.](https://guardian.github.i
 
 ## Installation
 
-`npm i` will install dependencies.
+Install dependencies with `./scripts/setup.sh`.
 
 ## Development
 
-`npm run watch` builds the project locally, watches for file changes, and serves the project locally at http://localhost:5000.
+`npm run watch` builds the project locally, watches for file changes, and serves the project locally at https://typerighter-client.local.dev-gutools.co.uk/ – or http://localhost:5000, if your Typerighter service doesn't require pan-domain authentication.
 
-The plugin must be pointed to the address of a running Typerighter service to submit a document and receive matches. To modify, change the address passed to the `TyperighterAdapter` in `pages/index.ts`.
+The plugin must be pointed to the address of a running Typerighter service to submit a document and receive matches. To modify this address, change the address passed to the `TyperighterAdapter` in `pages/index.ts`.
+
+To test this plugin in applications that use it before publishing a release, use [`npm link`](https://docs.npmjs.com/cli/link) –
+- Run `npm link` in the root of this project
+- Run `npm link @guardian/prosemirror-typerighter` in the root of the project that's consuming this package.
 
 ## Publishing new versions
 

--- a/nginx/nginx-mapping.yaml
+++ b/nginx/nginx-mapping.yaml
@@ -1,0 +1,5 @@
+name: typerighter-client
+mappings:
+  - prefix: typerighter-client
+    port: 5000
+    path: /

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -55,7 +55,7 @@ if (editorElement && sidebarElement && controlsElement) {
   const validationService = new MatcherService(
     store,
     commands,
-    new TyperighterAdapter("http://localhost:9000")
+    new TyperighterAdapter("https://api.typerighter.local.dev-gutools.co.uk")
   );
   createView(
     view,

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,23 @@
+installBrewfile() {
+  echo -e "\033[32mInstalling requirements from Brewfile\033[0m\n"
+  brew bundle
+}
+
+setupNginx() {
+  echo -e "\033[32mInstalling homebrew dependencies\033[0m\n"
+  dev-nginx setup-app ${DIR}/nginx/nginx-mapping.yml
+}
+
+installNpm() {
+  echo -e "\033[32mInstalling JS dependencies\033[0m\n"
+  npm install
+}
+
+main() {
+  installBrewfile
+  setupNginx
+  installNpm
+  echo -e "\033[32mInstallation complete.\033[0m\n"
+}
+
+main

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -56,6 +56,7 @@ class TyperighterAdapter implements IMatcherAdapter {
       try {
         const response = await fetch(`${this.url}/check`, {
           method: "POST",
+          credentials: 'include',
           headers: new Headers({
             "Content-Type": "application/json"
           }),
@@ -80,6 +81,7 @@ class TyperighterAdapter implements IMatcherAdapter {
   };
   public fetchCategories = async () => {
     const response = await fetch(`${this.url}/categories`, {
+      credentials: 'include',
       headers: new Headers({
         "Content-Type": "application/json"
       })


### PR DESCRIPTION
## What does this change?

At the moment, this plugin makes `fetch` requests that only include `same-origin` cookies (the default for fetch). This is insufficient when pan-domain authentication is added to a Typerighter service – we'll need to use the `include` setting to send pan-domain cookies for authentication.

This also complicates local development, in that once auth is added, sending requests from a localhost address will fail. We'll need to send requests from a dev-gutools.co.uk address, a problem that's solved by at the Guardian by using [dev-nginx](https://github.com/guardian/dev-nginx) to create the relevant address and map it to a local server.

This PR adds cookies to the API fetch requests, an nginx mapping file, and a setup script to install dev-nginx, run it, and install JS deps in one step.

It also updates the readme to detail these steps.

One caveat – once Typerighter requires pan-domain auth, you'll need to use another local service to get authenticated cookies at present. This repository – or the Typerighter service – doesn't provide a mechanism to get them yet.

Until Typerighter does require pan-domain auth, local development should work as normal.

## How to test

Install the dependencies, and run the app locally. It should perform as expected against a Typerighter service, without or with [pan-domain authentication](https://github.com/guardian/typerighter/pull/21).

## How can we measure success?

The test steps above should work as expected.

## Have we considered potential risks?

The addition of authentication that's closely linked to the way the Guardian digital department maintains software pushes the Typerighter project further away from being easily usable by the broader community.

Although this is a necessary step in the short term, we should consider other means of achieving this goal, for example by providing a generic oAuth2 service and authenticating at the [ALB level](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) in the Typerighter project.
