### PR TITLE
Add command to ignore matches

### DIFF
--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -17,6 +17,7 @@ export const REQUEST_ERROR = "REQUEST_ERROR" as const;
 export const REQUEST_COMPLETE = "REQUEST_COMPLETE" as const;
 export const NEW_HOVER_ID = "NEW_HOVER_ID" as const;
 export const SELECT_MATCH = "SELECT_MATCH" as const;
+export const REMOVE_MATCH = "REMOVE_MATCH" as const;
 export const APPLY_NEW_DIRTY_RANGES = "HANDLE_NEW_DIRTY_RANGES" as const;
 export const SET_DEBUG_STATE = "SET_DEBUG_STATE" as const;
 export const SET_REQUEST_MATCHES_ON_DOC_MODIFIED = "SET_REQUEST_MATCHES_ON_DOC_MODIFIED" as const;
@@ -110,6 +111,14 @@ export type ActionSetRequestMatchesOnDocModified = ReturnType<
   typeof setRequestMatchesOnDocModified
 >;
 
+export const removeMatch = (id: string) => ({
+  type: REMOVE_MATCH,
+  payload: { id }
+})
+export type ActionRemoveMatch = ReturnType<
+  typeof removeMatch
+>;
+
 export type Action<TMatch extends IMatch> =
   | ActionNewHoverIdReceived
   | ActionRequestMatchesSuccess<TMatch>
@@ -120,4 +129,5 @@ export type Action<TMatch extends IMatch> =
   | ActionSelectMatch
   | ActionHandleNewDirtyRanges
   | ActionSetDebugState
-  | ActionSetRequestMatchesOnDocModified;
+  | ActionSetRequestMatchesOnDocModified
+  | ActionRemoveMatch

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -9,7 +9,8 @@ import {
   requestMatchesForDirtyRanges,
   requestMatchesSuccess,
   newHoverIdReceived,
-  requestMatchesComplete as requestComplete
+  requestMatchesComplete as requestComplete,
+  removeMatch
 } from "../actions";
 import { selectBlockQueriesInFlightForSet } from "../selectors";
 import { createReducer, IPluginState } from "../reducer";
@@ -576,6 +577,21 @@ describe("Action handlers", () => {
       });
     });
   });
+  describe("removeMatch", () => {
+    const { state, tr } = createInitialData();
+    const matcherResponse = createMatcherResponse(5, 10)
+    let newState = reducer(
+      tr,
+      {
+        ...state,
+        requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
+      },
+      requestMatchesSuccess(matcherResponse)
+    );
+    newState = reducer(tr, newState, removeMatch(matcherResponse.matches[0].matchId))
+    expect(newState.currentMatches).toEqual([])
+    expect(newState.decorations).toEqual(state.decorations)
+  })
   describe("setDebug", () => {
     it("should set the debug state", () => {
       const { state } = createInitialData();

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -368,7 +368,7 @@ describe("Action handlers", () => {
           requestId: exampleRequestId,
           blockId: createBlockId(0, 1, 25),
           message: "Too many requests",
-          categoryIds: ['example-category']
+          categoryIds: ["example-category"]
         })
       );
       expect(newState).toMatchObject({
@@ -578,20 +578,36 @@ describe("Action handlers", () => {
     });
   });
   describe("removeMatch", () => {
-    const { state, tr } = createInitialData();
-    const matcherResponse = createMatcherResponse(5, 10)
-    let newState = reducer(
-      tr,
-      {
-        ...state,
-        requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
-      },
-      requestMatchesSuccess(matcherResponse)
-    );
-    newState = reducer(tr, newState, removeMatch(matcherResponse.matches[0].matchId))
-    expect(newState.currentMatches).toEqual([])
-    expect(newState.decorations).toEqual(state.decorations)
-  })
+    it("should be a noop when matches aren't present", () => {
+      const { state, tr } = createInitialData();
+      const newState = reducer(
+        tr,
+        state,
+        removeMatch("id-does-not-exist")
+      );
+      expect(newState.currentMatches).toEqual(state.currentMatches);
+      expect(newState.decorations).toEqual(state.decorations);
+    });
+    it("should remove matches when they're present", () => {
+      const { state, tr } = createInitialData();
+      const matcherResponse = createMatcherResponse(5, 10);
+      let newState = reducer(
+        tr,
+        {
+          ...state,
+          requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
+        },
+        requestMatchesSuccess(matcherResponse)
+      );
+      newState = reducer(
+        tr,
+        newState,
+        removeMatch(matcherResponse.matches[0].matchId)
+      );
+      expect(newState.currentMatches).toEqual([]);
+      expect(newState.decorations).toEqual(state.decorations);
+    });
+  });
   describe("setDebug", () => {
     it("should set the debug state", () => {
       const { state } = createInitialData();


### PR DESCRIPTION
## What does this change?

Adds a prosemirror command to ignore a match. Ignored matches are removed from the plugin state, along with their decorations.

PR for the relevant UI to follow.

## How to test

There's no UI path to exercise this code yet, but the tests should give some confidence that it works as expected.

## How can we measure success?

Issuing the `ignoreMatches` command removes matches and match decorations from the plugin state.
