### PR TITLE
Toggle on off

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -42,6 +42,10 @@
   justify-content: space-between;
 }
 
+.Sidebar__header-icon {
+  font-size: 1.25rem;
+}
+
 .Sidebar__list {
   margin: 0;
   padding: 0;

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -39,6 +39,11 @@
   position: relative;
   flex-shrink: 0.2;
   font-weight: bold;
+  justify-content: space-between;
+}
+
+.Sidebar__header-close-button {
+  
 }
 
 .Sidebar__list {

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -18,6 +18,10 @@
   font-size: $font-size-base;
 }
 
+.Sidebar__section-closed {
+  background: none;
+}
+
 .Sidebar__container + .Sidebar__container {
   margin-top: $gutter-width;
 }
@@ -26,6 +30,12 @@
   position: relative;
   padding: $gutter-width;
   border-bottom: 1px solid $sidebar-border-color;
+}
+
+.Sidebar__header-container-closed {
+  border: 0;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .Sidebar__header-contact {
@@ -40,10 +50,6 @@
   flex-shrink: 0.2;
   font-weight: bold;
   justify-content: space-between;
-}
-
-.Sidebar__header-icon {
-  font-size: 1.25rem;
 }
 
 .Sidebar__list {

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -18,8 +18,9 @@
   font-size: $font-size-base;
 }
 
-.Sidebar__section-closed {
+.Sidebar__section--is-closed {
   background: none;
+  border: 0;
 }
 
 .Sidebar__container + .Sidebar__container {
@@ -32,7 +33,7 @@
   border-bottom: 1px solid $sidebar-border-color;
 }
 
-.Sidebar__header-container-closed {
+.Sidebar__header-container--is-closed {
   border: 0;
   display: flex;
   justify-content: flex-end;

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -35,15 +35,11 @@
 
 .Sidebar__header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   position: relative;
   flex-shrink: 0.2;
   font-weight: bold;
   justify-content: space-between;
-}
-
-.Sidebar__header-close-button {
-  
 }
 
 .Sidebar__list {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -87,11 +87,6 @@ hr {
   outline: none;
 }
 
-.Button__light {
-  font-size: $font-size-small;
-  color: grey;
-}
-
 .MatchWidget {
   background-color: white;
   display: block;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -70,7 +70,7 @@ hr {
 }
 
 .Button {
-  padding: 1px 4px;
+  padding: 4px 6px;
   border: 1px solid lightgrey;
   border-radius: 3px;
   font-size: $font-size-base;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -87,6 +87,11 @@ hr {
   outline: none;
 }
 
+.Button__light {
+  font-size: $font-size-small;
+  color: grey;
+}
+
 .MatchWidget {
   background-color: white;
   display: block;

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -4,7 +4,8 @@ import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
 import { IMatch, ICategory } from "../interfaces/IMatch";
 import { selectHasError } from "../state/selectors";
-import { Button } from "@material-ui/core";
+// import IconButton from "@material-ui/core/IconButton";
+// import CloseIcon from "@material-ui/icons/Close";
 
 interface IProps {
   store: Store<IMatch>;
@@ -60,9 +61,16 @@ class Controls extends Component<IProps, IState> {
             >
               Check document
             </button>
-            <Button
+            <button
+              type="button"
+              className="Button Button__light"
               onClick={this.props.deactivate}
-            >Switch off</Button>
+            >Close</button>
+            {/* <IconButton
+              onClick={this.props.deactivate}
+            >
+              <CloseIcon fontSize="large" />
+            </IconButton> */}
           </div>
         </div>
       

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -63,6 +63,7 @@ class Controls extends Component<IProps, IState> {
             </button>
           
             <IconButton
+            className="Sidebar__header-icon"
               aria-label="close Typerighter"
               onClick={this.props.deactivate}
             >

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -63,7 +63,7 @@ class Controls extends Component<IProps, IState> {
             </button>
           
             <IconButton
-            className="Sidebar__header-icon"
+              size="small"
               aria-label="close Typerighter"
               onClick={this.props.deactivate}
             >

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -4,8 +4,8 @@ import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
 import { IMatch, ICategory } from "../interfaces/IMatch";
 import { selectHasError } from "../state/selectors";
-// import IconButton from "@material-ui/core/IconButton";
-// import CloseIcon from "@material-ui/icons/Close";
+import IconButton from "@material-ui/core/IconButton";
+import CloseIcon from "./icons/CloseIcon";
 
 interface IProps {
   store: Store<IMatch>;
@@ -61,16 +61,13 @@ class Controls extends Component<IProps, IState> {
             >
               Check document
             </button>
-            <button
-              type="button"
-              className="Button Button__light"
-              onClick={this.props.deactivate}
-            >Close</button>
-            {/* <IconButton
+          
+            <IconButton
+              aria-label="close Typerighter"
               onClick={this.props.deactivate}
             >
-              <CloseIcon fontSize="large" />
-            </IconButton> */}
+              <CloseIcon/>
+            </IconButton>
           </div>
         </div>
       

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -4,6 +4,7 @@ import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
 import { IMatch, ICategory } from "../interfaces/IMatch";
 import { selectHasError } from "../state/selectors";
+import { Button } from "@material-ui/core";
 
 interface IProps {
   store: Store<IMatch>;
@@ -15,6 +16,7 @@ interface IProps {
   addCategory: (id: string) => void;
   removeCategory: (id: string) => void;
   feedbackHref?: string;
+  deactivate: () => void;
 }
 
 interface IState {
@@ -34,7 +36,7 @@ class Controls extends Component<IProps, IState> {
     allCategories: [],
     currentCategories: [],
     isLoadingCategories: false,
-    pluginState: undefined
+    pluginState: undefined,
   } as IState;
   public componentWillMount() {
     this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
@@ -58,6 +60,9 @@ class Controls extends Component<IProps, IState> {
             >
               Check document
             </button>
+            <Button
+              onClick={this.props.deactivate}
+            >Switch off</Button>
           </div>
         </div>
       

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -31,6 +31,7 @@ class Results extends Component<
 > {
   public componentWillMount() {
     this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNewState);
+    this.setState({ pluginState: this.props.store.getState() });
   }
 
   public render() {

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -1,0 +1,64 @@
+import { h, Fragment } from "preact";
+import Store from ".././state/store";
+import Results from "./Results";
+import Controls from "./Controls";
+import { Commands } from ".././commands";
+import { IMatch } from ".././interfaces/IMatch";
+import { MatcherService } from "..";
+import { Button } from "@material-ui/core";
+import { useState } from "preact/hooks";
+
+interface IProps {
+  store: Store<IMatch>;
+  matcherService: MatcherService<IMatch>;
+  commands: Commands;
+  contactHref?: string;
+  feedbackHref?: string;
+  active: boolean;
+}
+
+const Sidebar = ({
+  store,
+  matcherService,
+  commands,
+  contactHref,
+  feedbackHref,
+  active
+}: IProps) => {
+  const [isActive, setIsActive] = useState(active);
+  return (
+    <div className="Sidebar__section">
+      {isActive ? (
+        <Fragment>
+          <Controls
+            store={store}
+            setDebugState={value => commands.setConfigValue("debug", value)}
+            setRequestOnDocModified={value =>
+              commands.setConfigValue("requestMatchesOnDocModified", value)
+            }
+            requestMatchesForDocument={commands.requestMatchesForDocument}
+            fetchCategories={matcherService.fetchCategories}
+            getCurrentCategories={matcherService.getCurrentCategories}
+            addCategory={matcherService.addCategory}
+            removeCategory={matcherService.removeCategory}
+            feedbackHref={feedbackHref}
+            deactivate={() => setIsActive(false)}
+          />
+          <Results
+            store={store}
+            applySuggestions={commands.applySuggestions}
+            applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
+            selectMatch={commands.selectMatch}
+            indicateHover={commands.indicateHover}
+            stopHover={commands.stopHover}
+            contactHref={contactHref}
+          />
+        </Fragment>
+      ) : (
+        <Button onClick={() => setIsActive(true)}>Switch on Typerighter</Button>
+      )}
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import Controls from "./Controls";
 import { Commands } from ".././commands";
 import { IMatch } from ".././interfaces/IMatch";
 import { MatcherService } from "..";
-import { Button } from "@material-ui/core";
 import { useState } from "preact/hooks";
 
 interface IProps {
@@ -55,7 +54,13 @@ const Sidebar = ({
           />
         </Fragment>
       ) : (
-        <Button onClick={() => setIsActive(true)}>Switch on Typerighter</Button>
+        <button
+          type="button"
+          className="Button"
+          onClick={() => setIsActive(true)}
+        >
+          Open Typerighter
+        </button>
       )}
     </div>
   );

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -54,13 +54,19 @@ const Sidebar = ({
           />
         </Fragment>
       ) : (
-        <button
-          type="button"
-          className="Button"
-          onClick={() => setIsActive(true)}
-        >
-          Open Typerighter
-        </button>
+        <div className="Sidebar__section-closed">
+          <div className="Sidebar__header-container Sidebar__header-container-closed">
+            <div className="Sidebar__header">
+              <button
+                type="button"
+                className="Button"
+                onClick={() => setIsActive(true)}
+              >
+                Open Typerighter
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/ts/components/icons/CloseIcon.tsx
+++ b/src/ts/components/icons/CloseIcon.tsx
@@ -1,0 +1,16 @@
+import { h } from "preact";
+
+import SvgIcon, { SvgIconTypeMap } from "@material-ui/core/SvgIcon";
+import { DefaultComponentProps } from "@material-ui/core/OverridableComponent";
+
+/**
+ * We'd prefer to source this icon directly from material-ui, but
+ * a problem with the preact integration prevents this for now. In
+ * the mean time, we can wrap icons in the `SvgIcon` wrapper and
+ * copy their paths manually.
+ */
+export default (props: DefaultComponentProps<SvgIconTypeMap<{}, "svg">>) => (
+  <SvgIcon {...props} width="100%" height="100%" viewBox="0 0 24 24">
+    <path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
+  </SvgIcon>
+);

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -53,7 +53,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
   const {
     expandRanges = expandRangesToParentBlockNode,
     matches = [],
-    isActive
+    isActive = true,
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TMatch>;
@@ -66,7 +66,11 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
   const plugin: Plugin = new Plugin({
     key: new PluginKey("prosemirror-typerighter"),
     state: {
-      init: (_, { doc }) => createInitialState(doc, matches, isActive),
+      init: (_, { doc }) => {
+        const initialState = createInitialState(doc, matches, isActive);
+        store.emit(STORE_EVENT_NEW_STATE, initialState);
+        return initialState;
+      },
       apply(tr: Transaction, state: TPluginState): TPluginState {
         // We use the reducer pattern to handle state transitions.
         return reducer(tr, state, tr.getMeta(PROSEMIRROR_TYPERIGHTER_ACTION));

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -79,7 +79,6 @@ const createView = ({
       commands={commands}
       contactHref={contactHref}
       feedbackHref={feedbackHref}
-      active={false}
     />,
     sidebarNode
   );

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -2,12 +2,11 @@ import { EditorView } from "prosemirror-view";
 import { h, render } from "preact";
 import MatchOverlay from "./components/MatchOverlay";
 import Store from "./state/store";
-import Results from "./components/Results";
-import Controls from "./components/Controls";
 import { Commands } from "./commands";
 import { IMatch } from "./interfaces/IMatch";
 import { MatcherService } from ".";
 import { ILogger, consoleLogger } from "./utils/logger";
+import Sidebar from "./components/Sidebar";
 
 interface IViewOptions {
   view: EditorView;
@@ -74,30 +73,14 @@ const createView = ({
   );
 
   render(
-    <div className="Sidebar__section">
-      <Controls
-        store={store}
-        setDebugState={value => commands.setConfigValue("debug", value)}
-        setRequestOnDocModified={value =>
-          commands.setConfigValue("requestMatchesOnDocModified", value)
-        }
-        requestMatchesForDocument={commands.requestMatchesForDocument}
-        fetchCategories={matcherService.fetchCategories}
-        getCurrentCategories={matcherService.getCurrentCategories}
-        addCategory={matcherService.addCategory}
-        removeCategory={matcherService.removeCategory}
-        feedbackHref={feedbackHref}
-      />
-      <Results
-        store={store}
-        applySuggestions={commands.applySuggestions}
-        applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
-        selectMatch={commands.selectMatch}
-        indicateHover={commands.indicateHover}
-        stopHover={commands.stopHover}
-        contactHref={contactHref}
-      />
-    </div>,
+    <Sidebar 
+      store={store}
+      matcherService={matcherService}
+      commands={commands}
+      contactHref={contactHref}
+      feedbackHref={feedbackHref}
+      active={false}
+    />,
     sidebarNode
   );
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
We want users to be able to turn Typerighter on and off in the UI so that they can work without distractions. This PR creates that functionality in the UI and links to state, following on from the work in this PR: https://github.com/guardian/prosemirror-typerighter/pull/91.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run locally and see the button to turn on Typerighter (it is defaulted to 'off' until linked with the store), and then click 'close' icon on the open sidebar to toggle.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The Typerighter UI is hidden when the 'close' icon is clicked and shown when 'open' is clicked.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Before 
![image](https://user-images.githubusercontent.com/15648334/89669839-0c5a4700-d8d8-11ea-84b4-0f965792c380.png)

### After 
![pm-on-off](https://user-images.githubusercontent.com/15648334/89885314-cb597f80-dbc2-11ea-9864-9bfd81767f6f.gif)

#### Decorations hidden on close
![decs-on-off](https://user-images.githubusercontent.com/15648334/89894557-2e9ede00-dbd2-11ea-8e1b-7e0b5ff96d24.gif)



