### PR TITLE
Improve contact link wording and styling

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -161,6 +161,7 @@ hr {
 .MatchWidget__feedbackLink {
   text-align: right;
   font-size: 12px;
+  padding: $gutter-width;
 }
 
 .MatchDecoration {

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -52,7 +52,7 @@ class Controls extends Component<IProps, IState> {
             className="Sidebar__header Sidebar__header-toggle"
             onClick={this.toggleOpenState}
           >
-            Controls
+            Typerighter
             <div className="Sidebar__toggle-label">Advanced</div>
             <div
               className="Sidebar__toggle"

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -43,7 +43,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
                 target="_blank"
                 href={this.getFeedbackLink(this.props.feedbackHref!, feedbackInfo)}
               >
-                Something's not right? Tell us!
+                Issue with this result? Tell us!
               </a>
             </div>
           )}

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -69,7 +69,7 @@ class Sidebar extends Component<
           {contactHref && (
             <div className="Sidebar__header-contact">
               <a href={contactHref} target="_blank">
-                Issue with a rule? Let us know!
+                Issue with Typerighter? Let us know!
               </a>
             </div>
           )}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

With the addition of feedback links to match overlays (https://github.com/guardian/prosemirror-typerighter/pull/75), the wording on the overlay and sidebar feedback links was confusing. The sidebar link is for issues with Typerighter in general, whereas the overlay link is for issues with a particular rule/result.

The link wording has been amended for clarity, and as part of that, the word 'Controls' has been renamed to 'Typerighter', so that users know that the sidebar is specific to the tool.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run the branch locally and see the wording has changed. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We receive feedback for the correct context, ie at tool-level or rule-level, as appropriate.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Before 
![image](https://user-images.githubusercontent.com/15648334/89315881-437bee80-d673-11ea-9318-9ae9715ccc5e.png)

![image](https://user-images.githubusercontent.com/15648334/89315920-5098dd80-d673-11ea-907b-ea53f8a4a4db.png)


### After (NB link colour will be the same as in Composer images above, these screenshots were taken from Prosemirror Validator)

![image](https://user-images.githubusercontent.com/15648334/89313017-df0b6000-d66f-11ea-9eb5-ea3d64e3ddbf.png)

![image](https://user-images.githubusercontent.com/15648334/89315949-5c849f80-d673-11ea-867d-08251d833c48.png)



