### PR TITLE
Add feedback link

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -158,6 +158,11 @@ hr {
   margin-top: 3px;
 }
 
+.MatchWidget__feedbackLink {
+  text-align: right;
+  font-size: 12px;
+}
+
 .MatchDecoration {
   border-bottom: 2px solid $match-color;
 }

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -41,7 +41,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
             <div className="MatchWidget__feedbackLink">
               <a
                 target="_blank"
-                href={this.getFeedbackLink(feedbackInfo)}
+                href={this.getFeedbackLink(this.props.feedbackHref!, feedbackInfo)}
               >
                 Something's not right? Tell us!
               </a>
@@ -52,9 +52,9 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
     );
   }
 
-  private getFeedbackLink = (feedbackInfo: any) => {
+  private getFeedbackLink = (feedbackHref: string, feedbackInfo: any) => {
     const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2))
-    return this.props.feedbackHref! + data
+    return feedbackHref + data
   }
 
 }

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -8,6 +8,11 @@ interface IMatchProps<TMatch extends IMatch> {
   match: TMatch;
 }
 
+const getFeedbackLink = (feedbackInfo: any) => {
+  const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2))
+  return "https://docs.google.com/forms/d/e/1FAIpQLSfMOgvJtCchnW0_2zB7Afz_WtYJ5lnPqQI-dgFZ-p0B4h6uKw/viewform?usp=pp_url&entry.110962249=" + data
+}
+
 class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
   public ref: HTMLDivElement | null = null;
   public render({
@@ -15,6 +20,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
     applySuggestions
   }: IMatchProps<TMatch>) {
     const suggestionsToRender = replacement ? [replacement] : suggestions || [];
+    const feedbackInfo = { matchId, category, message, suggestions, replacement };
     return (
       <div className="MatchWidget__container">
         <div className="MatchWidget" ref={_ => (this.ref = _)}>
@@ -32,6 +38,14 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
                 matchId={matchId}
                 suggestions={suggestionsToRender}
               />
+              <div className="MatchWidget__feedbackLink">
+                <a 
+                  target="_blank"
+                  href={getFeedbackLink(feedbackInfo)}
+                >
+                  Something's not right? Tell us!
+                </a>
+              </div>
             </div>
           )}
         </div>

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -6,6 +6,7 @@ import SuggestionList from "./SuggestionList";
 interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
   match: TMatch;
+  feedbackHref?: string;
 }
 
 class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
@@ -36,14 +37,16 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
               />
             </div>
           )}
-          <div className="MatchWidget__feedbackLink">
-            <a
-              target="_blank"
-              href={this.getFeedbackLink(feedbackInfo)}
-            >
-              Something's not right? Tell us!
-            </a>
+          {this.props.feedbackHref && (
+            <div className="MatchWidget__feedbackLink">
+              <a
+                target="_blank"
+                href={this.getFeedbackLink(feedbackInfo)}
+              >
+                Something's not right? Tell us!
+              </a>
             </div>
+          )}
         </div>
       </div>
     );
@@ -51,10 +54,9 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
 
   private getFeedbackLink = (feedbackInfo: any) => {
     const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2))
-    return "https://docs.google.com/forms/d/e/1FAIpQLSfMOgvJtCchnW0_2zB7Afz_WtYJ5lnPqQI-dgFZ-p0B4h6uKw/viewform?usp=pp_url&entry.110962249=" + data
+    return this.props.feedbackHref! + data
   }
 
 }
-
 
 export default Match;

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -15,7 +15,8 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
     applySuggestions
   }: IMatchProps<TMatch>) {
     const suggestionsToRender = replacement ? [replacement] : suggestions || [];
-    const feedbackInfo = { matchId, category, message, suggestions, replacement };
+    const url = document.URL;
+    const feedbackInfo = { matchId, category, message, suggestions, replacement, url };
     return (
       <div className="MatchWidget__container">
         <div className="MatchWidget" ref={_ => (this.ref = _)}>
@@ -52,7 +53,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
     const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2))
     return "https://docs.google.com/forms/d/e/1FAIpQLSfMOgvJtCchnW0_2zB7Afz_WtYJ5lnPqQI-dgFZ-p0B4h6uKw/viewform?usp=pp_url&entry.110962249=" + data
   }
-  
+
 }
 
 

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -38,16 +38,16 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
                 matchId={matchId}
                 suggestions={suggestionsToRender}
               />
