### PR TITLE
Add an 'ignore matches' predicate

### DIFF
--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -64,7 +64,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
           <div className="MatchWidget__type">
             <span
               className="MatchWidget__color-swatch"
-              style={{ backgroundColor: getColourForMatch(match, matchColours, false).backgroundColour }}
+              style={{ backgroundColor: getColourForMatch(match, matchColours, false).borderColour }}
             ></span>
             {category.name}
           </div>

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -59,7 +59,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     expandRanges = expandRangesToParentBlockNode,
     matches = [],
     isActive = true,
-    ignoreMatch = () => true
+    ignoreMatch = () => false
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TMatch>;

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -59,7 +59,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     expandRanges = expandRangesToParentBlockNode,
     matches = [],
     isActive = true,
-    ignoreMatch
+    ignoreMatch = () => true
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TMatch>;
@@ -67,7 +67,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
   // Set up our store, which we'll use to notify consumer code of state updates.
   const store = new Store();
   const emptyDecorationSet = new DecorationSet();
-  const reducer = createReducer(expandRanges);
+  const reducer = createReducer(expandRanges, ignoreMatch);
 
   const plugin: Plugin = new Plugin({
     key: new PluginKey("prosemirror-typerighter"),

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -39,7 +39,7 @@ export interface IPluginOptions<TMatch extends IMatch = IMatch> {
   isActive?: boolean;
 
   /**
-   * Ignore matches when this predicate returns false.
+   * Ignore matches when this predicate returns true.
    */
   ignoreMatch?: IIgnoreMatch;
 }

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -1,5 +1,5 @@
 import { applyNewDirtiedRanges } from "./state/actions";
-import { IPluginState, PROSEMIRROR_TYPERIGHTER_ACTION } from "./state/reducer";
+import { IPluginState, PROSEMIRROR_TYPERIGHTER_ACTION, IIgnoreMatch } from "./state/reducer";
 import { createInitialState, createReducer } from "./state/reducer";
 import { selectNewBlockInFlight } from "./state/selectors";
 import { DECORATION_ATTRIBUTE_ID } from "./utils/decoration";
@@ -37,6 +37,11 @@ export interface IPluginOptions<TMatch extends IMatch = IMatch> {
    * Is the plugin active as it starts?
    */
   isActive?: boolean;
+
+  /**
+   * Ignore matches when this predicate returns false.
+   */
+  ignoreMatch?: IIgnoreMatch;
 }
 
 /**
@@ -54,6 +59,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     expandRanges = expandRangesToParentBlockNode,
     matches = [],
     isActive = true,
+    ignoreMatch
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TMatch>;
@@ -67,7 +73,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     key: new PluginKey("prosemirror-typerighter"),
     state: {
       init: (_, { doc }) => {
-        const initialState = createInitialState(doc, matches, isActive);
+        const initialState = createInitialState(doc, matches, isActive, ignoreMatch);
         store.emit(STORE_EVENT_NEW_STATE, initialState);
         return initialState;
       },

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -1,5 +1,5 @@
 import { applyNewDirtiedRanges } from "./state/actions";
-import { IPluginState, PROSEMIRROR_TYPERIGHTER_ACTION, IIgnoreMatch } from "./state/reducer";
+import { IPluginState, PROSEMIRROR_TYPERIGHTER_ACTION, IIgnoreMatch, includeAllMatches } from "./state/reducer";
 import { createInitialState, createReducer } from "./state/reducer";
 import { selectNewBlockInFlight } from "./state/selectors";
 import { DECORATION_ATTRIBUTE_ID } from "./utils/decoration";
@@ -59,7 +59,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     expandRanges = expandRangesToParentBlockNode,
     matches = [],
     isActive = true,
-    ignoreMatch = () => false
+    ignoreMatch = includeAllMatches
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TMatch>;

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -1,0 +1,22 @@
+import { IPluginState, IIgnoreMatch } from "./reducer";
+import { IMatch } from "../interfaces/IMatch";
+import { createDecorationsForMatch } from "../utils/decoration";
+import { DecorationSet } from "prosemirror-view";
+
+export const addMatchesToState = <TMatch extends IMatch>(
+  state: IPluginState<TMatch>,
+  doc: any,
+  matches: TMatch[],
+  ignoreMatch?: IIgnoreMatch
+) => {
+  const matchesToApply = ignoreMatch ? matches.filter(ignoreMatch) : matches;
+  const decorations = matchesToApply.reduce(
+    (set, output) => set.add(doc, createDecorationsForMatch(output)),
+    new DecorationSet()
+  );
+  return {
+    ...state,
+    currentMatches: matchesToApply,
+    decorations
+  };
+};

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -1,4 +1,4 @@
-import { IPluginState, IIgnoreMatch } from "./reducer";
+import { IPluginState, IIgnoreMatch, defaultIgnoreMatch } from "./reducer";
 import { IMatch } from "../interfaces/IMatch";
 import { createDecorationsForMatch } from "../utils/decoration";
 import { DecorationSet } from "prosemirror-view";
@@ -7,7 +7,7 @@ export const addMatchesToState = <TMatch extends IMatch>(
   state: IPluginState<TMatch>,
   doc: any,
   matches: TMatch[],
-  ignoreMatch: IIgnoreMatch
+  ignoreMatch: IIgnoreMatch = defaultIgnoreMatch
 ) => {
   const matchesToApply = matches.filter(match => !ignoreMatch(match));
   const decorations = matchesToApply.reduce(

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -9,7 +9,7 @@ export const addMatchesToState = <TMatch extends IMatch>(
   matches: TMatch[],
   ignoreMatch: IIgnoreMatch
 ) => {
-  const matchesToApply = matches.filter(ignoreMatch);
+  const matchesToApply = matches.filter(match => !ignoreMatch(match));
   const decorations = matchesToApply.reduce(
     (set, output) => set.add(doc, createDecorationsForMatch(output)),
     new DecorationSet()

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -7,9 +7,9 @@ export const addMatchesToState = <TMatch extends IMatch>(
   state: IPluginState<TMatch>,
   doc: any,
   matches: TMatch[],
-  ignoreMatch?: IIgnoreMatch
+  ignoreMatch: IIgnoreMatch
 ) => {
-  const matchesToApply = ignoreMatch ? matches.filter(ignoreMatch) : matches;
+  const matchesToApply = matches.filter(ignoreMatch);
   const decorations = matchesToApply.reduce(
     (set, output) => set.add(doc, createDecorationsForMatch(output)),
     new DecorationSet()

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -1,4 +1,4 @@
-import { IPluginState, IIgnoreMatch, defaultIgnoreMatch } from "./reducer";
+import { IPluginState, IIgnoreMatch, includeAllMatches } from "./reducer";
 import { IMatch } from "../interfaces/IMatch";
 import { createDecorationsForMatch } from "../utils/decoration";
 import { DecorationSet } from "prosemirror-view";
@@ -7,7 +7,7 @@ export const addMatchesToState = <TMatch extends IMatch>(
   state: IPluginState<TMatch>,
   doc: any,
   matches: TMatch[],
-  ignoreMatch: IIgnoreMatch = defaultIgnoreMatch
+  ignoreMatch: IIgnoreMatch = includeAllMatches
 ) => {
   const matchesToApply = matches.filter(match => !ignoreMatch(match));
   const decorations = matchesToApply.reduce(

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -99,7 +99,7 @@ export interface IBlockInFlight {
  * exempt from checks.
  */
 export type IIgnoreMatch = (match: IMatch) => boolean;
-export const defaultIgnoreMatch: IIgnoreMatch = () => false;
+export const includeAllMatches: IIgnoreMatch = () => false;
 
 export interface IBlocksInFlightState {
   totalBlocks: number;
@@ -156,7 +156,7 @@ export const createInitialState = <TMatch extends IMatch>(
   doc: Node,
   matches: TMatch[] = [],
   active: boolean = true,
-  ignoreMatch: IIgnoreMatch = defaultIgnoreMatch
+  ignoreMatch: IIgnoreMatch = includeAllMatches
 ): IPluginState<TMatch> => {
   const initialState: IPluginState<TMatch> = {
     config: {
@@ -177,7 +177,7 @@ export const createInitialState = <TMatch extends IMatch>(
   return addMatchesToState(initialState, doc, matches, ignoreMatch);
 };
 
-export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch = defaultIgnoreMatch) => {
+export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch = includeAllMatches) => {
   const handleMatchesRequestForDirtyRanges = createHandleMatchesRequestForDirtyRanges(
     expandRanges
   );

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -99,6 +99,7 @@ export interface IBlockInFlight {
  * exempt from checks.
  */
 export type IIgnoreMatch = (match: IMatch) => boolean;
+export const defaultIgnoreMatch: IIgnoreMatch = () => false;
 
 export interface IBlocksInFlightState {
   totalBlocks: number;
@@ -155,7 +156,7 @@ export const createInitialState = <TMatch extends IMatch>(
   doc: Node,
   matches: TMatch[] = [],
   active: boolean = true,
-  ignoreMatch: IIgnoreMatch = () => false
+  ignoreMatch: IIgnoreMatch = defaultIgnoreMatch
 ): IPluginState<TMatch> => {
   const initialState: IPluginState<TMatch> = {
     config: {
@@ -176,7 +177,7 @@ export const createInitialState = <TMatch extends IMatch>(
   return addMatchesToState(initialState, doc, matches, ignoreMatch);
 };
 
-export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch = () => false) => {
+export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch = defaultIgnoreMatch) => {
   const handleMatchesRequestForDirtyRanges = createHandleMatchesRequestForDirtyRanges(
     expandRanges
   );

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -155,7 +155,7 @@ export const createInitialState = <TMatch extends IMatch>(
   doc: Node,
   matches: TMatch[] = [],
   active: boolean = true,
-  ignoreMatch?: IIgnoreMatch
+  ignoreMatch: IIgnoreMatch = () => true
 ): IPluginState<TMatch> => {
   const initialState: IPluginState<TMatch> = {
     config: {
@@ -176,7 +176,7 @@ export const createInitialState = <TMatch extends IMatch>(
   return addMatchesToState(initialState, doc, matches, ignoreMatch);
 };
 
-export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch) => {
+export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch = () => true) => {
   const handleMatchesRequestForDirtyRanges = createHandleMatchesRequestForDirtyRanges(
     expandRanges
   );
@@ -530,6 +530,7 @@ const handleMatchesRequestSuccess = (
     requestsInFlight.map(_ => _.block),
     match => !response.categoryIds.includes(match.category.id)
   );
+
   // Remove decorations superceded by the incoming matches.
   const decsToRemove = requestsInFlight.reduce(
     (acc, blockInFlight) =>

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -155,7 +155,7 @@ export const createInitialState = <TMatch extends IMatch>(
   doc: Node,
   matches: TMatch[] = [],
   active: boolean = true,
-  ignoreMatch: IIgnoreMatch = () => true
+  ignoreMatch: IIgnoreMatch = () => false
 ): IPluginState<TMatch> => {
   const initialState: IPluginState<TMatch> = {
     config: {
@@ -176,7 +176,7 @@ export const createInitialState = <TMatch extends IMatch>(
   return addMatchesToState(initialState, doc, matches, ignoreMatch);
 };
 
-export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch = () => true) => {
+export const createReducer = (expandRanges: ExpandRanges, ignoreMatch: IIgnoreMatch = () => false) => {
   const handleMatchesRequestForDirtyRanges = createHandleMatchesRequestForDirtyRanges(
     expandRanges
   );
@@ -553,7 +553,7 @@ const handleMatchesRequestSuccess = (
     [] as Decoration[]
   );
 
-  const matchesToAdd = response.matches.filter(ignoreMatch);
+  const matchesToAdd = response.matches.filter(match => !ignoreMatch(match));
   const currentMapping = selectBlockQueriesInFlightForSet(
     state,
     response.requestId

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -22,6 +22,7 @@ import {
 import { expandRangesToParentBlockNode } from "../../utils/range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
 import { IMatch, IMatchRequestError } from "../../interfaces/IMatch";
+import { addMatchesToState } from "../helpers";
 import {
   createMatcherResponse,
   createBlock,
@@ -30,8 +31,7 @@ import {
   exampleRequestId,
   createInitialData,
   defaultDoc,
-  createMatch,
-  addMatchesToState
+  createMatch
 } from "../../test/helpers/fixtures";
 import { createBlockId } from "../../utils/block";
 

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -29,7 +29,7 @@ import {
   exampleCategoryIds,
   createBlockQueriesInFlight,
   exampleRequestId,
-  createInitialState,
+  createInitialData,
   defaultDoc,
   createMatch,
   ICreateMatcherResponseSpec
@@ -48,7 +48,7 @@ const createStateWithMatches = (
   matches: ICreateMatcherResponseSpec[]
 ): { state: IPluginState; matches: IMatch[] } => {
   const docTime = 1337;
-  const { state, tr } = createInitialState(defaultDoc, docTime);
+  const { state, tr } = createInitialData(defaultDoc, docTime);
 
   let localState = localReducer(
     tr,
@@ -66,19 +66,19 @@ const createStateWithMatches = (
 describe("Action handlers", () => {
   describe("No action", () => {
     it("should just return the state", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       expect(reducer(tr, state)).toEqual(state);
     });
   });
   describe("Unknown action", () => {
-    const { state, tr } = createInitialState();
+    const { state, tr } = createInitialData();
     expect(reducer(tr, state, { type: "UNKNOWN_ACTION" } as any)).toEqual(
       state
     );
   });
   describe("requestMatchesForDocument", () => {
     it("should apply dirty ranges for the entire doc", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       expect(
         reducer(
           tr,
@@ -99,7 +99,7 @@ describe("Action handlers", () => {
   });
   describe("requestMatchesForDirtyRanges", () => {
     it("should remove the pending status and any dirtied ranges, and mark the request as in flight", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       expect(
         reducer(
           tr,
@@ -133,7 +133,7 @@ describe("Action handlers", () => {
       });
     });
     it("should remove debug decorations, if any", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       const newState = reducer(
         tr,
         {
@@ -158,7 +158,7 @@ describe("Action handlers", () => {
         p("Example text to check"),
         p("More text to check")
       );
-      const { state, tr } = createInitialState(doc);
+      const { state, tr } = createInitialData(doc);
       const newState = reducer(
         tr,
         {
@@ -180,7 +180,7 @@ describe("Action handlers", () => {
   });
   describe("requestMatchesSuccess", () => {
     it("shouldn't do anything if there's nothing in the response and nothing to clean up", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       expect(
         reducer(
           tr,
@@ -195,7 +195,7 @@ describe("Action handlers", () => {
       ).toEqual(state);
     });
     it("shouldn't do anything if there are no categories", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       expect(
         reducer(
           tr,
@@ -210,7 +210,7 @@ describe("Action handlers", () => {
       ).toEqual(state);
     });
     it("should add incoming matches to the state", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       let localState = reducer(
         tr,
         state,
@@ -230,7 +230,7 @@ describe("Action handlers", () => {
       ).toMatchObject([createMatch(1, 4)]);
     });
     it("should create decorations for the incoming matches", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       const newState = reducer(
         tr,
         {
@@ -247,7 +247,7 @@ describe("Action handlers", () => {
       expect(newState.decorations).toEqual(newDecorations);
     });
     describe("superceded matches", () => {
-      const { state: initialState, tr } = createInitialState();
+      const { state: initialState, tr } = createInitialData();
       const firstBlock = createBlock(0, 15, "Example text to check");
       const secondBlock = createBlock(16, 37, "Another block of text");
       const blocks = [firstBlock, secondBlock];
@@ -356,7 +356,7 @@ describe("Action handlers", () => {
       });
     });
     it("should not apply matches if the ranges they apply to have since been dirtied", () => {
-      const { state, tr } = createInitialState(defaultDoc, 1337);
+      const { state, tr } = createInitialData(defaultDoc, 1337);
       let localState = reducer(
         tr,
         state,
@@ -419,7 +419,7 @@ describe("Action handlers", () => {
   });
   describe("requestMatchesError", () => {
     it("Should re-add the in-flight request ranges as dirty ranges, and remove the inflight request", () => {
-      const { state: initialState, tr } = createInitialState();
+      const { state: initialState, tr } = createInitialData();
       const state = {
         ...initialState,
         requestsInFlight: createBlockQueriesInFlight([
@@ -457,7 +457,7 @@ describe("Action handlers", () => {
     });
   });
   describe("requestMatchesComplete", () => {
-    const { state: initialState, tr } = createInitialState();
+    const { state: initialState, tr } = createInitialData();
     it("should remove the inflight request from the state", () => {
       const state = {
         ...initialState,
@@ -490,7 +490,7 @@ describe("Action handlers", () => {
   });
   describe("newHoverIdReceived", () => {
     it("should update the hover id", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       expect(
         reducer(
           new Transaction(createDoc),
@@ -504,7 +504,7 @@ describe("Action handlers", () => {
       });
     });
     it("should add hover decorations", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       const output: IMatch = {
         matchId: "match-id",
         from: 0,
@@ -537,7 +537,7 @@ describe("Action handlers", () => {
       });
     });
     it("should remove hover decorations", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       const output: IMatch = {
         matchId: "match-id",
         from: 0,
@@ -574,7 +574,7 @@ describe("Action handlers", () => {
   });
   describe("handleNewDirtyRanges", () => {
     it("should remove any decorations and matches that touch the passed ranges", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
           matchId: "match-id",
@@ -615,7 +615,7 @@ describe("Action handlers", () => {
   });
   describe("selectMatch", () => {
     it("should apply the selected match id", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       const otherState = {
         ...state,
         currentMatches: [
@@ -651,13 +651,13 @@ describe("Action handlers", () => {
   });
   describe("removeMatch", () => {
     it("should be a noop when matches aren't present", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       const newState = reducer(tr, state, removeMatch("id-does-not-exist"));
       expect(newState.currentMatches).toEqual(state.currentMatches);
       expect(newState.decorations).toEqual(state.decorations);
     });
     it("should remove matches when they're present", () => {
-      const { state, tr } = createInitialState();
+      const { state, tr } = createInitialData();
       const matcherResponse = createMatcherResponse([{ from: 5, to: 10 }]);
       let newState = reducer(
         tr,
@@ -678,7 +678,7 @@ describe("Action handlers", () => {
   });
   describe("setConfigValue", () => {
     it("should set a config value", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       expect(
         reducer(
           new Transaction(createDoc),
@@ -688,7 +688,7 @@ describe("Action handlers", () => {
       ).toEqual({ ...state, config: { ...state.config, debug: true } });
     });
     it("should not accept incorrect config keys", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       reducer(
         new Transaction(createDoc),
         state,
@@ -697,7 +697,7 @@ describe("Action handlers", () => {
       );
     });
     it("should not accept incorrect config values", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       reducer(
         new Transaction(createDoc),
         state,

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -37,7 +37,7 @@ import {
 import { createBlockId } from "../../utils/block";
 import { getBlocksFromDocument } from "../../utils/prosemirror";
 
-const reducer = createReducer(expandRangesToParentBlockNode, () => true);
+const reducer = createReducer(expandRangesToParentBlockNode);
 
 /**
  * Create a plugin state, creating the given matches and
@@ -284,7 +284,7 @@ describe("Action handlers", () => {
           matcherResponse2.matches[0],
           matcherResponse3.matches[0]
         ],
-        () => true
+        () => false
       );
 
       it("should remove previous decorations that match block and category of the incoming match", () => {
@@ -388,7 +388,7 @@ describe("Action handlers", () => {
     it("should not apply matches if they trigger the ignoreMatch predicate", () => {
       const ignoreMatchReducer = createReducer(
         expandRangesToParentBlockNode,
-        match => match.from < 3
+        match => match.from > 3
       );
 
       const matchSpecs = [

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -35,7 +35,7 @@ import {
 } from "../../test/helpers/fixtures";
 import { createBlockId } from "../../utils/block";
 
-const reducer = createReducer(expandRangesToParentBlockNode);
+const reducer = createReducer(expandRangesToParentBlockNode, () => true);
 
 describe("Action handlers", () => {
   describe("No action", () => {
@@ -253,7 +253,8 @@ describe("Action handlers", () => {
           matcherResponse1.matches[0],
           matcherResponse2.matches[0],
           matcherResponse3.matches[0]
-        ]
+        ],
+        () => true
       );
 
       it("should remove previous decorations that match block and category of the incoming match", () => {
@@ -352,6 +353,33 @@ describe("Action handlers", () => {
         dirtiedRanges: [{ from: 1, to: 3 }],
         currentMatches: [],
         requestPending: true
+      });
+    });
+    it("should not apply matches if they trigger the ignoreMatch predicate", () => {
+      const reducerThatIgnoresMatches = createReducer(
+        expandRangesToParentBlockNode,
+        () => false
+      );
+      const { state, tr } = createInitialData(defaultDoc, 1337);
+      let localState = reducerThatIgnoresMatches(
+        tr,
+        state,
+        applyNewDirtiedRanges([{ from: 1, to: 3 }])
+      );
+      localState = reducerThatIgnoresMatches(
+        tr,
+        localState,
+        requestMatchesForDirtyRanges("id", exampleCategoryIds)
+      );
+      expect(
+        reducerThatIgnoresMatches(
+          tr,
+          localState,
+          requestMatchesSuccess(createMatcherResponse(1, 3))
+        )
+      ).toEqual({
+        ...localState,
+        currentMatches: [],
       });
     });
   });

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -199,7 +199,7 @@ describe("Action handlers", () => {
         reducer(
           tr,
           localState,
-          requestMatchesSuccess(createMatcherResponse(1, 22))
+          requestMatchesSuccess(createMatcherResponse([{ from: 1, to: 22 }]))
         ).currentMatches
       ).toMatchObject([createMatch(1, 4)]);
     });
@@ -211,7 +211,7 @@ describe("Action handlers", () => {
           ...state,
           requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
         },
-        requestMatchesSuccess(createMatcherResponse(5, 10))
+        requestMatchesSuccess(createMatcherResponse([{ from: 5, to: 10 }]))
       );
       const newMatch = newState.currentMatches[0];
       const newDecorations = new DecorationSet().add(
@@ -232,11 +232,15 @@ describe("Action handlers", () => {
           "This category should remain untouched -- it's not included in the categories for the incoming matches"
       };
       const matcherResponse1 = {
-        ...createMatcherResponse(0, 15, 1, 7),
+        ...createMatcherResponse([{ from: 0, to: 15, wordFrom: 1, wordTo: 7 }]),
         markAsCorrect: true
       };
-      const matcherResponse2 = createMatcherResponse(0, 15, 9, 13, category);
-      const matcherResponse3 = createMatcherResponse(16, 37, 17, 25); // Some other output for another block
+      const matcherResponse2 = createMatcherResponse([
+        { from: 0, to: 15, wordFrom: 9, wordTo: 13, category }
+      ]);
+      const matcherResponse3 = createMatcherResponse([
+        { from: 16, to: 37, wordFrom: 17, wordTo: 25 }
+      ]); // Some other output for another block
       const requestsInFlight = createBlockQueriesInFlight(
         blocks,
         exampleRequestId,
@@ -346,7 +350,7 @@ describe("Action handlers", () => {
         reducer(
           tr,
           localState,
-          requestMatchesSuccess(createMatcherResponse(1, 3))
+          requestMatchesSuccess(createMatcherResponse([{ from: 1, to: 3 }]))
         )
       ).toEqual({
         ...localState,
@@ -364,7 +368,7 @@ describe("Action handlers", () => {
       let localState = reducerThatIgnoresMatches(
         tr,
         state,
-        applyNewDirtiedRanges([{ from: 1, to: 3 }])
+        applyNewDirtiedRanges([{ from: 1, to: 5 }])
       );
       localState = reducerThatIgnoresMatches(
         tr,
@@ -375,11 +379,11 @@ describe("Action handlers", () => {
         reducerThatIgnoresMatches(
           tr,
           localState,
-          requestMatchesSuccess(createMatcherResponse(1, 3))
+          requestMatchesSuccess(createMatcherResponse([{ from: 1, to: 2 }]))
         )
       ).toEqual({
         ...localState,
-        currentMatches: [],
+        currentMatches: []
       });
     });
   });
@@ -624,7 +628,7 @@ describe("Action handlers", () => {
     });
     it("should remove matches when they're present", () => {
       const { state, tr } = createInitialData();
-      const matcherResponse = createMatcherResponse(5, 10);
+      const matcherResponse = createMatcherResponse([{ from: 5, to: 10 }]);
       let newState = reducer(
         tr,
         {

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -283,8 +283,7 @@ describe("Action handlers", () => {
           matcherResponse1.matches[0],
           matcherResponse2.matches[0],
           matcherResponse3.matches[0]
-        ],
-        () => false
+        ]
       );
 
       it("should remove previous decorations that match block and category of the incoming match", () => {

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -9,7 +9,7 @@ import {
   createBlock,
   createBlockQueriesInFlight,
   exampleRequestId,
-  createInitialState,
+  createInitialData,
   exampleCategoryIds
 } from "../../test/helpers/fixtures";
 import { IMatch } from '../../interfaces/IMatch';
@@ -71,7 +71,7 @@ describe("selectors", () => {
   });
   describe("selectNewBlockInFlight", () => {
     it("should find the new inflight matches given an old and a new state", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       expect(
@@ -98,7 +98,7 @@ describe("selectors", () => {
       ]);
     });
     it("shouldn't include matches missing in the new state but present in the old state", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       expect(
@@ -122,11 +122,11 @@ describe("selectors", () => {
   });
   describe("selectSuggestionAndRange", () => {
     it("should handle unknown outputs", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       expect(selectSuggestionAndRange(state, "invalidId", 5)).toEqual(null);
     });
     it("should handle unknown suggestions for found outputs", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
           matchId: "match-id",
@@ -161,7 +161,7 @@ describe("selectors", () => {
       ).toEqual(null);
     });
     it("should select a suggestion and the range it should be applied to, given a match id and suggestion index", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
           matchId: "match-id",
@@ -222,11 +222,11 @@ describe("selectors", () => {
   });
   describe("selectPercentRemaining", () => {
     it("should report nothing when there are no requests in flight", () => {
-      const { state } = createInitialState();
+      const { state } = createInitialData();
       expect(selectPercentRemaining(state)).toEqual(0);
     });
     it("should select the percentage remaining for a single request", () => {
-      const { state: initialState } = createInitialState();
+      const { state: initialState } = createInitialData();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       let state = {
@@ -250,7 +250,7 @@ describe("selectors", () => {
       expect(selectPercentRemaining(state)).toEqual(50);
     });
     it("should select the percentage remaining for multiple requests", () => {
-      const { state: initialState } = createInitialState();
+      const { state: initialState } = createInitialData();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       const input3 = createBlock(15, 20);

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -9,7 +9,7 @@ import {
   createBlock,
   createBlockQueriesInFlight,
   exampleRequestId,
-  createInitialData,
+  createInitialState,
   exampleCategoryIds
 } from "../../test/helpers/fixtures";
 import { IMatch } from '../../interfaces/IMatch';
@@ -71,7 +71,7 @@ describe("selectors", () => {
   });
   describe("selectNewBlockInFlight", () => {
     it("should find the new inflight matches given an old and a new state", () => {
-      const { state } = createInitialData();
+      const { state } = createInitialState();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       expect(
@@ -98,7 +98,7 @@ describe("selectors", () => {
       ]);
     });
     it("shouldn't include matches missing in the new state but present in the old state", () => {
-      const { state } = createInitialData();
+      const { state } = createInitialState();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       expect(
@@ -122,11 +122,11 @@ describe("selectors", () => {
   });
   describe("selectSuggestionAndRange", () => {
     it("should handle unknown outputs", () => {
-      const { state } = createInitialData();
+      const { state } = createInitialState();
       expect(selectSuggestionAndRange(state, "invalidId", 5)).toEqual(null);
     });
     it("should handle unknown suggestions for found outputs", () => {
-      const { state } = createInitialData();
+      const { state } = createInitialState();
       const currentMatches: IMatch[] = [
         {
           matchId: "match-id",
@@ -161,7 +161,7 @@ describe("selectors", () => {
       ).toEqual(null);
     });
     it("should select a suggestion and the range it should be applied to, given a match id and suggestion index", () => {
-      const { state } = createInitialData();
+      const { state } = createInitialState();
       const currentMatches: IMatch[] = [
         {
           matchId: "match-id",
@@ -222,11 +222,11 @@ describe("selectors", () => {
   });
   describe("selectPercentRemaining", () => {
     it("should report nothing when there are no requests in flight", () => {
-      const { state } = createInitialData();
+      const { state } = createInitialState();
       expect(selectPercentRemaining(state)).toEqual(0);
     });
     it("should select the percentage remaining for a single request", () => {
-      const { state: initialState } = createInitialData();
+      const { state: initialState } = createInitialState();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       let state = {
@@ -250,7 +250,7 @@ describe("selectors", () => {
       expect(selectPercentRemaining(state)).toEqual(50);
     });
     it("should select the percentage remaining for multiple requests", () => {
-      const { state: initialState } = createInitialData();
+      const { state: initialState } = createInitialState();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       const input3 = createBlock(15, 20);

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -107,4 +107,45 @@ describe("createTyperighterPlugin", () => {
     const decorations = getDecorationSpecsFromDoc(view);
     expect(decorations).toEqual(new Set());
   });
+  it("should not add matches and their decorations on init when the ignoreMatch predicate returns false", () => {
+    const { view, getState } = createPlugin({ ignoreMatch: () => false});
+
+    const decorations = getDecorationSpecsFromDoc(view);
+    expect(decorations).toEqual(new Set());
+
+    const pluginMatches = getState(view.state).currentMatches;
+    expect(pluginMatches).toEqual([]);
+  });
+  it("should not add matches and their decorations returned from a matcher when the ignoreMatch predicate returns false", () => {
+    const { commands, view, getState } = createPlugin({ ignoreMatch: () => false});
+
+    const response: IMatcherResponse = {
+      blocks,
+      categoryIds: ["cat1"],
+      matches: [
+        {
+          ...blocks[0],
+          matchId: "matchId",
+          matchedText: blocks[0].text,
+          message: "Example message",
+          category: {
+            id: "cat1",
+            name: "Category 1",
+            colour: "puce"
+          },
+          matchContext: "bigger block of text"
+        }
+      ],
+      requestId: "reqId"
+    };
+
+    commands.requestMatchesForDocument("docId", ["cat1"]);
+    commands.applyMatcherResponse(response);
+
+    const decorations = getDecorationSpecsFromDoc(view);
+    expect(decorations).toEqual(new Set());
+
+    const pluginMatches = getState(view.state).currentMatches;
+    expect(pluginMatches).toEqual([]);
+  });
 });

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -119,10 +119,10 @@ describe("createTyperighterPlugin", () => {
     const pluginMatches = getState(view.state).currentMatches;
     expect(pluginMatches).toEqual([match]);
   });
-  it("should not add matches and their decorations on init when the ignoreMatch predicate returns false", () => {
+  it("should not add matches and their decorations on init when the ignoreMatch predicate returns true", () => {
     const match = createMatch(1, 2);
     const { view, getState } = createPlugin({
-      ignoreMatch: () => false,
+      ignoreMatch: () => true,
       matches: [match]
     });
 
@@ -132,9 +132,9 @@ describe("createTyperighterPlugin", () => {
     const pluginMatches = getState(view.state).currentMatches;
     expect(pluginMatches).toEqual([]);
   });
-  it("should not add matches and their decorations returned from a matcher when the ignoreMatch predicate returns false", () => {
+  it("should not add matches and their decorations returned from a matcher when the ignoreMatch predicate returns true", () => {
     const { commands, view, getState } = createPlugin({
-      ignoreMatch: () => false
+      ignoreMatch: () => true
     });
 
     const response: IMatcherResponse = createMatcherResponse([

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -165,7 +165,7 @@ export const createInitialTr = (doc: Node = defaultDoc) => {
   return tr;
 };
 
-export const createInitialState = (doc: Node = defaultDoc, time = 0) => {
+export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
   const tr = createInitialTr(doc);
   tr.doc = doc;
   tr.time = time;

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -6,13 +6,15 @@ import {
   IMatcherResponse
 } from "../../interfaces/IMatch";
 import { createBlockId, createMatchId } from "../../utils/block";
-import { IPluginState, IBlocksInFlightState } from "../../state/reducer";
+import {
+  IPluginState,
+  IBlocksInFlightState
+} from "../../state/reducer";
 import { Mapping } from "prosemirror-transform";
 import { Transaction } from "prosemirror-state";
 import { Node } from "prosemirror-model";
 import { DecorationSet } from "prosemirror-view";
 import { createDoc, p } from "./prosemirror";
-import { createDecorationsForMatch } from "../../utils/decoration";
 
 export const matchLibrary: IMatchLibrary = [
   [
@@ -82,7 +84,7 @@ export const createMatcherResponse = (
       to: wordTo,
       matchId: createMatchId(0, wordFrom, wordTo, 0),
       suggestions,
-      matchContext: "here is a [block text] match",
+      matchContext: "here is a [block text] match"
     }
   ]
 });
@@ -104,7 +106,7 @@ export const createMatch = (
   to,
   matchId: createMatchId(0, from, to, 0),
   suggestions,
-  matchContext: "here is a [block text] match",
+  matchContext: "here is a [block text] match"
 });
 
 export const exampleCategoryIds = ["example-category"];
@@ -164,21 +166,5 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       requestPending: false,
       requestErrors: []
     } as IPluginState
-  };
-};
-
-export const addMatchesToState = (
-  state: IPluginState<IMatch>,
-  doc: any,
-  outputs: IMatch[]
-) => {
-  const decorations = outputs.reduce(
-    (set, output) => set.add(doc, createDecorationsForMatch(output)),
-    new DecorationSet()
-  );
-  return {
-    ...state,
-    currentMatches: outputs,
-    decorations
   };
 };

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -50,7 +50,7 @@ export const createBlock = (
   id: `0-from:${from}-to:${to}`
 });
 
-interface ICreateMatcherResponseSpec {
+export interface ICreateMatcherResponseSpec {
   from: number;
   to: number;
   block?: IBlock;
@@ -165,7 +165,7 @@ export const createInitialTr = (doc: Node = defaultDoc) => {
   return tr;
 };
 
-export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
+export const createInitialState = (doc: Node = defaultDoc, time = 0) => {
   const tr = createInitialTr(doc);
   tr.doc = doc;
   tr.time = time;

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -53,11 +53,12 @@ export const createBlock = (
 interface ICreateMatcherResponseSpec {
   from: number;
   to: number;
+  block?: IBlock;
   wordFrom?: number;
   wordTo?: number;
   category?: ICategory;
   suggestions?: ISuggestion[];
-};
+}
 
 export const createMatcherResponse = (
   specs: ICreateMatcherResponseSpec[],
@@ -70,6 +71,7 @@ export const createMatcherResponse = (
         to,
         wordFrom = from,
         wordTo = from + 3,
+        block,
         category = {
           id: "1",
           name: "Cat",
@@ -78,7 +80,7 @@ export const createMatcherResponse = (
         suggestions = [] as ISuggestion[]
       } = spec;
 
-      const newBlock = {
+      const newBlock = block || {
         id: createBlockId(0, from, to),
         from,
         to,
@@ -98,7 +100,8 @@ export const createMatcherResponse = (
 
       return {
         ...acc,
-        categoryIds: acc.categoryIds.concat(category.id),
+        // Category ids should be unique
+        categoryIds: Array.from(new Set(acc.categoryIds.concat(category.id))),
         blocks: acc.blocks.concat(newBlock),
         matches: acc.matches.concat(newMatch)
       };

--- a/src/ts/test/helpers/prosemirror.ts
+++ b/src/ts/test/helpers/prosemirror.ts
@@ -1,4 +1,4 @@
-import { Schema } from "prosemirror-model";
+import { Schema, Node } from "prosemirror-model";
 import { marks, nodes } from "prosemirror-schema-basic";
 import { builders } from "prosemirror-test-builder";
 import {
@@ -7,6 +7,8 @@ import {
   InlineDecorationSpec,
   Decoration
 } from "prosemirror-view";
+import { getNewDecorationsForCurrentMatches } from "../../utils/decoration";
+import { IMatch } from "../../interfaces/IMatch";
 
 const schema = new Schema({
   nodes,
@@ -31,6 +33,11 @@ export const getDecorationSpecsFromDoc = (
   view: EditorView
 ): Set<InlineDecorationSpec> =>
   getDecorationSpecsFromSet(view.someProp("decorations", f => f(view.state)));
+
+export const getDecorationSpecsFromMatches = (matches: IMatch[], doc: Node) => {
+  const decorationSet = getNewDecorationsForCurrentMatches(matches, new DecorationSet(), doc)
+  return getDecorationSpecsFromSet(decorationSet);
+}
 
 export const getDecorationSpecsFromSet = (
   set: DecorationSet

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -15,7 +15,7 @@ export const DecorationClassMap = {
   [DECORATION_INFLIGHT]: "MatchDebugInflight",
   [DECORATION_MATCH]: "MatchDecoration",
   [DECORATION_MATCH_HEIGHT_MARKER]: "MatchDecoration__height-marker",
-  [DECORATION_MATCH_IS_SELECTED]: "MatchDecoration--is-selected",
+  [DECORATION_MATCH_IS_SELECTED]: "MatchDecoration--is-selected"
 };
 
 export const DECORATION_ATTRIBUTE_ID = "data-match-id";
@@ -43,10 +43,7 @@ export const createDebugDecorationFromRange = (range: IRange, dirty = true) => {
 export const removeDecorationsFromRanges = (
   decorationSet: DecorationSet,
   ranges: IRange[],
-  types = [
-    DECORATION_MATCH,
-    DECORATION_MATCH_HEIGHT_MARKER
-  ]
+  types = [DECORATION_MATCH, DECORATION_MATCH_HEIGHT_MARKER]
 ) =>
   ranges.reduce((acc, range) => {
     const predicate = (spec: { [key: string]: any }) =>
@@ -102,18 +99,14 @@ export const createDecorationsForMatch = (
   addWidgetDecorations = true
 ) => {
   const className = isSelected
-    ? `${DecorationClassMap[DECORATION_MATCH]} ${
-        DecorationClassMap[DECORATION_MATCH_IS_SELECTED]
-      }`
+    ? `${DecorationClassMap[DECORATION_MATCH]} ${DecorationClassMap[DECORATION_MATCH_IS_SELECTED]}`
     : DecorationClassMap[DECORATION_MATCH];
 
-
-  const matchColour = match.markAsCorrect ? "3ff200" :  match.category.colour;
+  const matchColour = match.markAsCorrect ? "3ff200" : match.category.colour;
   const opacity = isSelected ? "30" : "07";
-  const style = `background-color: #${
-    matchColour
-  }${opacity}; border-bottom: 2px solid #${matchColour}`;
+  const style = `background-color: #${matchColour}${opacity}; border-bottom: 2px solid #${matchColour}`;
 
+  const spec = createDecorationSpecFromMatch(match);
   const decorations = [
     Decoration.inline(
       match.from,
@@ -122,14 +115,8 @@ export const createDecorationsForMatch = (
         class: className,
         style,
         [DECORATION_ATTRIBUTE_ID]: match.matchId
-      } as any,
-      {
-        type: DECORATION_MATCH,
-        id: match.matchId,
-        categoryId: match.category.id,
-        inclusiveStart: false,
-        inclusiveEnd: false
-      } as any
+      },
+      spec
     )
   ];
 
@@ -144,6 +131,15 @@ export const createDecorationsForMatch = (
   }
   return decorations;
 };
+
+export const createDecorationSpecFromMatch = (match: IMatch) =>
+  ({
+    type: DECORATION_MATCH,
+    id: match.matchId,
+    categoryId: match.category.id,
+    inclusiveStart: false,
+    inclusiveEnd: false
+  });
 
 export const createDecorationsForMatches = (matches: IMatch[]) =>
   flatten(matches.map(_ => createDecorationsForMatch(_)));


### PR DESCRIPTION
## What does this change?

Adds an 'ignore matches' predicate that the plugin consumer can supply. This predicate receives every match supplied to the plugin on init or as a result of a successful response. If it returns false, the match is not added to the plugin state.

An example use case at the Guardian: in our text editor, our users have the ability to mark text ranges as 'correct'. We don't want to see matches for these ranges.

## How to test

The added tests should give us an idea of how this works.

You could also spin this up in a test environment and add a predicate to check it behaves as expected.

## How can we measure success?

Matches that ... match the predicate are not included in the plugin state.
