### PR TITLE
Trigger search on toggle

### DIFF
--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -3,7 +3,7 @@ import { v4 } from "uuid";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
 import { IMatch, ICategory } from "../interfaces/IMatch";
-import { selectHasError } from "../state/selectors";
+import { selectHasError, selectRequestsInProgress } from "../state/selectors";
 import IconButton from "@material-ui/core/IconButton";
 import CloseIcon from "./icons/CloseIcon";
 
@@ -44,9 +44,6 @@ class Controls extends Component<IProps, IState> {
   }
 
   public render() {
-    const checkInProgress: boolean | undefined =
-      this.state.pluginState &&
-      !!Object.keys(this.state.pluginState.requestsInFlight).length;
 
     const handleCheckDocumentButtonClick = (): void => {
       if (!this.state.pluginState?.config.isActive) {
@@ -67,7 +64,7 @@ class Controls extends Component<IProps, IState> {
               type="button"
               className="Button"
               onClick={handleCheckDocumentButtonClick}
-              disabled={checkInProgress}
+              disabled={this.state.pluginState && selectRequestsInProgress(this.state.pluginState)}
             >
               Check document
             </button>
@@ -76,7 +73,7 @@ class Controls extends Component<IProps, IState> {
                 size="small"
                 aria-label="close Typerighter"
                 onClick={this.props.onToggleActiveState}
-                disabled={checkInProgress}
+                disabled={this.state.pluginState && selectRequestsInProgress(this.state.pluginState)}
               >
                 <CloseIcon />
               </IconButton>

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -66,6 +66,10 @@ class Controls extends Component<IProps, IState> {
               size="small"
               aria-label="close Typerighter"
               onClick={this.props.deactivate}
+              disabled={
+                this.state.pluginState &&
+                !!Object.keys(this.state.pluginState.requestsInFlight).length
+              }
             >
               <CloseIcon/>
             </IconButton>

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -37,7 +37,7 @@ class Controls extends Component<IProps, IState> {
     allCategories: [],
     currentCategories: [],
     isLoadingCategories: false,
-    pluginState: undefined,
+    pluginState: undefined
   } as IState;
   public componentWillMount() {
     this.props.store.on(STORE_EVENT_NEW_STATE, this.handleNotify);
@@ -45,8 +45,11 @@ class Controls extends Component<IProps, IState> {
   }
 
   public render() {
+    const buttonDisabled =
+      this.state.pluginState &&
+      !!Object.keys(this.state.pluginState.requestsInFlight).length;
 
-     return (
+    return (
       <Fragment>
         <div className="Sidebar__header-container">
           <div className="Sidebar__header">
@@ -54,28 +57,22 @@ class Controls extends Component<IProps, IState> {
               type="button"
               className="Button"
               onClick={this.requestMatchesForDocument}
-              disabled={
-                this.state.pluginState &&
-                !!Object.keys(this.state.pluginState.requestsInFlight).length
-              }
+              disabled={buttonDisabled}
             >
               Check document
             </button>
-          
+
             <IconButton
               size="small"
               aria-label="close Typerighter"
               onClick={this.props.deactivate}
-              disabled={
-                this.state.pluginState &&
-                !!Object.keys(this.state.pluginState.requestsInFlight).length
-              }
+              disabled={buttonDisabled}
             >
-              <CloseIcon/>
+              <CloseIcon />
             </IconButton>
           </div>
         </div>
-      
+
         {this.state.pluginState && selectHasError(this.state.pluginState) && (
           <div className="Controls__error-message">
             Error fetching matches. Please try checking the document again.{" "}
@@ -136,7 +133,7 @@ class Controls extends Component<IProps, IState> {
     const data = {
       url: document.location.href,
       errors: this.state.pluginState?.requestErrors?.slice(0, errorLmit)
-    }
+    };
     const encodedData = encodeURIComponent(JSON.stringify(data, undefined, 2));
     return this.props.feedbackHref + encodedData;
   };

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -125,7 +125,7 @@ class Results extends Component<
     if (oldKeys.length && !newKeys.length) {
       setTimeout(this.maybeResetLoadingBar, 300);
     }
-    if (!oldKeys.length && newKeys.length) {
+    if (!this.state.loadingBarVisible && newKeys.length) {
       this.setState({ loadingBarVisible: true });
     }
   };

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -21,20 +21,31 @@ const Sidebar = ({
   matcherService,
   commands,
   contactHref,
-  feedbackHref,
+  feedbackHref
 }: IProps) => {
-  const [pluginState, setPluginState] = useState<IPluginState | undefined>(undefined);
+  const [pluginState, setPluginState] = useState<IPluginState | undefined>(
+    undefined
+  );
   useEffect(() => {
     setPluginState(store.getState());
     store.on(STORE_EVENT_NEW_STATE, setPluginState);
     return () => {
-        store.removeEventListener(STORE_EVENT_NEW_STATE, setPluginState);
+      store.removeEventListener(STORE_EVENT_NEW_STATE, setPluginState);
     };
   }, []);
+
+  const handleToggleActiveState = (): void => {
+    commands.setConfigValue("isActive", !pluginState?.config.isActive);
+  };
+
+  const sidebarClasses = pluginState?.config.isActive
+    ? "Sidebar__section"
+    : "Sidebar__section Sidebar__section--is-closed";
+
   return (
-    <Fragment>    
-      {pluginState?.config.isActive ? (
-        <div className="Sidebar__section">
+    <Fragment>
+      {pluginState && (
+        <div className={sidebarClasses}>
           <Controls
             store={store}
             setDebugState={value => commands.setConfigValue("debug", value)}
@@ -47,31 +58,19 @@ const Sidebar = ({
             addCategory={matcherService.addCategory}
             removeCategory={matcherService.removeCategory}
             feedbackHref={feedbackHref}
-            deactivate={() => commands.setConfigValue("isActive", false)}
+            onToggleActiveState={handleToggleActiveState}
           />
-          <Results
-            store={store}
-            applySuggestions={commands.applySuggestions}
-            applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
-            selectMatch={commands.selectMatch}
-            indicateHover={commands.indicateHover}
-            stopHover={commands.stopHover}
-            contactHref={contactHref}
-          />
-        </div>
-      ) : (
-        <div className="Sidebar__section Sidebar__section--is-closed">
-          <div className="Sidebar__header-container Sidebar__header-container--is-closed">
-            <div className="Sidebar__header">
-              <button
-                type="button"
-                className="Button"
-                onClick={() => commands.setConfigValue("isActive", true)}
-              >
-                Open Typerighter
-              </button>
-            </div>
-          </div>
+          {pluginState?.config.isActive && (
+            <Results
+              store={store}
+              applySuggestions={commands.applySuggestions}
+              applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
+              selectMatch={commands.selectMatch}
+              indicateHover={commands.indicateHover}
+              stopHover={commands.stopHover}
+              contactHref={contactHref}
+            />
+          )}
         </div>
       )}
     </Fragment>

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -127,3 +127,7 @@ export const selectHasError = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
 ): boolean =>
   !!state.requestErrors && state.requestErrors.length > 0;
+
+export const selectRequestsInProgress = <TMatch extends IMatch>(
+  state: IPluginState<TMatch>
+): boolean => !!Object.keys(state.requestsInFlight).length;


### PR DESCRIPTION
## What does this change?
At the moment, users must click to activate Typerighter and click again to check a document. Re-activating the plugin without rechecking might be confusing to users. This PR addresses this by keeping the 'Check document' button across open/closed states of typerighter. As soon as 'Check document' is clicked in the closed state, a check is triggered and Typerighter is activated.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run branch locally and observe that Typerighter carries out a document check when 'Check document' is clicked in the closed state.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users will find the behaviour intuitive.

## Images

### Before
![toggle-on-off2](https://user-images.githubusercontent.com/15648334/90249135-db2acb00-de31-11ea-9220-0ff2824bae2f.gif)

### After
![toggle-on-off](https://user-images.githubusercontent.com/15648334/90248964-8b4c0400-de31-11ea-9f4c-74ce4a2ba41c.gif)


