### PR TITLE
Add markdown parsing to the match descriptions

### DIFF
--- a/build/rollup.config.build.js
+++ b/build/rollup.config.build.js
@@ -31,7 +31,8 @@ const externalModules = [
   "hoist-non-react-statics",
   "diff",
   "react-fast-compare",
-  "warning"
+  "warning",
+  "snarkdown"
 ];
 
 const external = id =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6715,10 +6715,9 @@
       }
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
+      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
     },
     "math-random": {
       "version": "1.0.4",
@@ -10782,6 +10781,12 @@
             "uglify-js": "^3.1.4",
             "wordwrap": "^1.0.0"
           }
+        },
+        "marked": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+          "dev": true
         },
         "minimist": {
           "version": "1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6714,11 +6714,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "marked": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
-      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
-    },
     "math-random": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
@@ -9995,6 +9990,11 @@
       "requires": {
         "kind-of": "^3.2.0"
       }
+    },
+    "snarkdown": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/snarkdown/-/snarkdown-1.2.2.tgz",
+      "integrity": "sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ="
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@popperjs/core": "^2.4.4",
     "diff": "^4.0.2",
     "lodash": "^4.17.11",
+    "marked": "^1.1.1",
     "preact": "^10.4.7",
     "prosemirror-tables": "^0.7.8",
     "prosemirror-utils": "^0.6.7",

--- a/package.json
+++ b/package.json
@@ -82,11 +82,11 @@
     "@popperjs/core": "^2.4.4",
     "diff": "^4.0.2",
     "lodash": "^4.17.11",
-    "marked": "^1.1.1",
     "preact": "^10.4.7",
     "prosemirror-tables": "^0.7.8",
     "prosemirror-utils": "^0.6.7",
     "react-popper": "^2.2.3",
+    "snarkdown": "^1.2.2",
     "uuid": "^8.3.0"
   }
 }

--- a/src/css/MatchWidget.scss
+++ b/src/css/MatchWidget.scss
@@ -58,6 +58,11 @@
 
 .MatchWidget__annotation {
   padding-top: $gutter-width;
+  // Match descriptions generated with markdown
+  // will be nested in p tags.
+  p {
+    margin: 0;
+  }
 }
 
 .MatchWidget__color-swatch {

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,3 +1,11 @@
 declare module "prosemirror-test-builder";
 declare module "prosemirror-example-setup";
+// Taken from https://github.com/developit/snarkdown/blob/master/snarkdown.d.ts –
+// at time of writing the typescript definition file is not yet in the npm release.
+declare module "snarkdown" {
+  interface Links {
+    [index: string]: string;
+  }
+  export default function (urlStr: string, prevLinks?: Links): string;
+}
 declare module "*.scss";

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -46,7 +46,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       markAsCorrect
     };
 
-    const safeMessage = stripHtml(message);
+    const messageWithoutHtml = stripHtml(message);
     const suggestionsToRender = replacement ? [replacement] : suggestions || [];
     const suggestionContent = (
       <div className="MatchWidget__suggestion-list">
@@ -88,7 +88,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
           {suggestionContent}
           <div
             className="MatchWidget__annotation"
-            dangerouslySetInnerHTML={{ __html: snarkdown(safeMessage) }}
+            dangerouslySetInnerHTML={{ __html: snarkdown(messageWithoutHtml) }}
           ></div>
           <div className="MatchWidget__footer">
             {this.props.feedbackHref && (

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -1,9 +1,12 @@
 import { Component, h } from "preact";
+import snarkdown from "snarkdown";
+
 import { IMatch } from "../interfaces/IMatch";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
 import { getColourForMatch, IMatchColours } from "../utils/decoration";
 import Correct from "./icons/Correct";
+import { stripHtml } from "../utils/dom";
 
 interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
@@ -43,28 +46,31 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       markAsCorrect
     };
 
+    const safeMessage = stripHtml(message);
     const suggestionsToRender = replacement ? [replacement] : suggestions || [];
     const suggestionContent = (
-        <div className="MatchWidget__suggestion-list">
-          {suggestionsToRender && applySuggestions && !markAsCorrect && 
+      <div className="MatchWidget__suggestion-list">
+        {suggestionsToRender && applySuggestions && !markAsCorrect && (
           <SuggestionList
             applySuggestions={applySuggestions}
             matchId={matchId}
             matchedText={matchedText}
             suggestions={suggestionsToRender}
-          />}
-          {onMarkCorrect && (
-              <div className="MatchWidget__ignore-match">
-                <div className="MatchWidget__ignore-match-button"
-                onClick={() => onMarkCorrect(match)}
-                >
-                  <Correct className="MatchWidget__ignore-match-icon"/>
-                   Mark as correct
-                </div>
-              </div>
-            )}
-        </div>
-      );
+          />
+        )}
+        {onMarkCorrect && (
+          <div className="MatchWidget__ignore-match">
+            <div
+              className="MatchWidget__ignore-match-button"
+              onClick={() => onMarkCorrect(match)}
+            >
+              <Correct className="MatchWidget__ignore-match-icon" />
+              Mark as correct
+            </div>
+          </div>
+        )}
+      </div>
+    );
 
     return (
       <div className="MatchWidget__container">
@@ -72,12 +78,18 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
           <div className="MatchWidget__type">
             <span
               className="MatchWidget__color-swatch"
-              style={{ backgroundColor: getColourForMatch(match, matchColours, false).borderColour }}
+              style={{
+                backgroundColor: getColourForMatch(match, matchColours, false)
+                  .borderColour
+              }}
             ></span>
             {category.name}
           </div>
           {suggestionContent}
-          <div className="MatchWidget__annotation">{message}</div>
+          <div
+            className="MatchWidget__annotation"
+            dangerouslySetInnerHTML={{ __html: snarkdown(safeMessage) }}
+          ></div>
           <div className="MatchWidget__footer">
             {this.props.feedbackHref && (
               <div className="MatchWidget__feedbackLink">

--- a/src/ts/utils/dom.ts
+++ b/src/ts/utils/dom.ts
@@ -1,6 +1,15 @@
 import { IStateHoverInfo } from "../state/reducer";
 
 /**
+ * Strip any HTML from an input string.
+ */
+export const stripHtml = (text: string) => {
+  const decoder = document.createElement('div')
+  decoder.innerHTML = text
+  return decoder.textContent || ''
+}
+
+/**
  * Find the first ancestor node of the given node that matches the selector.
  */
 export function findAncestor(


### PR DESCRIPTION
## What does this change?

Adds markdown to the match descriptions.

Before:

<img width="356" alt="Screenshot 2020-08-19 at 10 31 16" src="https://user-images.githubusercontent.com/7767575/90617887-244e9680-e207-11ea-9820-d2d3bc4c56af.png">


After:
<img width="323" alt="Screenshot 2020-08-19 at 09 04 54" src="https://user-images.githubusercontent.com/7767575/90617923-2d3f6800-e207-11ea-82f7-a9c55b90c392.png">

## How to test

Trigger a match with markdown syntax, like the example. It should be rendered correctly.

## Dev notes

Because we don't expect HTML markup, we can avoid using a sanitisation library by stripping HTML from the message data altogether – see `stripHtml`.