### PR TITLE
Remove 'fix all' button as not required currently

### DIFF
--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -5,7 +5,6 @@ import { ApplySuggestionOptions } from "../commands";
 import { IPluginState } from "../state/reducer";
 import { selectPercentRemaining } from "../state/selectors";
 import SidebarMatch from "./SidebarMatch";
-import { selectAllAutoFixableMatches } from "../state/selectors";
 import { IMatch } from "../interfaces/IMatch";
 
 interface IProps {
@@ -39,7 +38,6 @@ class Results extends Component<
   public render() {
     const {
       applySuggestions,
-      applyAutoFixableSuggestions,
       selectMatch,
       indicateHover,
       stopHover,
@@ -50,7 +48,6 @@ class Results extends Component<
     const { pluginState } = this.state;
     const { currentMatches = [], requestsInFlight, selectedMatch } = pluginState || { selectedMatch: undefined };
     const hasMatches = !!(currentMatches && currentMatches.length);
-    const noOfAutoFixableSuggestions = this.getNoOfAutoFixableSuggestions();
     const percentRemaining = this.getPercentRemaining();
     const isLoading =
       !!requestsInFlight && !!Object.keys(requestsInFlight).length;
@@ -62,14 +59,7 @@ class Results extends Component<
             <span>
               Results {hasMatches && <span>({currentMatches.length}) </span>}
             </span>
-            {!!noOfAutoFixableSuggestions && (
-              <button
-                class="Button flex-align-right"
-                onClick={applyAutoFixableSuggestions}
-              >
-                Fix all ({noOfAutoFixableSuggestions})
-              </button>
-            )}
+           
           </div>
           {contactHref && (
             <div className="Sidebar__header-contact">
@@ -153,13 +143,6 @@ class Results extends Component<
     return selectPercentRemaining(state);
   };
 
-  private getNoOfAutoFixableSuggestions = () => {
-    const state = this.state.pluginState;
-    if (!state) {
-      return 0;
-    }
-    return selectAllAutoFixableMatches(state).length;
-  };
 }
 
 export default Results;


### PR DESCRIPTION
Co-authored-by: Sam Hession <samhession@live.co.uk>

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The 'fix all' button appeared in the UI although it's not required at the moment. This PR removes it.

## How to test
Run this branch locally and see that there is no visible 'fix all' button next to 'Results'.

## Images

### Before
![image](https://user-images.githubusercontent.com/15648334/90495743-e422e180-e13c-11ea-8317-e5d2a5246316.png)


### After
![image](https://user-images.githubusercontent.com/15648334/90495577-ad4ccb80-e13c-11ea-9812-d5668d4ae34a.png)

