### PR TITLE
Bundle material-ui with the dist build, ignoring other modules

### DIFF
--- a/build/rollup.common.js
+++ b/build/rollup.common.js
@@ -1,3 +1,4 @@
+import alias from "@rollup/plugin-alias";
 import typescript from "rollup-plugin-typescript2";
 import postcss from "rollup-plugin-postcss";
 import sass from "@csstools/postcss-sass";
@@ -7,5 +8,12 @@ export const defaultPlugins = [
   postcss({
     extract: true,
     plugins: [sass]
-  })
+  }),
+  alias({
+    entries: {
+      react: "preact/compat",
+      "react-dom": "preact/compat",
+      '@material-ui/icons': '@material-ui/icons/esm',
+    }
+  }),
 ];

--- a/build/rollup.common.js
+++ b/build/rollup.common.js
@@ -1,3 +1,4 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 import alias from "@rollup/plugin-alias";
 import typescript from "rollup-plugin-typescript2";
 import postcss from "rollup-plugin-postcss";
@@ -9,6 +10,7 @@ export const defaultPlugins = [
     extract: true,
     plugins: [sass]
   }),
+  nodeResolve({ browser: true }),
   alias({
     entries: {
       react: "preact/compat",

--- a/build/rollup.config.build.js
+++ b/build/rollup.config.build.js
@@ -1,15 +1,39 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 import babel from "@rollup/plugin-babel";
-import replace from '@rollup/plugin-replace';
+import replace from "@rollup/plugin-replace";
 
 import { defaultPlugins } from "./rollup.common.js";
 
 const plugins = [
   ...defaultPlugins,
   babel(),
+  nodeResolve({ browser: true }),
   replace({
     "process.env.NODE_ENV": JSON.stringify("production")
-  }),
+  })
 ];
+
+const externalModules = [
+  "prosemirror-example-setup",
+  "prosemirror-history",
+  "prosemirror-keymap",
+  "prosemirror-menu",
+  "prosemirror-model",
+  "prosemirror-schema-basic",
+  "prosemirror-state",
+  "prosemirror-test-builder",
+  "prosemirror-view",
+  "preact",
+  "prosemirror-tables",
+  "prosemirror-utils",
+  "uuid",
+  "prop-types",
+  "react-is",
+  "hoist-non-react-statics"
+];
+
+const external = id =>
+  /(lodash)/.test(id) || externalModules.includes(id);
 
 export default [
   {
@@ -18,7 +42,8 @@ export default [
       file: "dist/index.js",
       format: "cjs"
     },
-    plugins
+    plugins,
+    external
   },
   {
     input: "src/ts/index.ts",
@@ -26,6 +51,7 @@ export default [
       file: "dist/index.m.js",
       format: "es"
     },
-    plugins
+    plugins,
+    external
   }
 ];

--- a/build/rollup.config.build.js
+++ b/build/rollup.config.build.js
@@ -1,4 +1,3 @@
-import { nodeResolve } from "@rollup/plugin-node-resolve";
 import babel from "@rollup/plugin-babel";
 import replace from "@rollup/plugin-replace";
 
@@ -7,7 +6,6 @@ import { defaultPlugins } from "./rollup.common.js";
 const plugins = [
   ...defaultPlugins,
   babel(),
-  nodeResolve({ browser: true }),
   replace({
     "process.env.NODE_ENV": JSON.stringify("production")
   })

--- a/build/rollup.config.dev.js
+++ b/build/rollup.config.dev.js
@@ -1,6 +1,4 @@
-import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
-import alias from "@rollup/plugin-alias";
 import replace from '@rollup/plugin-replace';
 import serve from "rollup-plugin-serve";
 
@@ -18,16 +16,9 @@ export default [
     },
     plugins: [
       ...defaultPlugins,
-      alias({
-        entries: {
-          react: "preact/compat",
-          "react-dom": "preact/compat"
-        }
-      }),
       replace({
         "process.env.NODE_ENV": JSON.stringify("development")
       }),
-      nodeResolve({ browser: true }),
       commonjs(),
       serve({ port: 5000, contentBase: "pages/dist" })
     ]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-env": "^7.2.0",
     "@csstools/postcss-sass": "^4.0.0",
     "@rollup/plugin-alias": "^3.1.1",
+    "@rollup/plugin-babel": "^5.0.2",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-replace": "^2.3.3",
@@ -77,7 +78,6 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
-    "@rollup/plugin-babel": "^5.0.2",
     "lodash": "^4.17.11",
     "preact": "^10.4.7",
     "prosemirror-tables": "^0.7.8",

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -5,7 +5,7 @@ import Block from "./icons/Block";
 import { IMatch } from "../interfaces/IMatch";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
-import { IconButton } from "@material-ui/core";
+import IconButton from "@material-ui/core/IconButton";
 
 interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;


### PR DESCRIPTION
## What does this change?

At the moment, `material-ui` is not bundled with our dist build. This means that our 'preact' aliasing doesn't work, which breaks the build.

This PR adds material UI directly to the bundle. It comes at a significant bundle cost – 67kb to ~458kb – which we should work to mitigate as a priority. It may be that material-ui is not a suitable candidate for inclusion.

## How to test

Consume this plugin via e.g. `npm link` in a consumer project. It should work as expected.
