### PR TITLE
[Bugfix] Remove matches on doc edit when this plugin is imported

### DIFF
--- a/build/rollup.config.build.js
+++ b/build/rollup.config.build.js
@@ -21,6 +21,7 @@ const externalModules = [
   "prosemirror-state",
   "prosemirror-test-builder",
   "prosemirror-view",
+  "prosemirror-transform",
   "preact",
   "prosemirror-tables",
   "prosemirror-utils",


### PR DESCRIPTION
## What does this change?

This PR fixes the 'remove matches on doc edit' when this plugin is imported.

To do it, it adds the `prosemirror-transform` to externals. This is necessary to fix a subtle bug. When the document changes, we figure out whether the `Step`s generated by the edit change the document in a way that should remove matches:

```ts
tr.steps.filter(
    step => step instanceof ReplaceStep || step instanceof ReplaceAroundStep
  );
```

However, if we include the library that supplies `ReplaceStep` etc. in our bundle – `prosemirror-transform` – it's then included twice when we import this plugin: once when the third party sets up the editor, and once in our bundle.

This is a problem, because `instanceof` works by comparing prototypes by reference, and we've got two different identities for `ReplaceStep`! The comparison always fails, the filter always returns an empty array, and so it never appears to the plugin that we're making actionable edits.

It'd be better to have another, more reliable way of making this comparison, but sadly there's nothing publicly exposed on the `Step` [child classes](https://prosemirror.net/docs/ref/#transform.ReplaceStep) that I can see that lets us differentiate by e.g. class properties.

## How to test

This is quite difficult, because we're _still going to see this problem when we use `npm link`_ – there'll be two versions of `prosemirror-transform` in that case, too. One way would be to [publish an alpha release](https://medium.com/@kevinkreuzer/publishing-a-beta-or-alpha-version-to-npm-46035b630dd7) and include that in a 3rd party editor. 

I've published `@guardian/prosemirror-typerighter@1.0.1`, which is marked as alpha, but also a minor version, because apparently that's a thing you can do, to demo this.

tldr; – install `@guardian/prosemirror-typerighter@1.0.1` and you should see the problem go away.

## How can we measure success?

When importing this plugin, we see matches removed when users edit their ranges.