### PR TITLE
Numerous styling changes

### DIFF
--- a/pages/dist/index.html
+++ b/pages/dist/index.html
@@ -62,10 +62,6 @@
         border-radius: 4px 4px 0 0;
       }
 
-      #controls {
-        flex-shrink: 0;
-      }
-
       #sidebar {
         min-height: 0;
       }
@@ -86,7 +82,6 @@
           </div>
         </div>
         <div class="Sidebar">
-            <div id="controls" class="Sidebar__container"></div>
             <div id="sidebar" class="Sidebar__container"></div>
         </div>
       </div>

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -32,10 +32,9 @@ if (contentElement && contentElement.parentElement) {
 const historyPlugin = history();
 const editorElement = document.querySelector("#editor");
 const sidebarElement = document.querySelector("#sidebar");
-const controlsElement = document.querySelector("#controls");
 const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin();
 
-if (editorElement && sidebarElement && controlsElement) {
+if (editorElement && sidebarElement) {
   const view = new EditorView(editorElement, {
     state: EditorState.create({
       doc,
@@ -63,8 +62,8 @@ if (editorElement && sidebarElement && controlsElement) {
     validationService,
     commands,
     sidebarElement,
-    controlsElement,
-    "mailto:example@typerighter.co.uk"
+    "mailto:example@typerighter.co.uk",
+    "http://a-form-for-example.com"
   );
 
   // Handy debugging tools

--- a/src/css/Controls.scss
+++ b/src/css/Controls.scss
@@ -27,7 +27,9 @@
 
 .Controls__error-message {
   color: red;
-  padding: $gutter-width / 2;
+  padding: $gutter-width;
+  padding-bottom: 0;
+  font-size: $font-size-small;
 }
 
 .LoadingBar {

--- a/src/css/Controls.scss
+++ b/src/css/Controls.scss
@@ -1,12 +1,22 @@
 .Controls__row {
   position: relative;
   display: flex;
-  padding: $gutter-width / 2;
+  align-items: center;
+  padding: $gutter-width;
+}
+
+.Controls__row + .Controls__row {
+  padding-top: 0;
+  padding-bottom: $gutter-width / 2;
 }
 
 .Controls__input {
   min-width: 30px;
   margin-left: auto;
+}
+
+.Controls__header {
+  font-weight: bold;
 }
 
 .Controls__label {

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -30,14 +30,14 @@
 
 .Sidebar__header-contact {
   margin-top: 5px;
-  font-size: $font-size-x-small;
+  font-size: $font-size-small;
 }
 
 .Sidebar__header {
   display: flex;
   align-items: baseline;
   position: relative;
-  flex-shrink: 0;
+  flex-shrink: 0.2;
   font-weight: bold;
 }
 

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -1,5 +1,5 @@
 .Sidebar__container {
-  font-size: 16px;
+  font-size: $font-size-small;
 }
 
 .Sidebar__content {
@@ -29,14 +29,14 @@
 
 .Sidebar__header-contact {
   margin-top: 5px;
-  font-size: 11px;
+  font-size: $font-size-x-small;
 }
 
 .Sidebar__header {
   display: flex;
   position: relative;
   flex-shrink: 0;
-  font-weight: 500;
+  font-weight: bold;
   justify-content: space-between;
 }
 
@@ -45,8 +45,8 @@
 }
 
 .Sidebar__header-option {
-  font-weight: 400;
-  font-size: 14px;
+  font-weight: regular;
+  font-size: $font-size-small;
 }
 
 .Sidebar__awaiting-match {
@@ -57,7 +57,7 @@
 .Sidebar__toggle,
 .Sidebar__toggle-label {
   align-self: baseline;
-  font-size: 0.8em;
+  font-size: $font-size-small;
 }
 
 .Sidebar__toggle {

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -15,6 +15,7 @@
   margin: 0 $gutter-width / 2;
   max-height: 100%;
   overflow: hidden;
+  font-size: $font-size-base;
 }
 
 .Sidebar__container + .Sidebar__container {
@@ -23,7 +24,7 @@
 
 .Sidebar__header-container {
   position: relative;
-  padding: $gutter-width $gutter-width/2;
+  padding: $gutter-width;
   border-bottom: 1px solid $sidebar-border-color;
 }
 
@@ -34,13 +35,14 @@
 
 .Sidebar__header {
   display: flex;
+  align-items: baseline;
   position: relative;
   flex-shrink: 0;
   font-weight: bold;
-  justify-content: space-between;
 }
 
 .Sidebar__header-toggle {
+  margin-top: $gutter-width;
   cursor: pointer;
 }
 
@@ -49,18 +51,15 @@
   font-size: $font-size-small;
 }
 
-.Sidebar__awaiting-match {
-  padding: $gutter-width/2;
-  color: #aaa;
-}
-
 .Sidebar__toggle,
 .Sidebar__toggle-label {
   align-self: baseline;
   font-size: $font-size-small;
+  font-weight: normal;
 }
 
 .Sidebar__toggle {
+  display: inline-block;
   transition: transform 0.15s;
   color: #aaa;
 }
@@ -78,7 +77,7 @@
 }
 
 .Sidebar__awaiting-match {
-  padding: $gutter-width/2;
+  padding: $gutter-width ;
   color: gray;
 }
 

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -42,7 +42,6 @@
 }
 
 .Sidebar__header-toggle {
-  margin-top: $gutter-width;
   cursor: pointer;
 }
 

--- a/src/css/SidebarMatch.scss
+++ b/src/css/SidebarMatch.scss
@@ -21,12 +21,12 @@
 }
 
 .SidebarMatch__header-match-text {
-  font-weight: 500;
+  margin-bottom: $gutter-width / 2;
   cursor: pointer;
 }
 
 .SidebarMatch__header-description {
-  font-size: 14px;
+  font-size: $font-size-small;
 }
 
 .SidebarMatch__header-meta {
@@ -36,7 +36,7 @@
 .SidebarMatch__header-range,
 .SidebarMatch__header-category {
   text-align: right;
-  font-size: 12px;
+  font-size: $font-size-x-small;
 }
 
 .SidebarMatch__header-category {
@@ -59,7 +59,7 @@
 
 .SidebarMatch__content {
   margin-top: ($gutter-width / 2) ;
-  font-size: 14px;
+  font-size: $font-size-small;
 }
 
 .SidebarMatch__suggestion-list {

--- a/src/css/SidebarMatch.scss
+++ b/src/css/SidebarMatch.scss
@@ -1,5 +1,5 @@
 .SidebarMatch__container {
-  padding: ($gutter-width / 2) ;
+  padding: $gutter-width;
   &:hover {
     background-color: #f6f6f6;
   }
@@ -27,6 +27,7 @@
 
 .SidebarMatch__header-description {
   font-size: $font-size-small;
+  color: $text-color-secondary
 }
 
 .SidebarMatch__header-meta {
@@ -36,7 +37,7 @@
 .SidebarMatch__header-range,
 .SidebarMatch__header-category {
   text-align: right;
-  font-size: $font-size-x-small;
+  font-size: $font-size-small;
 }
 
 .SidebarMatch__header-category {
@@ -44,6 +45,7 @@
   font-variant: small-caps;
   text-transform: lowercase;
   letter-spacing: 0.3px;
+  color: $match-gray;
 }
 
 .SidebarMatch__header-range {

--- a/src/css/Suggestion.scss
+++ b/src/css/Suggestion.scss
@@ -37,7 +37,7 @@
   position: relative;
   height: $match-suggestion-wiki-extract-height;
   overflow: hidden;
-  font-size: $font-size-x-small;
+  font-size: $font-size-small;
 }
 
 .WikiSuggestion__link {

--- a/src/css/Suggestion.scss
+++ b/src/css/Suggestion.scss
@@ -12,8 +12,8 @@
 
 .WikiSuggestion__suggestion {
   padding: $gutter-width $gutter-width $gutter-width 0;
-  font-weight: 700;
-  font-size: 16px;
+  font-weight: bold;
+  font-size: $font-size-large;
   color: $match-suggestion-color;
   cursor: pointer;
   &:hover {
@@ -37,7 +37,7 @@
   position: relative;
   height: $match-suggestion-wiki-extract-height;
   overflow: hidden;
-  font-size: 12px;
+  font-size: $font-size-x-small;
 }
 
 .WikiSuggestion__link {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -12,10 +12,9 @@ $match-suggestion-background-color-hover: #eee;
 $match-suggestion-color: #999;
 $match-suggestion-color-hover: #888;
 $match-suggestion-wiki-extract-height: 85px;
-$font-size-base: 14px;
+$font-size-base: 15px;
 $font-size-large: 1.1em;
 $font-size-small: 0.8em;
-$font-size-x-small: 0.7em;
 
 // Mixins
 @mixin placeholderAnimation {
@@ -100,7 +99,7 @@ hr {
   font-weight: normal;
   box-shadow: 0 14px 28px rgba(0, 0, 0, 0.2), 0 10px 10px rgba(0, 0, 0, 0.18);
   border-radius: 3px;
-  width: 300px;
+  width: 350px;
   transition: opacity 0.1s, transform 0.1s;
   transform: translate3d(0, -3px, 0);
   z-index: 100;
@@ -180,7 +179,7 @@ hr {
 
 .MatchWidget__feedbackLink {
   margin-top: $gutter-width;
-  font-size: $font-size-x-small;
+  font-size: $font-size-small;
   a {
     color: $match-gray;
   }

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,6 +1,6 @@
 // Variables
 $gutter-width: 10px;
-$sidebar-border-color: #ccc;
+$sidebar-border-color: #ddd;
 $match-color: #3dcde6;
 $match-color-hover: #3dcde624;
 $match-gray: #a0a0a0;
@@ -10,6 +10,10 @@ $match-suggestion-background-color: #fff;
 $match-suggestion-color: #999;
 $match-suggestion-color-hover: #f1f1f1;
 $match-suggestion-wiki-extract-height: 85px;
+$font-size-base: 14px;
+$font-size-large: 1.1em;
+$font-size-small: 0.85em;
+$font-size-x-small: 0.7em;
 
 // Mixins
 @mixin placeholderAnimation {
@@ -66,7 +70,7 @@ hr {
   padding: 1px 4px;
   border: 1px solid lightgrey;
   border-radius: 3px;
-  font-size: 1em;
+  font-size: $font-size-base;
   cursor: pointer;
 }
 
@@ -87,7 +91,7 @@ hr {
   display: block;
   position: relative;
   font-family: sans-serif;
-  font-size: 14px;
+  font-size: $font-size-small;
   font-style: normal;
   font-weight: normal;
   background-color: white;
@@ -101,7 +105,7 @@ hr {
 }
 
 .MatchWidget__container {
-  margin-top: 8px;
+  margin-top: 13px;
   position: relative;
 }
 
@@ -142,8 +146,8 @@ hr {
 .MatchWidget__suggestion {
   display: block;
   cursor: pointer;
-  font-weight: 700;
-  font-size: 16px;
+  font-weight: bold;
+  font-size: $font-size-large;
   color: $match-suggestion-color;
 }
 
@@ -160,8 +164,7 @@ hr {
 
 .MatchWidget__feedbackLink {
   text-align: right;
-  font-size: 12px;
-  padding: $gutter-width;
+  font-size: $font-size-x-small;
 }
 
 .MatchDecoration {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,18 +1,20 @@
 // Variables
-$gutter-width: 10px;
+$gutter-width: 8px;
 $sidebar-border-color: #ddd;
+$text-color-secondary: #5f5e5e;
 $match-color: #3dcde6;
 $match-color-hover: #3dcde624;
-$match-gray: #a0a0a0;
+$match-gray: #999999;
 $match-debug-color-dirty: #f7a85e66;
 $match-debug-color-inflight: #31a72085;
-$match-suggestion-background-color: #fff;
+$match-suggestion-background-color: #f3f3f3;
+$match-suggestion-background-color-hover: #eee;
 $match-suggestion-color: #999;
-$match-suggestion-color-hover: #f1f1f1;
+$match-suggestion-color-hover: #888;
 $match-suggestion-wiki-extract-height: 85px;
 $font-size-base: 14px;
 $font-size-large: 1.1em;
-$font-size-small: 0.85em;
+$font-size-small: 0.8em;
 $font-size-x-small: 0.7em;
 
 // Mixins
@@ -71,6 +73,7 @@ hr {
   border: 1px solid lightgrey;
   border-radius: 3px;
   font-size: $font-size-base;
+  font-weight: normal;
   cursor: pointer;
 }
 
@@ -88,14 +91,14 @@ hr {
 }
 
 .MatchWidget {
+  background-color: white;
   display: block;
   position: relative;
+  padding: $gutter-width * 1.5;
   font-family: sans-serif;
-  font-size: $font-size-small;
   font-style: normal;
   font-weight: normal;
-  background-color: white;
-  box-shadow: #4e56643b 0px 0px 1px 0px, #3f48573a 0px 2px 7px 0px;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.2), 0 10px 10px rgba(0, 0, 0, 0.18);
   border-radius: 3px;
   width: 300px;
   transition: opacity 0.1s, transform 0.1s;
@@ -107,6 +110,7 @@ hr {
 .MatchWidget__container {
   margin-top: 13px;
   position: relative;
+  font-size: $font-size-base;
 }
 
 .MatchWidget__container--is-hovering .MatchWidget {
@@ -117,18 +121,29 @@ hr {
 .MatchWidget__type {
   color: $match-gray;
   font-variant: small-caps;
+  // normalise line height, as the small-caps take up less space
+  line-height: 0.7;
   text-transform: lowercase;
   letter-spacing: 0.3px;
 }
-
-.MatchWidget__annotation,
-.MatchWidget__suggestion,
-.MatchWidget__type {
+.MatchWidget__suggestion {
   padding: $gutter-width;
 }
 
+.MatchWidget__type {
+  padding-bottom: $gutter-width;
+}
+
 .MatchWidget__annotation {
-  padding-top: 0;
+  padding-top: $gutter-width;
+}
+
+.MatchWidget__color-swatch {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 5px;
+  border-radius: 8px;
 }
 
 .MatchWidget__label {
@@ -140,7 +155,6 @@ hr {
 .MatchWidget__suggestion-list {
   display: block;
   margin-top: 3px;
-  padding: 0 $gutter-width $gutter-width $gutter-width;
 }
 
 .MatchWidget__suggestion {
@@ -149,6 +163,7 @@ hr {
   font-weight: bold;
   font-size: $font-size-large;
   color: $match-suggestion-color;
+  background-color: $match-suggestion-background-color;
 }
 
 .MatchWidget__suggestion:nth-child(even) {
@@ -156,15 +171,19 @@ hr {
 }
 
 .MatchWidget__suggestion:hover {
-  background-color: $match-suggestion-color-hover;
+  color: $match-suggestion-color-hover;
+  background-color: $match-suggestion-background-color-hover;
 }
 .MatchWidget__suggestion + .MatchWidget__suggestion {
   margin-top: 3px;
 }
 
 .MatchWidget__feedbackLink {
-  text-align: right;
+  margin-top: $gutter-width;
   font-size: $font-size-x-small;
+  a {
+    color: $match-gray;
+  }
 }
 
 .MatchDecoration {

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -1,9 +1,9 @@
-import { Component, h } from "preact";
+import { Component, h, Fragment } from "preact";
 import v4 from "uuid/v4";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
 import { IMatch, ICategory } from "../interfaces/IMatch";
-import { selectHasError } from '../state/selectors';
+import { selectHasError } from "../state/selectors";
 
 interface IProps {
   store: Store<IMatch>;
@@ -34,7 +34,7 @@ class Controls extends Component<IProps, IState> {
     allCategories: [],
     currentCategories: [],
     isLoadingCategories: false,
-    pluginState: undefined,
+    pluginState: undefined
   } as IState;
   public componentWillMount() {
     this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
@@ -47,26 +47,39 @@ class Controls extends Component<IProps, IState> {
     //   this.state.pluginState || {};
     const { isOpen, isLoadingCategories } = this.state;
     return (
-      <div className="Sidebar__section">
+      <Fragment>
         <div className="Sidebar__header-container">
-          <div
-            className="Sidebar__header Sidebar__header-toggle"
-            onClick={this.toggleOpenState}
-          >
-            Typerighter
-            <div className="Sidebar__toggle-label">Advanced</div>
-            <div
-              className="Sidebar__toggle"
-              style={{ transform: isOpen ? "" : "rotate(-90deg)" }}
+          <div class="Sidebar__header">Typerighter</div>
+          <div className="Sidebar__header Sidebar__header-toggle">
+            <button
+              type="button"
+              className="Button"
+              onClick={this.requestMatchesForDocument}
+              disabled={
+                this.state.pluginState &&
+                !!Object.keys(this.state.pluginState.requestsInFlight).length
+              }
             >
-              ▼
+              Check document
+            </button>
+
+            <div
+              onClick={this.toggleOpenState}
+              className="Sidebar__toggle-label"
+            >
+              Advanced&nbsp;
+              <span
+                className="Sidebar__toggle"
+                style={{ transform: isOpen ? "" : "rotate(-90deg)" }}
+              >
+                ▼
+              </span>
             </div>
           </div>
         </div>
-        <div className="Sidebar__content">
-          {isOpen && (
-            <div>
-              {/* <div className="Controls__row">
+        {isOpen && (
+          <div>
+            {/* <div className="Controls__row">
                 <label
                   className="Controls__label"
                   for="Controls__check-on-modify"
@@ -105,70 +118,67 @@ class Controls extends Component<IProps, IState> {
               <div className="Controls__row">
                 <hr />
               </div> */}
-              <div className="Controls__row">
+            <div className="Controls__row">
+              <div className="Controls__header">
                 Select categories&nbsp;
                 {isLoadingCategories && (
                   <span className="Sidebar__loading-spinner">|</span>
                 )}
-                <button
-                  type="button"
-                  class="Button flex-align-right"
-                  onClick={this.fetchCategories}
-                >
-                  Refresh
-                </button>
               </div>
-              {this.state.allCategories.map(category => (
-                <div className="Controls__row">
-                  <label
-                    className="Controls__label"
-                    for="Controls__show-dirty-ranges"
-                  >
-                    {category.name}
-                  </label>
-                  <div class="Controls__input">
-                    <input
-                      id="Controls__show-dirty-ranges"
-                      type="checkbox"
-                      checked={
-                        !!this.state.currentCategories.find(
-                          _ => _.id === category.id
-                        )
-                      }
-                      className="Input"
-                      onInput={(e: Event) =>
-                        this.setCategoryState(
-                          category.id,
-                          (e.target! as HTMLInputElement).checked
-                        )
-                      }
-                    />
-                  </div>
-                </div>
-              ))}
-              <div className="Controls__row">
-                <hr />
-              </div>
+              <button
+                type="button"
+                class="Button flex-align-right"
+                onClick={this.fetchCategories}
+              >
+                Refresh
+              </button>
             </div>
-          )}
-          <div className="Controls__row">
-            <button
-              type="button"
-              className="Button"
-              onClick={this.requestMatchesForDocument}
-              disabled={
-                this.state.pluginState &&
-                !!Object.keys(this.state.pluginState.requestsInFlight).length
-              }
-            >
-              Check whole document
-            </button>
+            {this.state.allCategories.map(category => (
+              <div className="Controls__row">
+                <label
+                  className="Controls__label"
+                  for="Controls__show-dirty-ranges"
+                >
+                  {category.name}
+                </label>
+                <div class="Controls__input">
+                  <input
+                    id="Controls__show-dirty-ranges"
+                    type="checkbox"
+                    checked={
+                      !!this.state.currentCategories.find(
+                        _ => _.id === category.id
+                      )
+                    }
+                    className="Input"
+                    onInput={(e: Event) =>
+                      this.setCategoryState(
+                        category.id,
+                        (e.target! as HTMLInputElement).checked
+                      )
+                    }
+                  />
+                </div>
+              </div>
+            ))}
+            <hr />
           </div>
-          {this.state.pluginState && selectHasError(this.state.pluginState) && <div className="Controls__error-message">
-            Error fetching matches. Please try checking the document again. {this.props.contactHref && <span>If the error persists, please <a href={this.props.contactHref} target="_blank">contact us</a>.</span>} 
-          </div>}
-        </div>
-      </div>
+        )}
+        {this.state.pluginState && selectHasError(this.state.pluginState) && (
+          <div className="Controls__error-message">
+            Error fetching matches. Please try checking the document again.{" "}
+            {this.props.contactHref && (
+              <span>
+                If the error persists, please{" "}
+                <a href={this.props.contactHref} target="_blank">
+                  contact us
+                </a>
+                .
+              </span>
+            )}
+          </div>
+        )}
+      </Fragment>
     );
   }
   private handleNotify = (state: IPluginState<IMatch>) => {

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -49,7 +49,6 @@ class Controls extends Component<IProps, IState> {
     return (
       <Fragment>
         <div className="Sidebar__header-container">
-          <div class="Sidebar__header">Typerighter</div>
           <div className="Sidebar__header Sidebar__header-toggle">
             <button
               type="button"

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -12,36 +12,48 @@ interface IMatchProps<TMatch extends IMatch> {
 class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
   public ref: HTMLDivElement | null = null;
   public render({
-    match: { matchId, category, message, suggestions, replacement },
+    match: { matchId, category, message, suggestions, replacement, markAsCorrect },
     applySuggestions
   }: IMatchProps<TMatch>) {
     const suggestionsToRender = replacement ? [replacement] : suggestions || [];
+    const suggestionContent = suggestionsToRender && applySuggestions && !markAsCorrect && (
+      <div className="MatchWidget__suggestion-list">
+        <SuggestionList
+          applySuggestions={applySuggestions}
+          matchId={matchId}
+          suggestions={suggestionsToRender}
+        />
+      </div>
+    )
     const url = document.URL;
-    const feedbackInfo = { matchId, category, message, suggestions, replacement, url };
+    const feedbackInfo = {
+      matchId,
+      category,
+      message,
+      suggestions,
+      replacement,
+      url
+    };
     return (
       <div className="MatchWidget__container">
         <div className="MatchWidget" ref={_ => (this.ref = _)}>
-          <div
-            className="MatchWidget__type"
-            style={{ color: `#${category.colour}` }}
-          >
+          <div className="MatchWidget__type">
+            <span
+              className="MatchWidget__color-swatch"
+              style={{ backgroundColor: `#${category.colour}` }}
+            ></span>
             {category.name}
           </div>
+          {suggestionContent}
           <div className="MatchWidget__annotation">{message}</div>
-          {suggestions && applySuggestions && (
-            <div className="MatchWidget__suggestion-list">
-              <SuggestionList
-                applySuggestions={applySuggestions}
-                matchId={matchId}
-                suggestions={suggestionsToRender}
-              />
-            </div>
-          )}
           {this.props.feedbackHref && (
             <div className="MatchWidget__feedbackLink">
               <a
                 target="_blank"
-                href={this.getFeedbackLink(this.props.feedbackHref!, feedbackInfo)}
+                href={this.getFeedbackLink(
+                  this.props.feedbackHref!,
+                  feedbackInfo
+                )}
               >
                 Issue with this result? Tell us!
               </a>
@@ -53,10 +65,9 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
   }
 
   private getFeedbackLink = (feedbackHref: string, feedbackInfo: any) => {
-    const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2))
-    return feedbackHref + data
-  }
-
+    const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2));
+    return feedbackHref + data;
+  };
 }
 
 export default Match;

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -70,7 +70,7 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
             // We hoist top slightly to ensure that the rendered element overlaps the
             // span that triggered the overlay -- if the mouse falls through a gap it
             // will trigger a mouseleave event that will close the overlay.
-            top: top - 1,
+            top: top - 5,
             left
           }}
         >
@@ -150,7 +150,7 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
 
     const left = absoluteLeft - hoverInfo.containerLeft;
     const top = absoluteTop - hoverInfo.containerTop;
-  
+
     return { left, top, maxLeft };
   };
 

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from "preact";
+import { Component, h, Fragment } from "preact";
 import sortBy from "lodash/sortBy";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { ApplySuggestionOptions } from "../commands";
@@ -19,9 +19,9 @@ interface IProps {
 }
 
 /**
- * A sidebar to display current matches and allow users to apply suggestions.
+ * Displays current matches and allows users to apply suggestions.
  */
-class Sidebar extends Component<
+class Results extends Component<
   IProps,
   {
     pluginState: IPluginState<IMatch> | undefined;
@@ -51,7 +51,7 @@ class Sidebar extends Component<
       !!requestsInFlight && !!Object.keys(requestsInFlight).length;
 
     return (
-      <div className="Sidebar__section">
+      <Fragment>
         <div className="Sidebar__header-container">
           <div className="Sidebar__header">
             <span>
@@ -105,7 +105,7 @@ class Sidebar extends Component<
             <div className="Sidebar__awaiting-match">No matches to report.</div>
           )}
         </div>
-      </div>
+      </Fragment>
     );
   }
 
@@ -154,4 +154,4 @@ class Sidebar extends Component<
   };
 }
 
-export default Sidebar;
+export default Results;

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -62,7 +62,7 @@ class SidebarMatch extends Component<IProps, IState> {
               </div>
             </div>
             <div className="SidebarMatch__header-meta">
-              <div className="SidebarMatch__header-category" style={{ color }}>
+              <div className="SidebarMatch__header-category">
                 {titleCase(output.category.name)}
               </div>
               {hasSuggestions && (

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -2,7 +2,7 @@ import { EditorView } from "prosemirror-view";
 import { h, render } from "preact";
 import MatchOverlay from "./components/MatchOverlay";
 import Store from "./state/store";
-import Sidebar from "./components/Sidebar";
+import Results from "./components/Results";
 import Controls from "./components/Controls";
 import { Commands } from "./commands";
 import { IMatch } from "./interfaces/IMatch";
@@ -21,7 +21,6 @@ const createView = (
   matcherService: MatcherService<IMatch>,
   commands: Commands,
   sidebarNode: Element,
-  controlsNode: Element,
   contactHref?: string,
   feedbackHref?: string
 ) => {
@@ -41,8 +40,8 @@ const createView = (
   render(
     <MatchOverlay
       store={store}
-      applySuggestions={(suggestionOpts) => {
-        commands.applySuggestions(suggestionOpts)
+      applySuggestions={suggestionOpts => {
+        commands.applySuggestions(suggestionOpts);
         commands.stopHover();
       }}
       containerElement={wrapperElement}
@@ -52,31 +51,29 @@ const createView = (
   );
 
   render(
-    <Sidebar
-      store={store}
-      applySuggestions={commands.applySuggestions}
-      applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
-      selectMatch={commands.selectMatch}
-      indicateHover={commands.indicateHover}
-      stopHover={commands.stopHover}
-      contactHref={contactHref}
-    />,
+    <div className="Sidebar__section">
+      <Controls
+        store={store}
+        setDebugState={commands.setDebugState}
+        setRequestOnDocModified={commands.setRequestOnDocModified}
+        requestMatchesForDocument={commands.requestMatchesForDocument}
+        fetchCategories={matcherService.fetchCategories}
+        getCurrentCategories={matcherService.getCurrentCategories}
+        addCategory={matcherService.addCategory}
+        removeCategory={matcherService.removeCategory}
+        contactHref={contactHref}
+      />
+      <Results
+        store={store}
+        applySuggestions={commands.applySuggestions}
+        applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
+        selectMatch={commands.selectMatch}
+        indicateHover={commands.indicateHover}
+        stopHover={commands.stopHover}
+        contactHref={contactHref}
+      />
+    </div>,
     sidebarNode
-  );
-
-  render(
-    <Controls
-      store={store}
-      setDebugState={commands.setDebugState}
-      setRequestOnDocModified={commands.setRequestOnDocModified}
-      requestMatchesForDocument={commands.requestMatchesForDocument}
-      fetchCategories={matcherService.fetchCategories}
-      getCurrentCategories={matcherService.getCurrentCategories}
-      addCategory={matcherService.addCategory}
-      removeCategory={matcherService.removeCategory}
-      contactHref={contactHref}
-    />,
-    controlsNode
   );
 };
 


### PR DESCRIPTION
## What does this change?

The UI for this plugin was looking a little frumpy. It's still a bit frumpy, but I've made a few changes –

- References to category colours are now represented by swatches or borders, to ensure the category text is always legible
- A bug which made it difficult to traverse from match to tooltip has been fixed
- The two panels are consolidated – I'm not sure there was a good reason to keep them separate
- Font sizes have been normalised into three variables to ensure things are consistent, and applied at the root with em sizing to ensure sizing is consistent when this UI is embedded elsewhere 
- A few spacing tweaks, also to keep things consistent
- The suggestion/replacement rendering has been moved to the top of the match tooltip, the bounding box of the suggestion is now clear from a background colour, and the styling of the form link toned down, which I think makes for a better UI.

Before:
![tr-before-makeover](https://user-images.githubusercontent.com/7767575/89319482-12ea8380-d678-11ea-8302-e1549e4f6d26.gif)
After:
![tr-makeover](https://user-images.githubusercontent.com/7767575/89319490-14b44700-d678-11ea-9d2d-e2356d22d9dc.gif)


Phew, that's a lot of changes! I'm happy to split into separate PRs – all of the points above were fairly trivial to implement but I appreciate it might not be straightforward to understand what does what.

Re: design, all of this is of course subjective, and comments/crits are welcomed!

## How to test

Take the UI for a spin!
