### PR TITLE
Store all request errors

### DIFF
--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -14,7 +14,7 @@ interface IProps {
   getCurrentCategories: () => ICategory[];
   addCategory: (id: string) => void;
   removeCategory: (id: string) => void;
-  contactHref?: string;
+  feedbackHref?: string;
 }
 
 interface IState {
@@ -166,10 +166,10 @@ class Controls extends Component<IProps, IState> {
         {this.state.pluginState && selectHasError(this.state.pluginState) && (
           <div className="Controls__error-message">
             Error fetching matches. Please try checking the document again.{" "}
-            {this.props.contactHref && (
+            {this.props.feedbackHref && (
               <span>
                 If the error persists, please{" "}
-                <a href={this.props.contactHref} target="_blank">
+                <a href={this.getErrorFeedbackLink()} target="_blank">
                   contact us
                 </a>
                 .
@@ -225,6 +225,16 @@ class Controls extends Component<IProps, IState> {
       v4(),
       this.props.getCurrentCategories().map(_ => _.id)
     );
+  };
+
+  private getErrorFeedbackLink = () => {
+    const errorLmit = 10;
+    const data = {
+      url: document.location.href,
+      errors: this.state.pluginState?.requestErrors?.slice(0, errorLmit)
+    }
+    const encodedData = encodeURIComponent(JSON.stringify(data, undefined, 2));
+    return this.props.feedbackHref + encodedData;
   };
 }
 

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -65,7 +65,7 @@ const createView = (
         getCurrentCategories={matcherService.getCurrentCategories}
         addCategory={matcherService.addCategory}
         removeCategory={matcherService.removeCategory}
-        contactHref={contactHref}
+        feedbackHref={feedbackHref}
       />
       <Results
         store={store}

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -125,7 +125,7 @@ export interface IPluginState<TMatches extends IMatch = IMatch> {
     [requestId: string]: IBlocksInFlightState;
   };
   // The current error message.
-  errorMessage: IMatchRequestError[];
+  requestErrors: IMatchRequestError[];
 }
 
 // The transaction meta key that namespaces our actions.
@@ -148,7 +148,7 @@ export const createInitialState = <TMatch extends IMatch>(
   hoverInfo: undefined,
   requestsInFlight: {},
   requestPending: false,
-  errorMessage: []
+  requestErrors: []
 });
 
 export const createReducer = (expandRanges: ExpandRanges) => {
@@ -417,7 +417,7 @@ const handleRequestStart = (
 
   return {
     ...state,
-    errorMessage: [],
+    requestErrors: [],
     decorations,
     // We reset the dirty ranges, as they've been expanded and sent in a request.
     dirtiedRanges: [],
@@ -580,7 +580,7 @@ const handleMatchesRequestError = <TMatch extends IMatch>(
   const { requestId, blockId, categoryIds } = matchRequestError;
 
   if (!blockId) {
-    return { ...state, errorMessage: state.errorMessage.concat(matchRequestError) };
+    return { ...state, requestErrors: state.requestErrors.concat(matchRequestError) };
   }
 
   const requestsInFlight = selectBlockQueriesInFlightForSet(state, requestId);
@@ -596,7 +596,7 @@ const handleMatchesRequestError = <TMatch extends IMatch>(
   );
 
   if (!blockInFlight) {
-    return { ...state, errorMessage: state.errorMessage.concat(matchRequestError) };
+    return { ...state, requestErrors: state.requestErrors.concat(matchRequestError) };
   }
 
   const dirtiedRanges = blockInFlight
@@ -639,7 +639,7 @@ const handleMatchesRequestError = <TMatch extends IMatch>(
       blockId,
       categoryIds
     ),
-    errorMessage: state.errorMessage.concat(matchRequestError)
+    requestErrors: state.requestErrors.concat(matchRequestError)
   };
 };
 

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -125,5 +125,5 @@ export const selectAllAutoFixableMatches = <TMatch extends IMatch>(
 
 export const selectHasError = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
-): Boolean =>
+): boolean =>
   !!state.errorMessage && state.errorMessage.length > 0;

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -126,4 +126,4 @@ export const selectAllAutoFixableMatches = <TMatch extends IMatch>(
 export const selectHasError = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
 ): boolean =>
-  !!state.errorMessage && state.errorMessage.length > 0;
+  !!state.requestErrors && state.requestErrors.length > 0;

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -21,7 +21,7 @@ import {
 } from "../../utils/decoration";
 import { expandRangesToParentBlockNode } from "../../utils/range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
-import { IMatch } from "../../interfaces/IMatch";
+import { IMatch, IMatchRequestError } from "../../interfaces/IMatch";
 import {
   createMatcherResponse,
   createBlock,
@@ -380,7 +380,12 @@ describe("Action handlers", () => {
           }
         ],
         decorations: new DecorationSet(),
-        errorMessage: "Too many requests"
+        requestErrors: [{
+          requestId: exampleRequestId,
+          blockId: createBlockId(0, 1, 25),
+          message: "Too many requests",
+          categoryIds: ['example-category']
+        } as IMatchRequestError]
       });
     });
   });

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -159,7 +159,7 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       trHistory: [tr],
       requestsInFlight: {},
       requestPending: false,
-      errorMessage: undefined
+      errorMessage: []
     } as IPluginState
   };
 };

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -159,7 +159,7 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       trHistory: [tr],
       requestsInFlight: {},
       requestPending: false,
-      errorMessage: []
+      requestErrors: []
     } as IPluginState
   };
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR stores the errors received over the course of a match request and allows a users to submit them to support. These errors are cleared out once a new request for matches is made. When an error occurs, a contact us message appears, this link has been changed to use the existing google form but provides error context instead of rule context.

The format for the error context is: 
```
{
  "url": "https://typerighter-client.local.dev-gutools.co.uk/",
  "errors": [
    {
      "requestId": "e0ebcce8-5489-4085-a2de-87c42d5af3e1",
      "blockId": "1596720218960-from:16-to:972",
      "message": "400: Bad Request",
      "categoryIds": [
        "Red",
        "Blue",
        "Green"
      ]
    }
  ]
}
```

Up to ten error messages will be sent to the form, this is an arbitrary amount, designed to avoid the character limit on urls. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Provide the google form as the feedback HREF in .pages/index.ts: `https://docs.google.com/forms/d/e/1FAIpQLSfMOgvJtCchnW0_2zB7Afz_WtYJ5lnPqQI-dgFZ-p0B4h6uKw/viewform?entry.110962249=`
Load the client, check the document, receive errors for requests by either having an out of date cookie or blocking outgoing requests. After pressing the contact us link, you should be directed to the form page with the error information.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users with issues can easily contact us, with context, allowing us to diagnose any issues.

