### PR TITLE
Logging param in createView.tsx should be optional

### DIFF
--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -17,7 +17,7 @@ interface IViewOptions {
   sidebarNode: Element;
   contactHref?: string;
   feedbackHref?: string;
-  logger: ILogger;
+  logger?: ILogger;
   onIgnoreMatch?: (match: IMatch) => void;
 }
 


### PR DESCRIPTION
## What does this change?

#88 broke our test page – the logging param in `createView.tsx` should be optional. This PR fixes that.

## How to test

`npm run watch` should work as expected.
