### PR TITLE
Add interfaces to exports

### DIFF
--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,3 +1,5 @@
+import { IMatch, IBlock } from './interfaces/IMatch'
+import { IStore } from './state/store';
 import createTyperighterPlugin from "./createTyperighterPlugin";
 import MatcherService from "./services/MatcherService";
 import TyperighterAdapter, { convertTyperighterResponse } from "./services/adapters/TyperighterAdapter";
@@ -13,5 +15,8 @@ export {
   convertTyperighterResponse,
   createBoundCommands,
   createView,
-  createTyperighterPlugin
+  createTyperighterPlugin,
+  IMatch,
+  IBlock,
+  IStore
 };

--- a/src/ts/state/store.ts
+++ b/src/ts/state/store.ts
@@ -100,6 +100,6 @@ class Store<
   }
 }
 
-export type IStore = typeof Store;
+export type IStore<TMatch extends IMatch = IMatch> = Store<TMatch>;
 
 export default Store;

--- a/src/ts/state/store.ts
+++ b/src/ts/state/store.ts
@@ -100,4 +100,6 @@ class Store<
   }
 }
 
+export type IStore = typeof Store;
+
 export default Store;


### PR DESCRIPTION
## What does this change?

We've added a few predicates/callbacks recently (#94, #88) that require us to reason about plugin interfaces in consumer code. We'll need to export those interfaces so consuming code can use them when defining those predicates.

## How to test

This is a no-op.

## How can we measure success?

We can access the given interfaces in consumer code.
