### PR TITLE
Use popper.js to position tooltips properly

### DIFF
--- a/build/rollup.config.build.js
+++ b/build/rollup.config.build.js
@@ -29,7 +29,9 @@ const externalModules = [
   "prop-types",
   "react-is",
   "hoist-non-react-statics",
-  "diff"
+  "diff",
+  "react-fast-compare",
+  "warning"
 ];
 
 const external = id =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,6 +918,11 @@
         "react-is": "^16.8.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
+      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+    },
     "@rollup/plugin-alias": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.1.tgz",
@@ -8621,10 +8626,24 @@
         }
       }
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-popper": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.3.tgz",
+      "integrity": "sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==",
+      "requires": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      }
     },
     "react-transition-group": {
       "version": "4.4.1",
@@ -11099,6 +11118,14 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watch": {

--- a/package.json
+++ b/package.json
@@ -79,11 +79,13 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@popperjs/core": "^2.4.4",
     "diff": "^4.0.2",
     "lodash": "^4.17.11",
     "preact": "^10.4.7",
     "prosemirror-tables": "^0.7.8",
     "prosemirror-utils": "^0.6.7",
+    "react-popper": "^2.2.3",
     "uuid": "^8.3.0"
   }
 }

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -62,7 +62,6 @@ if (editorElement && sidebarNode) {
     new TyperighterAdapter("https://api.typerighter.local.dev-gutools.co.uk")
   );
   createView({
-    view,
     store,
     matcherService,
     commands,

--- a/src/css/MatchDebug.scss
+++ b/src/css/MatchDebug.scss
@@ -1,0 +1,8 @@
+
+.MatchDebugDirty {
+  background-color: $match-debug-color-dirty;
+}
+
+.MatchDebugInflight {
+  background-color: $match-debug-color-inflight;
+}

--- a/src/css/MatchDecoration.scss
+++ b/src/css/MatchDecoration.scss
@@ -1,0 +1,26 @@
+.MatchDecoration {
+  border-bottom: 2px solid $match-color;
+}
+
+.MatchDecoration__height-marker {
+  &:before {
+    // We insert a unicode zero width space character here to ensure the
+    // height marker has content. As a result, it grows to match the line-height.
+    // See https://stackoverflow.com/questions/14217902/how-to-set-empty-span-height-equal-to-default-line-height
+    content: "\200b";
+  }
+}
+
+.MatchDecoration--is-correct {
+  position: relative;
+  &:after {
+    display: block;
+    content: "✓";
+    position: absolute;
+    right: -10px;
+    top: -8px;
+    color: rgb(4, 213, 20);
+    font-weight: bold;
+    pointer-events: none;
+  }
+}

--- a/src/css/MatchWidget.scss
+++ b/src/css/MatchWidget.scss
@@ -1,0 +1,143 @@
+
+.MatchWidget {
+  background-color: white;
+  display: block;
+  position: relative;
+  padding: $gutter-width * 1.5;
+  font-family: sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.2), 0 10px 10px rgba(0, 0, 0, 0.18);
+  border-radius: 3px;
+  width: 300px;
+  transition: opacity 0.1s, transform 0.1s;
+  transform: translate3d(0, -3px, 0);
+  z-index: 100;
+  overflow: hidden;
+}
+
+.MatchWidget__container {
+  /**
+   * We provide padding here to distance the MatchWidget tooltip
+   * from the decoration it's attached to. The value is 15px, but
+   * the distance the user sees is ~10px, as we ask our tooltip
+   * library to offset its positioning by -5px.
+   *
+   * This ensures that there's no gap between the tooltip and the
+   * decoration when the user moves their mouse from the decoration
+   * to the tooltip. If there's a gap, the tooltip library detects a
+   * `mouseleave` event and closes the tooltip prematurely.
+   *
+   * We align the tooltip to the left by default,
+   */
+  padding: 15px 15px 15px 0px;
+  position: relative;
+  font-size: $font-size-base;
+}
+
+.MatchWidget__container--is-hovering .MatchWidget {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.MatchWidget__type {
+  color: $match-gray;
+  font-variant: small-caps;
+  // normalise line height, as the small-caps take up less space
+  line-height: 0.7;
+  text-transform: lowercase;
+  letter-spacing: 0.3px;
+}
+.MatchWidget__suggestion {
+  padding: $gutter-width;
+}
+
+.MatchWidget__type {
+  padding-bottom: $gutter-width;
+}
+
+.MatchWidget__annotation {
+  padding-top: $gutter-width;
+}
+
+.MatchWidget__color-swatch {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 5px;
+  border-radius: 8px;
+}
+
+.MatchWidget__label {
+  display: block;
+  margin-bottom: 2px;
+  transition: background-color 0.1s;
+}
+
+.MatchWidget__suggestion-list {
+  display: block;
+  margin-top: 3px;
+}
+
+.MatchWidget__suggestion {
+  display: block;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: $font-size-large;
+  color: $match-suggestion-color;
+  background-color: $match-suggestion-background-color;
+}
+
+.MatchWidget__suggestion:nth-child(even) {
+  background-color: darken($match-suggestion-background-color, 2%);
+}
+
+.MatchWidget__suggestion:hover {
+  color: $match-suggestion-color-hover;
+  background-color: $match-suggestion-background-color-hover;
+}
+.MatchWidget__suggestion + .MatchWidget__suggestion {
+  margin-top: 3px;
+}
+
+.MatchWidget__footer {
+  margin-top: $gutter-width;
+  display: flex;
+  align-items: flex-end;
+  width: 100%;
+}
+
+.MatchWidget__ignore-match {
+  display: block;
+  margin-left: auto;
+  cursor: pointer;
+
+  .MatchWidget__ignore-match-button {
+    padding: $gutter-width;
+    border-radius: $base-border-radius;
+    font-weight: normal;
+    font-size: $font-size-base;
+    color: $match-suggestion-background-color;
+  }
+
+  .MatchWidget__ignore-match-button:hover {
+    background-color: $match-ignore-color-hover;
+  }
+
+  .MatchWidget__ignore-match-icon {
+    font-size: 0.8em;
+    padding-right: 5px;
+  }
+
+}
+
+.SidebarMatch__suggestion-list + .MatchWidget__ignore-match {
+  margin-top: 3px;
+}
+
+.MatchWidget__feedbackLink {
+  font-size: $font-size-small;
+  a {
+    color: $match-gray;
+  }
+}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -50,6 +50,9 @@ $base-border-radius: 3px;
 @import "./Suggestion.scss";
 @import "./SuggestionList.scss";
 @import "./Icon.scss";
+@import "./MatchWidget.scss";
+@import "./MatchDecoration.scss";
+@import "./MatchDebug.scss";
 
 // Elements
 
@@ -89,171 +92,6 @@ hr {
   outline: none;
 }
 
-.MatchWidget {
-  background-color: white;
-  display: block;
-  position: relative;
-  padding: $gutter-width * 1.5;
-  font-family: sans-serif;
-  font-style: normal;
-  font-weight: normal;
-  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.2), 0 10px 10px rgba(0, 0, 0, 0.18);
-  border-radius: 3px;
-  width: 300px;
-  transition: opacity 0.1s, transform 0.1s;
-  transform: translate3d(0, -3px, 0);
-  z-index: 100;
-  overflow: hidden;
-}
-
-.MatchWidget__container {
-  margin-top: 13px;
-  position: relative;
-  font-size: $font-size-base;
-}
-
-.MatchWidget__container--is-hovering .MatchWidget {
-  opacity: 1;
-  transform: translate3d(0, 0, 0);
-}
-
-.MatchWidget__type {
-  color: $match-gray;
-  font-variant: small-caps;
-  // normalise line height, as the small-caps take up less space
-  line-height: 0.7;
-  text-transform: lowercase;
-  letter-spacing: 0.3px;
-}
-.MatchWidget__suggestion {
-  padding: $gutter-width;
-}
-
-.MatchWidget__type {
-  padding-bottom: $gutter-width;
-}
-
-.MatchWidget__annotation {
-  padding-top: $gutter-width;
-}
-
-.MatchWidget__color-swatch {
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  margin-right: 5px;
-  border-radius: 8px;
-}
-
-.MatchWidget__label {
-  display: block;
-  margin-bottom: 2px;
-  transition: background-color 0.1s;
-}
-
-.MatchWidget__suggestion-list {
-  display: block;
-  margin-top: 3px;
-}
-
-.MatchWidget__suggestion {
-  display: block;
-  cursor: pointer;
-  font-weight: bold;
-  font-size: $font-size-large;
-  color: $match-suggestion-color;
-  background-color: $match-suggestion-background-color;
-}
-
-.MatchWidget__suggestion:nth-child(even) {
-  background-color: darken($match-suggestion-background-color, 2%);
-}
-
-.MatchWidget__suggestion:hover {
-  color: $match-suggestion-color-hover;
-  background-color: $match-suggestion-background-color-hover;
-}
-.MatchWidget__suggestion + .MatchWidget__suggestion {
-  margin-top: 3px;
-}
-
-.MatchWidget__footer {
-  margin-top: $gutter-width;
-  display: flex;
-  align-items: flex-end;
-  width: 100%;
-}
-
-.MatchWidget__ignore-match {
-  display: block;
-  margin-left: auto;
-  cursor: pointer;
-
-  .MatchWidget__ignore-match-button {
-    padding: $gutter-width;
-    border-radius: $base-border-radius;
-    font-weight: normal;
-    font-size: $font-size-base;
-    color: $match-suggestion-background-color;
-  }
-
-  .MatchWidget__ignore-match-button:hover {
-    background-color: $match-ignore-color-hover;
-  }
-
-  .MatchWidget__ignore-match-icon {
-    font-size: 0.8em;
-    padding-right: 5px;
-  }
-
-}
-
-.SidebarMatch__suggestion-list + .MatchWidget__ignore-match {
-  margin-top: 3px;
-}
-
-.MatchWidget__feedbackLink {
-  font-size: $font-size-small;
-  a {
-    color: $match-gray;
-  }
-}
-
-.MatchDecoration {
-  border-bottom: 2px solid $match-color;
-}
-
-.MatchDecoration__height-marker {
-  &:before {
-    // We insert a unicode zero width space character here to ensure the
-    // height marker has content. As a result, it grows to match the line-height.
-    // See https://stackoverflow.com/questions/14217902/how-to-set-empty-span-height-equal-to-default-line-height
-    content: "\200b";
-  }
-}
-
-.MatchDecoration--is-correct {
-  position: relative;
-  &:after {
-    display: block;
-    content: "✓";
-    position: absolute;
-    right: -10px;
-    top: -8px;
-    color: rgb(4, 213, 20);
-    font-weight: bold;
-    pointer-events: none;
-  }
-}
-
-.MatchDebugDirty {
-  background-color: $match-debug-color-dirty;
-}
-
-.MatchDebugInflight {
-  background-color: $match-debug-color-inflight;
-}
-
 .TyperighterPlugin__overlay {
   position: absolute;
   top: 0;
@@ -264,6 +102,11 @@ hr {
   position: absolute;
 }
 
-.TyperighterPlugin__container {
+.TyperighterPlugin__tooltip-overlay {
+  // position: relative provides a new stacking context, which
+  // gives the tooltip a better chance of appearing on top of
+  // other elements.
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
   position: relative;
+  z-index: 10;
 }

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -1,4 +1,3 @@
-import { EditorView } from "prosemirror-view";
 import { h, render } from "preact";
 import MatchOverlay from "./components/MatchOverlay";
 import Store from "./state/store";
@@ -9,7 +8,6 @@ import { ILogger, consoleLogger } from "./utils/logger";
 import Sidebar from "./components/Sidebar";
 
 interface IViewOptions {
-  view: EditorView;
   store: Store<IMatch>;
   matcherService: MatcherService<IMatch>;
   commands: Commands;

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -26,7 +26,6 @@ interface IViewOptions {
   // to place the match in the middle of the screen, as the size of the
   // document might change during the lifecycle of the page.
   getScrollOffset?: () => number;
-
 }
 
 /**
@@ -37,7 +36,6 @@ interface IViewOptions {
  *  - The plugin results pane
  */
 const createView = ({
-  view,
   store,
   matcherService,
   commands,
@@ -52,14 +50,8 @@ const createView = ({
   // Create our overlay node, which is responsible for displaying
   // match messages when the user hovers over highlighted ranges.
   const overlayNode = document.createElement("div");
-
-  // We wrap this in a container to allow the overlay to be positioned
-  // relative to the editable document.
-  const wrapperElement = document.createElement("div");
-  wrapperElement.classList.add("TyperighterPlugin__container");
-  view.dom.parentNode!.replaceChild(wrapperElement, view.dom);
-  wrapperElement.appendChild(view.dom);
-  view.dom.insertAdjacentElement("afterend", overlayNode);
+  overlayNode.classList.add("TyperighterPlugin__tooltip-overlay");
+  document.body.appendChild(overlayNode);
   logger.info("Typerighter plugin starting");
 
   // Finally, render our components.
@@ -77,7 +69,6 @@ const createView = ({
           onMarkCorrect(match);
         })
       }
-      containerElement={wrapperElement}
       feedbackHref={feedbackHref}
     />,
     overlayNode


### PR DESCRIPTION
## What does this change?

Previously, some ad-hoc position code was being used to position tooltips. This is a hard, edge-casey, solved problem. This PR uses [popper.js](https://popper.js.org/) to solve it instead.

## How to test

Tooltips should appear underneath match decorations as usual, but now, they're liberated from the bounds of their editor element.

<img width="578" alt="Screenshot 2020-08-18 at 18 05 30" src="https://user-images.githubusercontent.com/7767575/90546209-a8f6d180-e181-11ea-8e21-1e6afda940c6.png">

## How can we measure success?

Tooltips are no longer hidden by other DOM elements or constrained by the editor element.