-              <div className="MatchWidget__feedbackLink">
-                <a 
-                  target="_blank"
-                  href={getFeedbackLink(feedbackInfo)}
-                >
-                  Something's not right? Tell us!
-                </a>
-              </div>
             </div>
           )}
+          <div className="MatchWidget__feedbackLink">
+            <a 
+              target="_blank"
+              href={getFeedbackLink(feedbackInfo)}
+            >
+              Something's not right? Tell us!
+            </a>
+            </div>
         </div>
       </div>
     );

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -8,11 +8,6 @@ interface IMatchProps<TMatch extends IMatch> {
   match: TMatch;
 }
 
-const getFeedbackLink = (feedbackInfo: any) => {
-  const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2))
-  return "https://docs.google.com/forms/d/e/1FAIpQLSfMOgvJtCchnW0_2zB7Afz_WtYJ5lnPqQI-dgFZ-p0B4h6uKw/viewform?usp=pp_url&entry.110962249=" + data
-}
-
 class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
   public ref: HTMLDivElement | null = null;
   public render({
@@ -41,9 +36,9 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
             </div>
           )}
           <div className="MatchWidget__feedbackLink">
-            <a 
+            <a
               target="_blank"
-              href={getFeedbackLink(feedbackInfo)}
+              href={this.getFeedbackLink(feedbackInfo)}
             >
               Something's not right? Tell us!
             </a>
@@ -52,6 +47,13 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       </div>
     );
   }
+
+  private getFeedbackLink = (feedbackInfo: any) => {
+    const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2))
+    return "https://docs.google.com/forms/d/e/1FAIpQLSfMOgvJtCchnW0_2zB7Afz_WtYJ5lnPqQI-dgFZ-p0B4h6uKw/viewform?usp=pp_url&entry.110962249=" + data
+  }
+  
 }
+
 
 export default Match;

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -19,6 +19,7 @@ interface IProps<TMatch extends IMatch> {
   // The element that contains the tooltips. Tooltips will be positioned
   // within this element.
   containerElement?: HTMLElement;
+  feedbackHref?: string;
 }
 
 /**
@@ -77,6 +78,7 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
             ref={_ => (this.matchRef = _)}
             match={match}
             applySuggestions={this.props.applySuggestions}
+            feedbackHref={this.props.feedbackHref}
           />
         </div>
       </div>

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -15,7 +15,7 @@ interface IProps {
   selectMatch: (matchId: string) => void;
   indicateHover: (matchId: string, _?: any) => void;
   stopHover: () => void;
-  contactHref: string;
+  contactHref?: string;
 }
 
 /**
@@ -65,11 +65,13 @@ class Sidebar extends Component<
               </button>
             )}
           </div>
-          <div className="Sidebar__header-contact">
-            <a href={contactHref} target="_blank">
-              Issue with a rule? Let us know!
-            </a>
-          </div>
+          {contactHref && (
+            <div className="Sidebar__header-contact">
+              <a href={contactHref} target="_blank">
+                Issue with a rule? Let us know!
+              </a>
+            </div>
+          )}
           {this.state.loadingBarVisible && (
             <div
               class="LoadingBar"

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -18,7 +18,8 @@ const createView = (
   commands: Commands,
   sidebarNode: Element,
   controlsNode: Element,
-  contactHref: string
+  contactHref?: string,
+  feedbackHref?: string
 ) => {
   // Create our overlay node, which is responsible for displaying
   // match messages when the user hovers over highlighted ranges.
@@ -41,6 +42,7 @@ const createView = (
         commands.stopHover();
       }}
       containerElement={wrapperElement}
+      feedbackHref={feedbackHref}
     />,
     overlayNode
   );


### PR DESCRIPTION
## What does this change?

Adds a link to the typerighter popup so allow the user to send feedback via a google form.

The google form has been set up to only accept entries from validated email addresses ending @guardian.co.uk, but is currently owned by Justin Rowles and should be owned by an internal account.

## How to test

I... don't really know.  I ran composer locally and installed the plugin locally.

## How can we measure success?

Clickable link with appropriate embedded metadata appears in popup.

Form sends email to typerighter@theguardian.com

## Have we considered potential risks?

## Images

![image](https://user-images.githubusercontent.com/5476326/88791574-e0311e80-d191-11ea-880e-4926184a175f.png)
