### PR TITLE
Derive colours for matches

### DIFF
--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -6,10 +6,12 @@ import { IMatch } from "../interfaces/IMatch";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
 import IconButton from "@material-ui/core/IconButton";
+import { getColourForMatch, IMatchColours } from "../utils/decoration";
 
 interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
   match: TMatch;
+  matchColours: IMatchColours;
   feedbackHref?: string;
   onIgnoreMatch?: (match: IMatch) => void;
 }
@@ -18,6 +20,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
   public ref: HTMLDivElement | null = null;
   public render({
     match,
+    matchColours,
     applySuggestions,
     onIgnoreMatch
   }: IMatchProps<TMatch>) {
@@ -61,7 +64,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
           <div className="MatchWidget__type">
             <span
               className="MatchWidget__color-swatch"
-              style={{ backgroundColor: `#${category.colour}` }}
+              style={{ backgroundColor: getColourForMatch(match, matchColours) }}
             ></span>
             {category.name}
           </div>

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -12,6 +12,7 @@ interface IState {
   hoverInfo: IStateHoverInfo | undefined;
   match: IMatch | undefined;
   isVisible: boolean;
+  pluginState: IPluginState | undefined;
 }
 interface IProps<TMatch extends IMatch> {
   store: Store<TMatch, IStoreEvents<TMatch>>;
@@ -35,7 +36,8 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
     left: undefined,
     top: undefined,
     hoverInfo: undefined,
-    match: undefined
+    match: undefined,
+    pluginState: undefined
   };
   private matchRef: Match<TMatch> | undefined = undefined;
 
@@ -57,8 +59,8 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
 
   public render() {
     const { applySuggestions, feedbackHref, onIgnoreMatch } = this.props;
-    const { match, left, top } = this.state;
-    if (!match || left === undefined || top === undefined) {
+    const { match, left, top, pluginState } = this.state;
+    if (!pluginState || !match || left === undefined || top === undefined) {
       return null;
     }
     return (
@@ -79,6 +81,7 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
           <Match
             ref={_ => (this.matchRef = _)}
             match={match}
+            matchColours={pluginState.config.matchColours}
             applySuggestions={applySuggestions}
             feedbackHref={feedbackHref}
             onIgnoreMatch={onIgnoreMatch}
@@ -101,12 +104,14 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
       return this.setState({
         hoverInfo: state.hoverInfo,
         match,
+        pluginState: state,
         ...newState
       });
     }
     this.setState({
       hoverInfo: undefined,
       match: undefined,
+      pluginState: state,
       ...newState
     });
   };
@@ -146,7 +151,9 @@ class MatchOverlay<TMatch extends IMatch = IMatch> extends Component<
       spanRects.length > 1
         ? Math.max(...spanRects.map(_ => _.right))
         : undefined;
-    const absoluteLeft = hoveredRect ? hoveredRect.left : hoverInfo.mouseClientX;
+    const absoluteLeft = hoveredRect
+      ? hoveredRect.left
+      : hoverInfo.mouseClientX;
     const absoluteTop = hoveredRect
       ? hoveredRect.top + hoveredRect.height
       : hoverInfo.mouseClientX;

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -43,8 +43,8 @@ class Results extends Component<
       stopHover,
       contactHref
     } = this.props;
-    const { currentMatches = [], requestsInFlight, selectedMatch } = this.state
-      .pluginState || { selectedMatch: undefined };
+    const { pluginState } = this.state;
+    const { currentMatches = [], requestsInFlight, selectedMatch } = pluginState || { selectedMatch: undefined };
     const hasMatches = !!(currentMatches && currentMatches.length);
     const noOfAutoFixableSuggestions = this.getNoOfAutoFixableSuggestions();
     const percentRemaining = this.getPercentRemaining();
@@ -86,12 +86,13 @@ class Results extends Component<
         </div>
 
         <div className="Sidebar__content">
-          {hasMatches && (
+          {hasMatches && pluginState && (
             <ul className="Sidebar__list">
-              {currentMatches.map(output => (
-                <li className="Sidebar__list-item" key={output.matchId}>
+              {currentMatches.map(match => (
+                <li className="Sidebar__list-item" key={match.matchId}>
                   <SidebarMatch
-                    output={output}
+                    matchColours={pluginState?.config.matchColours}
+                    match={match}
                     selectedMatch={selectedMatch}
                     applySuggestions={applySuggestions}
                     selectMatch={selectMatch}

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -1,13 +1,14 @@
 import compact from "lodash/compact";
 import { IMatch } from "../interfaces/IMatch";
 import { Component, h } from "preact";
-import { DECORATION_ATTRIBUTE_ID } from "../utils/decoration";
+import { DECORATION_ATTRIBUTE_ID, IMatchColours, getColourForMatch } from "../utils/decoration";
 import titleCase from "lodash/startCase";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
 
 interface IProps {
-  output: IMatch;
+  match: IMatch;
+  matchColours: IMatchColours;
   applySuggestions: (suggestions: ApplySuggestionOptions) => void;
   selectMatch: (matchId: string) => void;
   indicateHover: (blockId: string, _?: any) => void;
@@ -28,17 +29,17 @@ class SidebarMatch extends Component<IProps, IState> {
   };
 
   public render() {
-    const { output, applySuggestions, selectedMatch } = this.props;
-    const color = `#${output.category.colour}`;
-    const hasSuggestions = !!output.suggestions && !!output.suggestions.length;
+    const { match, matchColours, applySuggestions, selectedMatch } = this.props;
+    const color = getColourForMatch(match, matchColours);
+    const hasSuggestions = !!match.suggestions && !!match.suggestions.length;
     const suggestions = compact([
-      output.replacement,
-      ...(output.suggestions || [])
+      match.replacement,
+      ...(match.suggestions || [])
     ]);
     return (
       <div
         className={`SidebarMatch__container ${
-          selectedMatch === output.matchId
+          selectedMatch === match.matchId
             ? "SidebarMatch__container--is-selected"
             : ""
         }`}
@@ -55,15 +56,15 @@ class SidebarMatch extends Component<IProps, IState> {
           <div className="SidebarMatch__header-label">
             <div>
               <div className="SidebarMatch__header-match-text">
-                {output.matchedText}
+                {match.matchedText}
               </div>
               <div className="SidebarMatch__header-description">
-                {output.message}
+                {match.message}
               </div>
             </div>
             <div className="SidebarMatch__header-meta">
               <div className="SidebarMatch__header-category">
-                {titleCase(output.category.name)}
+                {titleCase(match.category.name)}
               </div>
               {hasSuggestions && (
                 <div className="SidebarMatch__header-toggle-status">
@@ -79,7 +80,7 @@ class SidebarMatch extends Component<IProps, IState> {
               <div className="SidebarMatch__suggestion-list">
                 <SuggestionList
                   applySuggestions={applySuggestions}
-                  matchId={output.matchId}
+                  matchId={match.matchId}
                   suggestions={suggestions}
                 />
               </div>
@@ -96,9 +97,9 @@ class SidebarMatch extends Component<IProps, IState> {
   private scrollToRange = (e: MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.selectMatch(this.props.output.matchId);
+    this.props.selectMatch(this.props.match.matchId);
     const decorationElement = document.querySelector(
-      `[${DECORATION_ATTRIBUTE_ID}="${this.props.output.matchId}"]`
+      `[${DECORATION_ATTRIBUTE_ID}="${this.props.match.matchId}"]`
     );
     if (decorationElement) {
       decorationElement.scrollIntoView({
@@ -108,7 +109,7 @@ class SidebarMatch extends Component<IProps, IState> {
   };
 
   private handleMouseEnter = () => {
-    this.props.indicateHover(this.props.output.matchId);
+    this.props.indicateHover(this.props.match.matchId);
   };
 
   private handleMouseLeave = () => {

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -2,7 +2,7 @@ import { applyNewDirtiedRanges } from "./state/actions";
 import { IPluginState, PROSEMIRROR_TYPERIGHTER_ACTION } from "./state/reducer";
 import { createInitialState, createReducer } from "./state/reducer";
 import { selectNewBlockInFlight } from "./state/selectors";
-import { DECORATION_ATTRIBUTE_ID } from "./utils/decoration";
+import { DECORATION_ATTRIBUTE_ID, IMatchColours, defaultMatchColours } from "./utils/decoration";
 import { EditorView, DecorationSet } from "prosemirror-view";
 import { Plugin, Transaction, EditorState, PluginKey } from "prosemirror-state";
 import { expandRangesToParentBlockNode } from "./utils/range";
@@ -37,6 +37,11 @@ export interface IPluginOptions<TMatch extends IMatch = IMatch> {
    * Is the plugin active as it starts?
    */
   isActive?: boolean;
+
+  /**
+   * The colours to use for document matches.
+   */
+  matchColours?: IMatchColours;
 }
 
 /**
@@ -54,6 +59,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     expandRanges = expandRangesToParentBlockNode,
     matches = [],
     isActive = true,
+    matchColours = defaultMatchColours
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TMatch>;
@@ -67,7 +73,7 @@ const createTyperighterPlugin = <TMatch extends IMatch>(
     key: new PluginKey("prosemirror-typerighter"),
     state: {
       init: (_, { doc }) => {
-        const initialState = createInitialState(doc, matches, isActive);
+        const initialState = createInitialState(doc, matches, isActive, matchColours);
         store.emit(STORE_EVENT_NEW_STATE, initialState);
         return initialState;
       },

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -37,7 +37,8 @@ import {
   removeDecorationsFromRanges,
   DECORATION_MATCH,
   createDecorationsForMatch,
-  createDecorationsForMatches
+  createDecorationsForMatches,
+  IMatchColours
 } from "../utils/decoration";
 import {
   mergeRanges,
@@ -108,6 +109,8 @@ export interface IPluginConfig {
   // Is the plugin in debug mode? Debug mode adds marks to show dirtied
   // and expanded ranges.
   debug: boolean;
+  // The colours to use when rendering matches
+  matchColours: IMatchColours;
 }
 
 export interface IPluginState<TMatches extends IMatch = IMatch> {
@@ -146,14 +149,16 @@ export const PROSEMIRROR_TYPERIGHTER_ACTION = "PROSEMIRROR_TYPERIGHTER_ACTION";
 export const createInitialState = <TMatch extends IMatch>(
   doc: Node,
   matches: TMatch[] = [],
-  active: boolean = true
+  active: boolean = true,
+  matchColours: IMatchColours
 ): IPluginState<TMatch> => ({
   config: {
     isActive: active,
     debug: false,
-    requestMatchesOnDocModified: false
+    requestMatchesOnDocModified: false,
+    matchColours
   },
-  decorations: DecorationSet.create(doc, createDecorationsForMatches(matches)),
+  decorations: DecorationSet.create(doc, createDecorationsForMatches(matches, matchColours)),
   dirtiedRanges: [],
   currentMatches: matches,
   selectedMatch: undefined,
@@ -323,7 +328,7 @@ const handleNewHoverId = <TMatch extends IMatch>(
     }
     return decorations.add(
       tr.doc,
-      createDecorationsForMatch(output, hoverData.isSelected, false)
+      createDecorationsForMatch(output, state.config.matchColours, hoverData.isSelected, false)
     );
   }, decorations);
 
@@ -551,7 +556,7 @@ const handleMatchesRequestSuccess = <TMatch extends IMatch>(
   currentMatches = removeOverlappingRanges(currentMatches, state.dirtiedRanges);
 
   // Create our decorations for the newly current matches.
-  const newDecorations = createDecorationsForMatches(response.matches);
+  const newDecorations = createDecorationsForMatches(response.matches, state.config.matchColours);
 
   // Amend the block queries in flight to
   const newBlockQueriesInFlight = requestsInFlight.reduce(

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -17,7 +17,8 @@ import { createReducer, IPluginState } from "../reducer";
 import {
   createDebugDecorationFromRange,
   getNewDecorationsForCurrentMatches,
-  createDecorationsForMatch
+  createDecorationsForMatch,
+  defaultMatchColours
 } from "../../utils/decoration";
 import { expandRangesToParentBlockNode } from "../../utils/range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
@@ -461,14 +462,14 @@ describe("Action handlers", () => {
         currentMatches: [output],
         decorations: new DecorationSet().add(
           tr.doc,
-          createDecorationsForMatch(output, false)
+          createDecorationsForMatch(output, defaultMatchColours, false)
         )
       };
       expect(reducer(tr, localState, newHoverIdReceived("match-id"))).toEqual({
         ...localState,
         decorations: new DecorationSet().add(
           tr.doc,
-          createDecorationsForMatch(output, true)
+          createDecorationsForMatch(output, defaultMatchColours, true)
         ),
         hoverId: "match-id",
         hoverInfo: undefined
@@ -492,7 +493,7 @@ describe("Action handlers", () => {
       const localState = {
         ...state,
         decorations: new DecorationSet().add(tr.doc, [
-          ...createDecorationsForMatch(output, true)
+          ...createDecorationsForMatch(output, defaultMatchColours, true)
         ]),
         currentMatches: [output],
         hoverId: "match-id",
@@ -503,7 +504,7 @@ describe("Action handlers", () => {
       ).toEqual({
         ...localState,
         decorations: new DecorationSet().add(tr.doc, [
-          ...createDecorationsForMatch(output, false)
+          ...createDecorationsForMatch(output, defaultMatchColours, false)
         ]),
         hoverId: undefined,
         hoverInfo: undefined
@@ -535,7 +536,8 @@ describe("Action handlers", () => {
         decorations: getNewDecorationsForCurrentMatches(
           currentMatches,
           state.decorations,
-          defaultDoc
+          defaultDoc,
+          defaultMatchColours
         )
       };
       expect(

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -12,7 +12,7 @@ import { Transaction } from "prosemirror-state";
 import { Node } from "prosemirror-model";
 import { DecorationSet } from "prosemirror-view";
 import { createDoc, p } from "./prosemirror";
-import { createDecorationsForMatch } from "../../utils/decoration";
+import { createDecorationsForMatch, defaultMatchColours } from "../../utils/decoration";
 
 export const matchLibrary: IMatchLibrary = [
   [
@@ -148,7 +148,8 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       config: {
         debug: false,
         requestMatchesOnDocModified: true,
-        isActive: true
+        isActive: true,
+        matchColours: defaultMatchColours
       },
       currentThrottle: 100,
       initialThrottle: 100,

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -10,9 +10,9 @@ export interface IMatchColours {
 }
 
 export const defaultMatchColours = {
-  unambiguous: "d90000",
-  ambiguous: "ffa500",
-  correct: "3ff200"
+  unambiguous: "#d90000",
+  ambiguous: "#ffa500",
+  correct: "#3ff200"
 };
 
 // Our decoration types.
@@ -118,7 +118,7 @@ export const createDecorationsForMatch = (
 
   const matchColour = getColourForMatch(match, matchColours);
   const opacity = isSelected ? "30" : "07";
-  const style = `background-color: #${matchColour}${opacity}; border-bottom: 2px solid #${matchColour}`;
+  const style = `background-color: ${matchColour}${opacity}; border-bottom: 2px solid ${matchColour}`;
 
   const decorations = [
     Decoration.inline(

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -108,7 +108,7 @@ const createHeightMarkerElement = (id: string) => {
  */
 export const createDecorationsForMatch = (
   match: IMatch,
-  matchColours: IMatchColours,
+  matchColours: IMatchColours = defaultMatchColours,
   isSelected = false,
   addWidgetDecorations = true
 ) => {
@@ -166,7 +166,7 @@ export const getColourForMatch = (
 
 export const createDecorationsForMatches = (
   matches: IMatch[],
-  matchColours: IMatchColours
+  matchColours: IMatchColours = defaultMatchColours
 ) => flatten(matches.map(_ => createDecorationsForMatch(_, matchColours)));
 
 export const findSingleDecoration = (

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -18,7 +18,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                `background-color: #${defaultMatchColours.ambiguous}07; border-bottom: 2px solid #${defaultMatchColours.ambiguous}`
+                `background-color: ${defaultMatchColours.ambiguous}07; border-bottom: 2px solid ${defaultMatchColours.ambiguous}`
             },
             spec: {
               categoryId: "1",
@@ -54,7 +54,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                `background-color: #${defaultMatchColours.correct}07; border-bottom: 2px solid #${defaultMatchColours.correct}`
+                `background-color: ${defaultMatchColours.correct}07; border-bottom: 2px solid ${defaultMatchColours.correct}`
             },
             spec: {
               categoryId: "1",

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -1,4 +1,4 @@
-import { createDecorationsForMatch } from "../decoration";
+import { createDecorationsForMatch, defaultMatchColours } from "../decoration";
 import { createMatch } from "../../test/helpers/fixtures";
 import { IMatch } from "../../interfaces/IMatch";
 
@@ -18,7 +18,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                "background-color: #eeeee07; border-bottom: 2px solid #eeeee"
+                `background-color: #${defaultMatchColours.ambiguous}07; border-bottom: 2px solid #${defaultMatchColours.ambiguous}`
             },
             spec: {
               categoryId: "1",
@@ -54,7 +54,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                "background-color: #3ff20007; border-bottom: 2px solid #3ff200"
+                `background-color: #${defaultMatchColours.correct}07; border-bottom: 2px solid #${defaultMatchColours.correct}`
             },
             spec: {
               categoryId: "1",


### PR DESCRIPTION
_co-authored-by: @tjsilver_

## What does this change?

At the moment, we assign colours to rule matches in the UI via their categories.

This PR implements a new approach to colours for matches:

- Green: the tool knows this match is correct.
- Orange: the tool is unsure about this match, and would like the user to check it.
- Red: the tool is sure this match isn't correct, and has a replacement.

We can derive these colours from the match state. If a rule doesn't have a replacement, it's Orange; if a rule does have a replacement that's different from the matched text, it's Red; if a rule has a replacement that matches the matched text, it's green.

Before:

<img width="831" alt="Screenshot 2020-08-12 at 12 17 38" src="https://user-images.githubusercontent.com/7767575/90009424-f234b600-dc95-11ea-8c18-8bd52bd6416d.png">

After:

<img width="831" alt="Screenshot 2020-08-12 at 12 16 09" src="https://user-images.githubusercontent.com/7767575/90009442-fc56b480-dc95-11ea-8d96-86b0a2b874ab.png">

## How to test

Run this plugin locally against text that has all three sorts of matches (for example, this [long read](https://www.theguardian.com/news/2019/aug/02/athleisure-barre-kale-tyranny-ideal-woman-labour).) You should see that match colours in the document, sidebar and match tooltips correspond to the above rules.

## How can we measure success?

The above rules are implemented.