### PR TITLE
Reduces the opacity of ambiguous decorations

### DIFF
--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -64,7 +64,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
           <div className="MatchWidget__type">
             <span
               className="MatchWidget__color-swatch"
-              style={{ backgroundColor: getColourForMatch(match, matchColours) }}
+              style={{ backgroundColor: getColourForMatch(match, matchColours, false).backgroundColour }}
             ></span>
             {category.name}
           </div>

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -30,7 +30,7 @@ class SidebarMatch extends Component<IProps, IState> {
 
   public render() {
     const { match, matchColours, applySuggestions, selectedMatch } = this.props;
-    const color = getColourForMatch(match, matchColours);
+    const color = getColourForMatch(match, matchColours, false).borderColour;
     const hasSuggestions = !!match.suggestions && !!match.suggestions.length;
     const suggestions = compact([
       match.replacement,

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -116,9 +116,8 @@ export const createDecorationsForMatch = (
     ? `${DecorationClassMap[DECORATION_MATCH]} ${DecorationClassMap[DECORATION_MATCH_IS_SELECTED]}`
     : DecorationClassMap[DECORATION_MATCH];
 
-  const matchColour = getColourForMatch(match, matchColours);
-  const opacity = isSelected ? "30" : "07";
-  const style = `background-color: ${matchColour}${opacity}; border-bottom: 2px solid ${matchColour}`;
+  const {backgroundColour, borderColour} = getColourForMatch(match, matchColours, isSelected);
+  const style = `background-color: ${backgroundColour}; border-bottom: 2px solid ${borderColour}`;
 
   const decorations = [
     Decoration.inline(
@@ -151,17 +150,30 @@ export const createDecorationsForMatch = (
   return decorations;
 };
 
-export const getColourForMatch = (
+export const getColourForMatch  = (
   match: IMatch,
-  matchColours: IMatchColours
-) => {
+  matchColours: IMatchColours,
+  isSelected: boolean
+) : {backgroundColour: string, borderColour: string} => {
+
+  const backgroundOpacity = isSelected ? "30" : "07";
+
   if (match.markAsCorrect) {
-    return matchColours.correct;
+    return {
+      backgroundColour: `${matchColours.correct}${backgroundOpacity}`, 
+      borderColour: `${matchColours.correct}`
+    };
   }
   if (match.replacement) {
-    return matchColours.unambiguous;
+    return {
+      backgroundColour: `${matchColours.unambiguous}${backgroundOpacity}`, 
+      borderColour: `${matchColours.unambiguous}`
+    };
   }
-  return matchColours.ambiguous;
+  return {
+    backgroundColour: `${matchColours.ambiguous}${backgroundOpacity}`, 
+    borderColour: `${matchColours.ambiguous}4D`
+  };
 };
 
 export const createDecorationsForMatches = (

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -5,14 +5,20 @@ import { IRange, IMatch } from "../interfaces/IMatch";
 
 export interface IMatchColours {
   unambiguous: string;
+  unambiguousOpacity: string;
   ambiguous: string;
+  ambiguousOpacity: string;
   correct: string;
+  correctOpacity: string;
 }
 
 export const defaultMatchColours = {
   unambiguous: "#d90000",
+  unambiguousOpacity: "FF",
   ambiguous: "#ffa500",
-  correct: "#3ff200"
+  ambiguousOpacity: "4D",
+  correct: "#3ff200",
+  correctOpacity: "FF"
 };
 
 // Our decoration types.
@@ -150,7 +156,7 @@ export const createDecorationsForMatch = (
   return decorations;
 };
 
-export const getColourForMatch  = (
+export const getColourForMatch = (
   match: IMatch,
   matchColours: IMatchColours,
   isSelected: boolean
@@ -161,18 +167,18 @@ export const getColourForMatch  = (
   if (match.markAsCorrect) {
     return {
       backgroundColour: `${matchColours.correct}${backgroundOpacity}`, 
-      borderColour: `${matchColours.correct}`
+      borderColour: `${matchColours.correct}${matchColours.correctOpacity}`
     };
   }
   if (match.replacement) {
     return {
       backgroundColour: `${matchColours.unambiguous}${backgroundOpacity}`, 
-      borderColour: `${matchColours.unambiguous}`
+      borderColour: `${matchColours.unambiguous}${matchColours.unambiguousOpacity}`
     };
   }
   return {
     backgroundColour: `${matchColours.ambiguous}${backgroundOpacity}`, 
-    borderColour: `${matchColours.ambiguous}4D`
+    borderColour: `${matchColours.ambiguous}${matchColours.ambiguousOpacity}`
   };
 };
 

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -18,7 +18,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                `background-color: ${defaultMatchColours.ambiguous}07; border-bottom: 2px solid ${defaultMatchColours.ambiguous}4D`
+                `background-color: ${defaultMatchColours.ambiguous}07; border-bottom: 2px solid ${defaultMatchColours.ambiguous}${defaultMatchColours.ambiguousOpacity}`
             },
             spec: {
               categoryId: "1",
@@ -54,7 +54,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                `background-color: ${defaultMatchColours.correct}07; border-bottom: 2px solid ${defaultMatchColours.correct}`
+                `background-color: ${defaultMatchColours.correct}07; border-bottom: 2px solid ${defaultMatchColours.correct}${defaultMatchColours.correctOpacity}`
             },
             spec: {
               categoryId: "1",

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -18,7 +18,7 @@ describe("Decoration utils", () => {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
               style:
-                `background-color: ${defaultMatchColours.ambiguous}07; border-bottom: 2px solid ${defaultMatchColours.ambiguous}`
+                `background-color: ${defaultMatchColours.ambiguous}07; border-bottom: 2px solid ${defaultMatchColours.ambiguous}4D`
             },
             spec: {
               categoryId: "1",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR reduces the opacity of the ambiguous colour, this reduces the amount of visual noise that Typerighter creates for rules that may be inaccurate. This PR is based on the work done to [change the match colours](https://github.com/guardian/prosemirror-typerighter/pull/95).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Open a document, run the document through Typerighter, observe the amount of visual noise generated by ambiguous rules. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users' attention is on matches which are most significant and accurate.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
Before:
![Screenshot 2020-08-12 at 14 08 00](https://user-images.githubusercontent.com/4633246/90020298-95da9200-dca7-11ea-97cb-3dd9d72b9a34.png)

After:
![Screenshot 2020-08-12 at 14 07 21](https://user-images.githubusercontent.com/4633246/90020300-96732880-dca7-11ea-9126-892468b11e41.png)

