### PR TITLE
Add an 'isActive' config param to the plugin, and remove decorations when the plugin is not active

### DIFF
--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -3,8 +3,7 @@ import {
   newHoverIdReceived,
   requestMatchesForDocument,
   selectMatch,
-  setDebugState,
-  setRequestMatchesOnDocModified,
+  setConfigValue,
   requestMatchesSuccess,
   requestError,
   requestMatchesForDirtyRanges,
@@ -18,7 +17,8 @@ import {
 import {
   PROSEMIRROR_TYPERIGHTER_ACTION,
   IPluginState,
-  IStateHoverInfo
+  IStateHoverInfo,
+  IPluginConfig
 } from "./state/reducer";
 import {
   IMatcherResponse,
@@ -131,32 +131,20 @@ export const selectMatchCommand = <TMatch extends IMatch>(
 };
 
 /**
- * Set the debug state. Enabling debug mode provides additional marks
- * to reveal dirty ranges and ranges sent for matching.
+ * Set a configuration value.
  */
-export const setDebugStateCommand = (debug: boolean): Command => (
-  state,
-  dispatch
-) => {
-  if (dispatch) {
-    dispatch(
-      state.tr.setMeta(PROSEMIRROR_TYPERIGHTER_ACTION, setDebugState(debug))
-    );
-  }
-  return true;
-};
-
-/**
- * When enabled, the plugin will queue match requests as soon as the document is modified.
- */
-export const setRequestOnDocModifiedState = (
-  requestMatchesOnDocModified: boolean
+export const setConfigValueCommand = <
+  ConfigKey extends keyof IPluginConfig,
+  ConfigValue extends IPluginConfig[ConfigKey]
+>(
+  key: ConfigKey,
+  value: ConfigValue
 ): Command => (state, dispatch) => {
   if (dispatch) {
     dispatch(
       state.tr.setMeta(
         PROSEMIRROR_TYPERIGHTER_ACTION,
-        setRequestMatchesOnDocModified(requestMatchesOnDocModified)
+        setConfigValue(key, value)
       )
     );
   }
@@ -341,8 +329,7 @@ export const createBoundCommands = <TMatch extends IMatch>(
     ),
     indicateHover: bindCommand(indicateHoverCommand),
     stopHover: bindCommand(stopHoverCommand),
-    setDebugState: bindCommand(setDebugStateCommand),
-    setRequestOnDocModified: bindCommand(setRequestOnDocModifiedState),
+    setConfigValue: bindCommand(setConfigValueCommand),
     applyMatcherResponse: bindCommand(applyMatcherResponseCommand),
     applyRequestError: bindCommand(applyRequestErrorCommand),
     applyRequestComplete: bindCommand(applyRequestCompleteCommand)

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -80,7 +80,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
         [] as IRange[]
       );
       if (newDirtiedRanges.length) {
-        if (newPluginState.requestMatchesOnDocModified) {
+        if (newPluginState.config.requestMatchesOnDocModified) {
           // We wait a tick here, as applyNewDirtiedRanges must run
           // before the newly dirtied range is available in the state.
           // @todo -- this is a bit of a hack, it can be done better.

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -2,10 +2,8 @@ import { applyNewDirtiedRanges } from "./state/actions";
 import { IPluginState, PROSEMIRROR_TYPERIGHTER_ACTION } from "./state/reducer";
 import { createInitialState, createReducer } from "./state/reducer";
 import { selectNewBlockInFlight } from "./state/selectors";
-import {
-  DECORATION_ATTRIBUTE_ID
-} from "./utils/decoration";
-import { EditorView } from "prosemirror-view";
+import { DECORATION_ATTRIBUTE_ID } from "./utils/decoration";
+import { EditorView, DecorationSet } from "prosemirror-view";
 import { Plugin, Transaction, EditorState, PluginKey } from "prosemirror-state";
 import { expandRangesToParentBlockNode } from "./utils/range";
 import { getReplaceStepRangesFromTransaction } from "./utils/prosemirror";
@@ -21,7 +19,7 @@ import { indicateHoverCommand, stopHoverCommand } from "./commands";
 
 export type ExpandRanges = (ranges: IRange[], doc: Node<any>) => IRange[];
 
-interface IPluginOptions<TMatch extends IMatch> {
+export interface IPluginOptions<TMatch extends IMatch = IMatch> {
   /**
    * A function that receives ranges that have been dirtied since the
    * last request, and returns the new ranges to find matches for. The
@@ -34,6 +32,11 @@ interface IPluginOptions<TMatch extends IMatch> {
    * The initial set of matches to apply to the document, if any.
    */
   matches?: TMatch[];
+
+  /**
+   * Is the plugin active as it starts?
+   */
+  isActive?: boolean;
 }
 
 /**
@@ -47,18 +50,23 @@ interface IPluginOptions<TMatch extends IMatch> {
 const createTyperighterPlugin = <TMatch extends IMatch>(
   options: IPluginOptions<TMatch> = {}
 ) => {
-  const { expandRanges = expandRangesToParentBlockNode, matches = [] } = options;
+  const {
+    expandRanges = expandRangesToParentBlockNode,
+    matches = [],
+    isActive
+  } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TMatch>;
 
   // Set up our store, which we'll use to notify consumer code of state updates.
   const store = new Store();
+  const emptyDecorationSet = new DecorationSet();
   const reducer = createReducer(expandRanges);
 
   const plugin: Plugin = new Plugin({
     key: new PluginKey("prosemirror-typerighter"),
     state: {
-      init: (_, { doc }) => createInitialState(doc, matches),
+      init: (_, { doc }) => createInitialState(doc, matches, isActive),
       apply(tr: Transaction, state: TPluginState): TPluginState {
         // We use the reducer pattern to handle state transitions.
         return reducer(tr, state, tr.getMeta(PROSEMIRROR_TYPERIGHTER_ACTION));
@@ -106,7 +114,10 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     },
     props: {
       decorations: state => {
-        return plugin.getState(state).decorations;
+        const pluginState = plugin.getState(state);
+        return pluginState.config.isActive
+          ? pluginState.decorations
+          : emptyDecorationSet;
       },
       handleDOMEvents: {
         mouseover: (view: EditorView, event: Event) => {

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -77,8 +77,10 @@ const createView = ({
     <div className="Sidebar__section">
       <Controls
         store={store}
-        setDebugState={commands.setConfigValue}
-        setRequestOnDocModified={commands.setConfigValue}
+        setDebugState={value => commands.setConfigValue("debug", value)}
+        setRequestOnDocModified={value =>
+          commands.setConfigValue("requestMatchesOnDocModified", value)
+        }
         requestMatchesForDocument={commands.requestMatchesForDocument}
         fetchCategories={matcherService.fetchCategories}
         getCurrentCategories={matcherService.getCurrentCategories}

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -77,8 +77,8 @@ const createView = ({
     <div className="Sidebar__section">
       <Controls
         store={store}
-        setDebugState={commands.setDebugState}
-        setRequestOnDocModified={commands.setRequestOnDocModified}
+        setDebugState={commands.setConfigValue}
+        setRequestOnDocModified={commands.setConfigValue}
         requestMatchesForDocument={commands.requestMatchesForDocument}
         fetchCategories={matcherService.fetchCategories}
         getCurrentCategories={matcherService.getCurrentCategories}

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -4,7 +4,7 @@ import {
   IRange,
   IMatch
 } from "../interfaces/IMatch";
-import { IStateHoverInfo } from "./reducer";
+import { IStateHoverInfo, IPluginConfig } from "./reducer";
 
 /**
  * Action types.
@@ -19,8 +19,7 @@ export const NEW_HOVER_ID = "NEW_HOVER_ID" as const;
 export const SELECT_MATCH = "SELECT_MATCH" as const;
 export const REMOVE_MATCH = "REMOVE_MATCH" as const;
 export const APPLY_NEW_DIRTY_RANGES = "HANDLE_NEW_DIRTY_RANGES" as const;
-export const SET_DEBUG_STATE = "SET_DEBUG_STATE" as const;
-export const SET_REQUEST_MATCHES_ON_DOC_MODIFIED = "SET_REQUEST_MATCHES_ON_DOC_MODIFIED" as const;
+export const SET_CONFIG_VALUE = "SET_CONFIG_VALUE" as const;
 
 /**
  * Action creators.
@@ -95,29 +94,23 @@ export const selectMatch = (matchId: string) => ({
 });
 export type ActionSelectMatch = ReturnType<typeof selectMatch>;
 
-export const setDebugState = (debug: boolean) => ({
-  type: SET_DEBUG_STATE,
-  payload: { debug }
-});
-export type ActionSetDebugState = ReturnType<typeof setDebugState>;
-
-export const setRequestMatchesOnDocModified = (
-  requestMatchesOnDocModified: boolean
+export const setConfigValue = <
+  ConfigKey extends keyof IPluginConfig,
+  ConfigValue extends IPluginConfig[ConfigKey]
+>(
+  key: ConfigKey,
+  value: ConfigValue
 ) => ({
-  type: SET_REQUEST_MATCHES_ON_DOC_MODIFIED,
-  payload: { requestMatchesOnDocModified }
+  type: SET_CONFIG_VALUE,
+  payload: { key, value }
 });
-export type ActionSetRequestMatchesOnDocModified = ReturnType<
-  typeof setRequestMatchesOnDocModified
->;
+export type ActionSetConfigValue = ReturnType<typeof setConfigValue>;
 
 export const removeMatch = (id: string) => ({
   type: REMOVE_MATCH,
   payload: { id }
-})
-export type ActionRemoveMatch = ReturnType<
-  typeof removeMatch
->;
+});
+export type ActionRemoveMatch = ReturnType<typeof removeMatch>;
 
 export type Action<TMatch extends IMatch> =
   | ActionNewHoverIdReceived
@@ -128,6 +121,5 @@ export type Action<TMatch extends IMatch> =
   | ActionRequestComplete
   | ActionSelectMatch
   | ActionHandleNewDirtyRanges
-  | ActionSetDebugState
-  | ActionSetRequestMatchesOnDocModified
-  | ActionRemoveMatch
+  | ActionSetConfigValue
+  | ActionRemoveMatch;

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -153,7 +153,7 @@ export const createInitialState = <TMatch extends IMatch>(
     debug: false,
     requestMatchesOnDocModified: false
   },
-  decorations: DecorationSet.create(doc, []),
+  decorations: DecorationSet.create(doc, createDecorationsForMatches(matches)),
   dirtiedRanges: [],
   currentMatches: matches,
   selectedMatch: undefined,

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -101,8 +101,8 @@ export interface IBlocksInFlightState {
 }
 
 export interface IPluginConfig {
-  // Is the plugin enabled – e.g. should it display matches and respond to commands?
-  isTyperighterOn: boolean;
+  // Is the plugin active – e.g. should it display matches and respond to commands?
+  isActive: boolean;
   // Should we trigger a request when the document is modified?
   requestMatchesOnDocModified: boolean;
   // Is the plugin in debug mode? Debug mode adds marks to show dirtied
@@ -145,10 +145,11 @@ export const PROSEMIRROR_TYPERIGHTER_ACTION = "PROSEMIRROR_TYPERIGHTER_ACTION";
  */
 export const createInitialState = <TMatch extends IMatch>(
   doc: Node,
-  matches: TMatch[] = []
+  matches: TMatch[] = [],
+  active: boolean = true
 ): IPluginState<TMatch> => ({
   config: {
-    isTyperighterOn: true,
+    isActive: active,
     debug: false,
     requestMatchesOnDocModified: false
   },

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -102,7 +102,7 @@ export interface IBlocksInFlightState {
 
 export interface IPluginConfig {
   // Is the plugin enabled – e.g. should it display matches and respond to commands?
-  enabled: boolean;
+  isTyperighterOn: boolean;
   // Should we trigger a request when the document is modified?
   requestMatchesOnDocModified: boolean;
   // Is the plugin in debug mode? Debug mode adds marks to show dirtied
@@ -148,7 +148,7 @@ export const createInitialState = <TMatch extends IMatch>(
   matches: TMatch[] = []
 ): IPluginState<TMatch> => ({
   config: {
-    enabled: true,
+    isTyperighterOn: true,
     debug: false,
     requestMatchesOnDocModified: false
   },

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -87,7 +87,10 @@ describe("Action handlers", () => {
         )
       ).toEqual({
         ...state,
-        debug: true,
+        config: {
+          ...state.config,
+          debug: true
+        },
         dirtiedRanges: [],
         decorations: new DecorationSet().add(tr.doc, [
           createDebugDecorationFromRange({ from: 1, to: 22 }, false)
@@ -615,18 +618,30 @@ describe("Action handlers", () => {
     it("should set a config value", () => {
       const { state } = createInitialData();
       expect(
-        reducer(new Transaction(createDoc), state, setConfigValue("debug", true))
-      ).toEqual({ ...state, debug: true });
+        reducer(
+          new Transaction(createDoc),
+          state,
+          setConfigValue("debug", true)
+        )
+      ).toEqual({ ...state, config: { ...state.config, debug: true } });
     });
     it("should not accept incorrect config keys", () => {
       const { state } = createInitialData();
-      // @ts-expect-error
-      reducer(new Transaction(createDoc), state, setConfigValue("not-a-key", true))
+      reducer(
+        new Transaction(createDoc),
+        state,
+        // @ts-expect-error
+        setConfigValue("not-a-key", true)
+      );
     });
     it("should not accept incorrect config values", () => {
       const { state } = createInitialData();
-      // @ts-expect-error
-      reducer(new Transaction(createDoc), state, setConfigValue("debug", "true"))
+      reducer(
+        new Transaction(createDoc),
+        state,
+        // @ts-expect-error
+        setConfigValue("debug", "true")
+      );
     });
   });
 });

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -2,7 +2,7 @@ import { Transaction } from "prosemirror-state";
 import { DecorationSet } from "prosemirror-view";
 import {
   selectMatch,
-  setDebugState,
+  setConfigValue,
   applyNewDirtiedRanges,
   requestMatchesForDocument,
   requestError,
@@ -79,7 +79,7 @@ describe("Action handlers", () => {
           tr,
           {
             ...state,
-            debug: true,
+            config: { ...state.config, debug: true },
             dirtiedRanges: [{ from: 5, to: 10 }],
             requestPending: true
           },
@@ -109,7 +109,7 @@ describe("Action handlers", () => {
         tr,
         {
           ...state,
-          debug: true,
+          config: { ...state.config, debug: true },
           dirtiedRanges: [{ from: 5, to: 10 }],
           decorations: new DecorationSet().add(tr.doc, [
             createDebugDecorationFromRange({ from: 1, to: 3 })
@@ -134,7 +134,7 @@ describe("Action handlers", () => {
         tr,
         {
           ...state,
-          debug: true,
+          config: { ...state.config, debug: true },
           dirtiedRanges: [
             { from: 5, to: 10 },
             { from: 28, to: 35 }
@@ -380,12 +380,14 @@ describe("Action handlers", () => {
           }
         ],
         decorations: new DecorationSet(),
-        requestErrors: [{
-          requestId: exampleRequestId,
-          blockId: createBlockId(0, 1, 25),
-          message: "Too many requests",
-          categoryIds: ['example-category']
-        } as IMatchRequestError]
+        requestErrors: [
+          {
+            requestId: exampleRequestId,
+            blockId: createBlockId(0, 1, 25),
+            message: "Too many requests",
+            categoryIds: ["example-category"]
+          } as IMatchRequestError
+        ]
       });
     });
   });
@@ -585,11 +587,7 @@ describe("Action handlers", () => {
   describe("removeMatch", () => {
     it("should be a noop when matches aren't present", () => {
       const { state, tr } = createInitialData();
-      const newState = reducer(
-        tr,
-        state,
-        removeMatch("id-does-not-exist")
-      );
+      const newState = reducer(tr, state, removeMatch("id-does-not-exist"));
       expect(newState.currentMatches).toEqual(state.currentMatches);
       expect(newState.decorations).toEqual(state.decorations);
     });
@@ -613,12 +611,22 @@ describe("Action handlers", () => {
       expect(newState.decorations).toEqual(state.decorations);
     });
   });
-  describe("setDebug", () => {
-    it("should set the debug state", () => {
+  describe("setConfigValue", () => {
+    it("should set a config value", () => {
       const { state } = createInitialData();
       expect(
-        reducer(new Transaction(createDoc), state, setDebugState(true))
+        reducer(new Transaction(createDoc), state, setConfigValue("debug", true))
       ).toEqual({ ...state, debug: true });
+    });
+    it("should not accept incorrect config keys", () => {
+      const { state } = createInitialData();
+      // @ts-expect-error
+      reducer(new Transaction(createDoc), state, setConfigValue("not-a-key", true))
+    });
+    it("should not accept incorrect config values", () => {
+      const { state } = createInitialData();
+      // @ts-expect-error
+      reducer(new Transaction(createDoc), state, setConfigValue("debug", "true"))
     });
   });
 });

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -1,8 +1,10 @@
 import { EditorState } from "prosemirror-state";
-import { EditorView } from "prosemirror-view";
+import { EditorView, DecorationSet } from "prosemirror-view";
 
 import { createDoc, p } from "./helpers/prosemirror";
-import createTyperighterPlugin from "../createTyperighterPlugin";
+import createTyperighterPlugin, {
+  IPluginOptions
+} from "../createTyperighterPlugin";
 import { createMatch } from "./helpers/fixtures";
 import { createBoundCommands } from "../commands";
 import { IMatcherResponse } from "../interfaces/IMatch";
@@ -11,30 +13,37 @@ import { getBlocksFromDocument } from "../utils/prosemirror";
 const doc = createDoc(p("Example text to check"), p("More text to check"));
 const blocks = getBlocksFromDocument(doc);
 const matches = [createMatch(1)];
-const { plugin, getState, store } = createTyperighterPlugin({
-  matches
-});
-const state = EditorState.create({
-  doc,
-  plugins: [plugin]
-});
-const editorElement = document.createElement("div");
-const view = new EditorView(editorElement, { state });
-const commands = createBoundCommands(view, getState);
+
+const createPlugin = (opts?: IPluginOptions) => {
+  const { plugin, getState, store } = createTyperighterPlugin({
+    matches,
+    ...opts
+  });
+  const state = EditorState.create({
+    doc,
+    plugins: [plugin]
+  });
+  const editorElement = document.createElement("div");
+  const view = new EditorView(editorElement, { state });
+  const commands = createBoundCommands(view, getState);
+  return { plugin, getState, store, state, view, commands };
+};
 
 describe("createTyperighterPlugin", () => {
   let now: () => number;
   beforeAll(() => {
-    now = Date.now
+    now = Date.now;
     Date.now = () => 1337;
-  })
+  });
   afterAll(() => {
     Date.now = now;
-  })
+  });
   it("should add matches passed to the plugin to the plugin state when the plugin is constructed", () => {
+    const { getState, state } = createPlugin();
     expect(getState(state).currentMatches).toEqual(matches);
   });
   it("should trigger onMatches when matches are found in the document", () => {
+    const { store, commands } = createPlugin();
     const storeSpy = jest.fn();
     store.on("STORE_EVENT_NEW_MATCHES", storeSpy);
     const response: IMatcherResponse = {
@@ -75,5 +84,36 @@ describe("createTyperighterPlugin", () => {
         }
       ]
     ]);
+  });
+
+  it("should not show decorations when plugin is inactive", () => {
+    const { store, commands, view, getState } = createPlugin({
+      isActive: false
+    });
+    const storeSpy = jest.fn();
+    store.on("STORE_EVENT_NEW_MATCHES", storeSpy);
+    const response: IMatcherResponse = {
+      blocks,
+      categoryIds: ["cat1"],
+      matches: [
+        {
+          ...blocks[0],
+          matchId: "matchId",
+          matchedText: blocks[0].text,
+          message: "Example message",
+          category: {
+            id: "cat1",
+            name: "Category 1",
+            colour: "puce"
+          },
+          matchContext: "bigger block of text"
+        }
+      ],
+      requestId: "reqId"
+    };
+    commands.requestMatchesForDocument("docId", ["cat1"]);
+    commands.applyMatcherResponse(response);
+    const decorations = getState(view.state).decorations;
+    expect(decorations).toEqual(new DecorationSet());
   });
 });

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -1,11 +1,9 @@
 import { EditorState } from "prosemirror-state";
-import { EditorView, DecorationSet } from "prosemirror-view";
+import { EditorView } from "prosemirror-view";
 
 import {
   createDoc,
   p,
-  getDecorationsForDoc,
-  getDecorationSpecsFromSet,
   getDecorationSpecsFromDoc,
   getDecorationSpecs
 } from "./helpers/prosemirror";

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -145,8 +145,11 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
   return {
     tr,
     state: {
-      debug: false,
-      requestMatchesOnDocModified: true,
+      config: {
+        debug: false,
+        requestMatchesOnDocModified: true,
+        isActive: true
+      },
       currentThrottle: 100,
       initialThrottle: 100,
       maxThrottle: 1000,

--- a/src/ts/test/helpers/prosemirror.ts
+++ b/src/ts/test/helpers/prosemirror.ts
@@ -1,6 +1,12 @@
 import { Schema } from "prosemirror-model";
 import { marks, nodes } from "prosemirror-schema-basic";
 import { builders } from "prosemirror-test-builder";
+import {
+  EditorView,
+  DecorationSet,
+  InlineDecorationSpec,
+  Decoration
+} from "prosemirror-view";
 
 const schema = new Schema({
   nodes,
@@ -15,3 +21,21 @@ const build = builders(schema, {
 
 export const createDoc = build.doc;
 export const p = build.p;
+
+/**
+ * We cannot compare document decorations to plugin decorations, as the
+ * .ProseMirror-widget class is applied – but we can compare their specs.
+ * We compare sets here because the order is arbitrary.
+ */
+export const getDecorationSpecsFromDoc = (
+  view: EditorView
+): Set<InlineDecorationSpec> =>
+  getDecorationSpecsFromSet(view.someProp("decorations", f => f(view.state)));
+
+export const getDecorationSpecsFromSet = (
+  set: DecorationSet
+): Set<InlineDecorationSpec> => new Set(set.find().map(_ => _.spec));
+
+export const getDecorationSpecs = (
+  decorations: Decoration[]
+): Set<InlineDecorationSpec> => new Set(decorations.map(_ => _.spec));


### PR DESCRIPTION
## What does this change?

Adds an 'isActive' config param to the plugin state. This removes decorations from the document when it's not `true`.

It anticipates a UI change to allow the active state to be toggled, which will change this param and respond to it by hiding the sidebar UI.

## How to test

There's no UI to test for this yet, but there are tests in the `createTyperighterPlugin` spec that test to check that decorations are applied to the view, or not.

## How can we measure success?

We've an API to set the plugin to an active/inactive state.

## Dev notes

We have a few different configuration params, and PR adds another one, so I've grouped them into a `config` object and added a single, typesafe setter to reduce code duplication.
