### PR TITLE
Hide Advanced pane

### DIFF
--- a/src/css/Controls.scss
+++ b/src/css/Controls.scss
@@ -10,15 +10,6 @@
   padding-bottom: $gutter-width / 2;
 }
 
-// .Controls__input {
-//   min-width: 30px;
-//   margin-left: auto;
-// }
-
-// .Controls__header {
-//   font-weight: bold;
-// }
-
 .Controls__label {
   font-weight: normal;
   cursor: pointer;

--- a/src/css/Controls.scss
+++ b/src/css/Controls.scss
@@ -10,14 +10,14 @@
   padding-bottom: $gutter-width / 2;
 }
 
-.Controls__input {
-  min-width: 30px;
-  margin-left: auto;
-}
+// .Controls__input {
+//   min-width: 30px;
+//   margin-left: auto;
+// }
 
-.Controls__header {
-  font-weight: bold;
-}
+// .Controls__header {
+//   font-weight: bold;
+// }
 
 .Controls__label {
   font-weight: normal;

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -41,29 +41,6 @@
   font-weight: bold;
 }
 
-// .Sidebar__header-toggle {
-//   cursor: pointer;
-// }
-
-// .Sidebar__toggle,
-// .Sidebar__toggle-label {
-//   align-self: baseline;
-//   font-size: $font-size-small;
-//   font-weight: normal;
-// }
-
-// .Sidebar__toggle {
-//   display: inline-block;
-//   transition: transform 0.15s;
-//   color: #aaa;
-// }
-
-// .Sidebar__toggle-label {
-//   color: #888;
-//   margin-left: auto;
-//   padding-right: 5px;
-// }
-
 .Sidebar__list {
   margin: 0;
   padding: 0;
@@ -84,16 +61,6 @@
 .Sidebar__list-item + .Sidebar__list-item {
   border-top: 1px solid $sidebar-border-color;
 }
-
-// .Sidebar__loading-spinner {
-//   display: inline-block;
-//   margin-top: 1px;
-//   margin-left: $gutter-width/2;
-//   line-height: 1;
-//   animation-duration: 0.5s;
-//   animation-name: spin;
-//   animation-iteration-count: infinite;
-// }
 
 @keyframes spin {
   from {

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -41,33 +41,28 @@
   font-weight: bold;
 }
 
-.Sidebar__header-toggle {
-  cursor: pointer;
-}
+// .Sidebar__header-toggle {
+//   cursor: pointer;
+// }
 
-.Sidebar__header-option {
-  font-weight: regular;
-  font-size: $font-size-small;
-}
+// .Sidebar__toggle,
+// .Sidebar__toggle-label {
+//   align-self: baseline;
+//   font-size: $font-size-small;
+//   font-weight: normal;
+// }
 
-.Sidebar__toggle,
-.Sidebar__toggle-label {
-  align-self: baseline;
-  font-size: $font-size-small;
-  font-weight: normal;
-}
+// .Sidebar__toggle {
+//   display: inline-block;
+//   transition: transform 0.15s;
+//   color: #aaa;
+// }
 
-.Sidebar__toggle {
-  display: inline-block;
-  transition: transform 0.15s;
-  color: #aaa;
-}
-
-.Sidebar__toggle-label {
-  color: #888;
-  margin-left: auto;
-  padding-right: 5px;
-}
+// .Sidebar__toggle-label {
+//   color: #888;
+//   margin-left: auto;
+//   padding-right: 5px;
+// }
 
 .Sidebar__list {
   margin: 0;
@@ -90,15 +85,15 @@
   border-top: 1px solid $sidebar-border-color;
 }
 
-.Sidebar__loading-spinner {
-  display: inline-block;
-  margin-top: 1px;
-  margin-left: $gutter-width/2;
-  line-height: 1;
-  animation-duration: 0.5s;
-  animation-name: spin;
-  animation-iteration-count: infinite;
-}
+// .Sidebar__loading-spinner {
+//   display: inline-block;
+//   margin-top: 1px;
+//   margin-left: $gutter-width/2;
+//   line-height: 1;
+//   animation-duration: 0.5s;
+//   animation-name: spin;
+//   animation-iteration-count: infinite;
+// }
 
 @keyframes spin {
   from {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -80,9 +80,9 @@ hr {
   background-color: #eee;
 }
 
-.Input[type="checkbox"] {
-  margin-left: $gutter-width;
-}
+// .Input[type="checkbox"] {
+//   margin-left: $gutter-width;
+// }
 
 .Button:active,
 .Button:focus {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -80,10 +80,6 @@ hr {
   background-color: #eee;
 }
 
-// .Input[type="checkbox"] {
-//   margin-left: $gutter-width;
-// }
-
 .Button:active,
 .Button:focus {
   outline: none;

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -45,11 +45,14 @@ class Controls extends Component<IProps, IState> {
     // const { setDebugState, setRequestOnDocModified } = this.props;
     // const { debug = false, requestMatchesOnDocModified = false } =
     //   this.state.pluginState || {};
-    const { isOpen, isLoadingCategories } = this.state;
+    // const { isOpen, isLoadingCategories } = this.state;
     return (
       <Fragment>
         <div className="Sidebar__header-container">
-          <div className="Sidebar__header Sidebar__header-toggle">
+          <div className="
+          Sidebar__header 
+          // Sidebar__header-toggle
+          ">
             <button
               type="button"
               className="Button"
@@ -62,7 +65,7 @@ class Controls extends Component<IProps, IState> {
               Check document
             </button>
 
-            <div
+            {/* <div
               onClick={this.toggleOpenState}
               className="Sidebar__toggle-label"
             >
@@ -73,11 +76,11 @@ class Controls extends Component<IProps, IState> {
               >
                 ▼
               </span>
-            </div>
+            </div> */}
           </div>
         </div>
-        {isOpen && (
-          <div>
+        {/* {isOpen && (
+          <div> */}
             {/* <div className="Controls__row">
                 <label
                   className="Controls__label"
@@ -117,7 +120,7 @@ class Controls extends Component<IProps, IState> {
               <div className="Controls__row">
                 <hr />
               </div> */}
-            <div className="Controls__row">
+            {/* <div className="Controls__row">
               <div className="Controls__header">
                 Select categories&nbsp;
                 {isLoadingCategories && (
@@ -162,7 +165,7 @@ class Controls extends Component<IProps, IState> {
             ))}
             <hr />
           </div>
-        )}
+        )} */}
         {this.state.pluginState && selectHasError(this.state.pluginState) && (
           <div className="Controls__error-message">
             Error fetching matches. Please try checking the document again.{" "}
@@ -183,15 +186,15 @@ class Controls extends Component<IProps, IState> {
   private handleNotify = (state: IPluginState<IMatch>) => {
     this.setState({ pluginState: state });
   };
-  private toggleOpenState = () => this.setState({ isOpen: !this.state.isOpen });
-  private setCategoryState = (categoryId: string, enabled: boolean) => {
-    enabled
-      ? this.props.addCategory(categoryId)
-      : this.props.removeCategory(categoryId);
-    this.setState({
-      currentCategories: this.props.getCurrentCategories()
-    });
-  };
+  // private toggleOpenState = () => this.setState({ isOpen: !this.state.isOpen });
+  // private setCategoryState = (categoryId: string, enabled: boolean) => {
+  //   enabled
+  //     ? this.props.addCategory(categoryId)
+  //     : this.props.removeCategory(categoryId);
+  //   this.setState({
+  //     currentCategories: this.props.getCurrentCategories()
+  //   });
+  // };
 
   private initCategories = async () => {
     const allCategories = await this.fetchCategories();

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -42,17 +42,11 @@ class Controls extends Component<IProps, IState> {
   }
 
   public render() {
-    // const { setDebugState, setRequestOnDocModified } = this.props;
-    // const { debug = false, requestMatchesOnDocModified = false } =
-    //   this.state.pluginState || {};
-    // const { isOpen, isLoadingCategories } = this.state;
-    return (
+
+     return (
       <Fragment>
         <div className="Sidebar__header-container">
-          <div className="
-          Sidebar__header 
-          // Sidebar__header-toggle
-          ">
+          <div className="Sidebar__header">
             <button
               type="button"
               className="Button"
@@ -64,108 +58,9 @@ class Controls extends Component<IProps, IState> {
             >
               Check document
             </button>
-
-            {/* <div
-              onClick={this.toggleOpenState}
-              className="Sidebar__toggle-label"
-            >
-              Advanced&nbsp;
-              <span
-                className="Sidebar__toggle"
-                style={{ transform: isOpen ? "" : "rotate(-90deg)" }}
-              >
-                ▼
-              </span>
-            </div> */}
           </div>
         </div>
-        {/* {isOpen && (
-          <div> */}
-            {/* <div className="Controls__row">
-                <label
-                  className="Controls__label"
-                  for="Controls__check-on-modify"
-                >
-                  Run checks when the document is modified
-                </label>
-                <div class="Controls__input">
-                  <input
-                    type="checkbox"
-                    id="Controls__check-on-modify"
-                    checked={requestMatchesOnDocModified}
-                    className="Input"
-                    onClick={() =>
-                      setRequestOnDocModified(!requestMatchesOnDocModified)
-                    }
-                  />
-                </div>
-              </div>
-              <div className="Controls__row">
-                <label
-                  className="Controls__label"
-                  for="Controls__show-dirty-ranges"
-                >
-                  Show dirty and pending ranges
-                </label>
-                <div class="Controls__input">
-                  <input
-                    id="Controls__show-dirty-ranges"
-                    type="checkbox"
-                    checked={debug}
-                    className="Input"
-                    onClick={() => setDebugState(!debug)}
-                  />
-                </div>
-              </div>
-              <div className="Controls__row">
-                <hr />
-              </div> */}
-            {/* <div className="Controls__row">
-              <div className="Controls__header">
-                Select categories&nbsp;
-                {isLoadingCategories && (
-                  <span className="Sidebar__loading-spinner">|</span>
-                )}
-              </div>
-              <button
-                type="button"
-                class="Button flex-align-right"
-                onClick={this.fetchCategories}
-              >
-                Refresh
-              </button>
-            </div>
-            {this.state.allCategories.map(category => (
-              <div className="Controls__row">
-                <label
-                  className="Controls__label"
-                  for="Controls__show-dirty-ranges"
-                >
-                  {category.name}
-                </label>
-                <div class="Controls__input">
-                  <input
-                    id="Controls__show-dirty-ranges"
-                    type="checkbox"
-                    checked={
-                      !!this.state.currentCategories.find(
-                        _ => _.id === category.id
-                      )
-                    }
-                    className="Input"
-                    onInput={(e: Event) =>
-                      this.setCategoryState(
-                        category.id,
-                        (e.target! as HTMLInputElement).checked
-                      )
-                    }
-                  />
-                </div>
-              </div>
-            ))}
-            <hr />
-          </div>
-        )} */}
+      
         {this.state.pluginState && selectHasError(this.state.pluginState) && (
           <div className="Controls__error-message">
             Error fetching matches. Please try checking the document again.{" "}
@@ -186,15 +81,6 @@ class Controls extends Component<IProps, IState> {
   private handleNotify = (state: IPluginState<IMatch>) => {
     this.setState({ pluginState: state });
   };
-  // private toggleOpenState = () => this.setState({ isOpen: !this.state.isOpen });
-  // private setCategoryState = (categoryId: string, enabled: boolean) => {
-  //   enabled
-  //     ? this.props.addCategory(categoryId)
-  //     : this.props.removeCategory(categoryId);
-  //   this.setState({
-  //     currentCategories: this.props.getCurrentCategories()
-  //   });
-  // };
 
   private initCategories = async () => {
     const allCategories = await this.fetchCategories();


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The 'Advanced' pane is not required at present, and with the coming categories/tags refactor, it doesn't present useful things to the user.

I've commented out the code relating to the 'Advanced' pane and any CSS that was only used by that code. I chose to comment out the code (a) in case it might be used in the future, and (b) because some of the code wrapped already-commented-out code, but can delete instead if preferred.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run the branch locally and see that the 'Advanced' pane is no longer present.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Before

![image](https://user-images.githubusercontent.com/15648334/89553273-34c54100-d805-11ea-8736-e385ed75bb2d.png)

![image](https://user-images.githubusercontent.com/15648334/89553118-05aecf80-d805-11ea-8644-da4ff96680cc.png)


### After

![image](https://user-images.githubusercontent.com/15648334/89553188-1c552680-d805-11ea-9080-be86df105531.png)
