### PR TITLE
Add markdown to sidebar matches, too

### DIFF
--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -1,12 +1,11 @@
 import React, { Component } from "react";
-import snarkdown from "snarkdown";
 
 import { IMatch } from "../interfaces/IMatch";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
 import { getColourForMatch, IMatchColours } from "../utils/decoration";
 import { Check } from "@material-ui/icons";
-import { stripHtml } from "../utils/dom";
+import { getHtmlFromMarkdown } from "../utils/dom";
 
 interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
@@ -47,7 +46,6 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       markAsCorrect
     };
 
-    const messageWithoutHtml = stripHtml(message);
     const suggestionsToRender = replacement ? [replacement] : suggestions || [];
     const suggestionContent = (
       <div className="MatchWidget__suggestion-list">
@@ -57,20 +55,23 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
             matchId={matchId}
             matchedText={matchedText}
             suggestions={suggestionsToRender}
-/>
-)}
-          {onMarkCorrect && (
-              <div className="MatchWidget__ignore-match">
-                <div className="MatchWidget__ignore-match-button"
-                onClick={() => onMarkCorrect(match)}
-                >
-                  <Check fontSize="small" />
-                  <span className="MatchWidget__ignore-match-text">Mark as correct</span>
-                </div>
-              </div>
-            )}
-        </div>
-      );
+          />
+        )}
+        {onMarkCorrect && (
+          <div className="MatchWidget__ignore-match">
+            <div
+              className="MatchWidget__ignore-match-button"
+              onClick={() => onMarkCorrect(match)}
+            >
+              <Check fontSize="small" />
+              <span className="MatchWidget__ignore-match-text">
+                Mark as correct
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+    );
 
     return (
       <div className="MatchWidget__container">
@@ -88,7 +89,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
           {suggestionContent}
           <div
             className="MatchWidget__annotation"
-            dangerouslySetInnerHTML={{ __html: snarkdown(messageWithoutHtml) }}
+            dangerouslySetInnerHTML={{ __html: getHtmlFromMarkdown(message) }}
           ></div>
           <div className="MatchWidget__footer">
             {this.props.feedbackHref && (

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -1,6 +1,8 @@
 import compact from "lodash/compact";
-import { IMatch } from "../interfaces/IMatch";
+
 import React, { Component } from "react";
+
+import { IMatch } from "../interfaces/IMatch";
 import {
   IMatchColours,
   getColourForMatch,
@@ -9,6 +11,7 @@ import {
 import titleCase from "lodash/startCase";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
+import { getHtmlFromMarkdown } from "../utils/dom";
 
 interface IProps {
   match: IMatch;
@@ -64,9 +67,12 @@ class SidebarMatch extends Component<IProps, IState> {
               <div className="SidebarMatch__header-match-text">
                 {match.matchedText}
               </div>
-              <div className="SidebarMatch__header-description">
-                {match.message}
-              </div>
+              <div
+                className="SidebarMatch__header-description"
+                dangerouslySetInnerHTML={{
+                  __html: getHtmlFromMarkdown(match.message)
+                }}
+              ></div>
             </div>
             <div className="SidebarMatch__header-meta">
               <div className="SidebarMatch__header-category">

--- a/src/ts/utils/dom.ts
+++ b/src/ts/utils/dom.ts
@@ -1,7 +1,9 @@
 import snarkdown from "snarkdown";
 
 /**
- * Strip any HTML from an input string.
+ * Convert a string containing markdown to HTML.
+ *
+ * Strips any existing markup before converting.
  */
 export const getHtmlFromMarkdown = (markdown: string) => {
   const decoder = document.createElement("div");

--- a/src/ts/utils/dom.ts
+++ b/src/ts/utils/dom.ts
@@ -1,11 +1,13 @@
+import snarkdown from "snarkdown";
+
 /**
  * Strip any HTML from an input string.
  */
-export const stripHtml = (text: string) => {
-  const decoder = document.createElement('div')
-  decoder.innerHTML = text
-  return decoder.textContent || ''
-}
+export const getHtmlFromMarkdown = (markdown: string) => {
+  const decoder = document.createElement("div");
+  decoder.innerHTML = markdown;
+  return snarkdown(decoder.textContent || "");
+};
 
 /**
  * Find the first ancestor node of the given node that matches the selector.


### PR DESCRIPTION
## What does this change?

#115 added markdown for tooltips. But we also have the same markdown in the sidebar 🤦 

This PR adds that.

Before:

<img width="293" alt="Screenshot 2020-08-19 at 14 36 48" src="https://user-images.githubusercontent.com/7767575/90641733-799b9f80-e229-11ea-851a-ed608114bb78.png">

After:

<img width="293" alt="Screenshot 2020-08-19 at 14 36 20" src="https://user-images.githubusercontent.com/7767575/90641737-7bfdf980-e229-11ea-9736-6d6c984a5510.png">

## How to test

You should be able to see markdown in the sidebar match descriptions, as well as the tooltips.
