### PR TITLE
Add default colours to `createInitialState`

### DIFF
--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -38,7 +38,8 @@ import {
   DECORATION_MATCH,
   createDecorationsForMatch,
   createDecorationsForMatches,
-  IMatchColours
+  IMatchColours,
+  defaultMatchColours
 } from "../utils/decoration";
 import {
   mergeRanges,
@@ -160,7 +161,7 @@ export const createInitialState = <TMatch extends IMatch>(
   matches: TMatch[] = [],
   active: boolean = true,
   ignoreMatch: IIgnoreMatch = includeAllMatches,
-  matchColours: IMatchColours
+  matchColours: IMatchColours = defaultMatchColours
 ): IPluginState<TMatch> => {
   const initialState: IPluginState<TMatch> = {
     config: {


### PR DESCRIPTION
## What does this change?

A previous merge seems to have removed the default for this function, which broke the build. This PR fixes that issue.

## How to test

The build succeeds.