### PR TITLE
Remove tick from correct matches

### DIFF
--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -5,7 +5,6 @@ import { IRange, IMatch } from "../interfaces/IMatch";
 
 // Our decoration types.
 export const DECORATION_MATCH = "DECORATION_MATCH";
-export const DECORATION_MATCH_IS_CORRECT = "DECORATION_MATCH_IS_CORRECT";
 export const DECORATION_MATCH_IS_SELECTED = "DECORATION_MATCH_IS_HOVERING";
 export const DECORATION_MATCH_HEIGHT_MARKER = "DECORATION_MATCH_HEIGHT_MARKER";
 export const DECORATION_DIRTY = "DECORATION_DIRTY";
@@ -17,7 +16,6 @@ export const DecorationClassMap = {
   [DECORATION_MATCH]: "MatchDecoration",
   [DECORATION_MATCH_HEIGHT_MARKER]: "MatchDecoration__height-marker",
   [DECORATION_MATCH_IS_SELECTED]: "MatchDecoration--is-selected",
-  [DECORATION_MATCH_IS_CORRECT]: "MatchDecoration--is-correct"
 };
 
 export const DECORATION_ATTRIBUTE_ID = "data-match-id";
@@ -47,8 +45,7 @@ export const removeDecorationsFromRanges = (
   ranges: IRange[],
   types = [
     DECORATION_MATCH,
-    DECORATION_MATCH_HEIGHT_MARKER,
-    DECORATION_MATCH_IS_CORRECT
+    DECORATION_MATCH_HEIGHT_MARKER
   ]
 ) =>
   ranges.reduce((acc, range) => {
@@ -97,17 +94,6 @@ const createHeightMarkerElement = (id: string) => {
 };
 
 /**
- * Create an 'isCorrect' element. Displays a little tick to let
- * users know that this range has been marked as correct.
- */
-const createIsCorrectElement = (id: string) => {
-  const element = document.createElement("span");
-  element.setAttribute(DECORATION_ATTRIBUTE_IS_CORRECT_ID, id);
-  element.className = DecorationClassMap[DECORATION_MATCH_IS_CORRECT];
-  return element;
-};
-
-/**
  * Create decorations for the given match.
  */
 export const createDecorationsForMatch = (
@@ -121,10 +107,12 @@ export const createDecorationsForMatch = (
       }`
     : DecorationClassMap[DECORATION_MATCH];
 
+
+  const matchColour = match.markAsCorrect ? "3ff200" :  match.category.colour;
   const opacity = isSelected ? "30" : "07";
   const style = `background-color: #${
-    match.category.colour
-  }${opacity}; border-bottom: 2px solid #${match.category.colour}`;
+    matchColour
+  }${opacity}; border-bottom: 2px solid #${matchColour}`;
 
   const decorations = [
     Decoration.inline(
@@ -154,20 +142,6 @@ export const createDecorationsForMatch = (
       } as any)
     );
   }
-
-  if (addWidgetDecorations && match.markAsCorrect) {
-    decorations.push(
-      Decoration.widget(match.to, createIsCorrectElement(match.matchId), {
-        type: DECORATION_MATCH_IS_CORRECT,
-        id: match.matchId,
-        categoryId: match.category.id,
-        // Important to keep the user from being able to insert characters
-        // between the inline decorations and this widget decoration
-        side: -1
-      } as any)
-    );
-  }
-
   return decorations;
 };
 

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -54,7 +54,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                "background-color: #eeeee07; border-bottom: 2px solid #eeeee"
+                "background-color: #3ff20007; border-bottom: 2px solid #3ff200"
             },
             spec: {
               categoryId: "1",
@@ -74,18 +74,6 @@ describe("Decoration utils", () => {
               categoryId: "1",
               id: "0-from:0-to:5--match-0",
               type: "DECORATION_MATCH_HEIGHT_MARKER"
-            }
-          }
-        },
-        {
-          from: 5,
-          to: 5,
-          type: {
-            side: -1,
-            spec: {
-              categoryId: "1",
-              id: "0-from:0-to:5--match-0",
-              type: "DECORATION_MATCH_IS_CORRECT"
             }
           }
         }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR simply removes the `markAsCorrect` tick from matches where the suggestion perfectly matches the text. Instead it marks those matches as the currently used green colour #3ff200.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Check for matches on a phrase where the suggestion matches the word exactly, an example is Instagram. The decoration for this match should no longer include a tick, and should always appear green.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
There is less noise on the document when checking for matches.