### PR TITLE
Ts/error on auth fail

### DIFF
--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -22,8 +22,8 @@ import {
 } from "./state/reducer";
 import {
   IMatcherResponse,
-  IMatchRequestError,
-  IMatch
+  IMatch,
+  TMatchRequestErrorWithDefault
 } from "./interfaces/IMatch";
 import { EditorView } from "prosemirror-view";
 import { compact } from "./utils/array";
@@ -208,13 +208,16 @@ export const applyMatcherResponseCommand = (
  * to be resent on the next request.
  */
 export const applyRequestErrorCommand = (
-  matchRequestError: IMatchRequestError
+  matchRequestError: TMatchRequestErrorWithDefault
 ): Command => (state, dispatch) => {
   if (dispatch) {
     dispatch(
       state.tr.setMeta(
         PROSEMIRROR_TYPERIGHTER_ACTION,
-        requestError(matchRequestError)
+        requestError({
+          ...matchRequestError,
+          type: matchRequestError.type || "GENERAL_ERROR"
+        })
       )
     );
   }

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -6,7 +6,11 @@ import { Close } from "@material-ui/icons";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
 import { IMatch, ICategory } from "../interfaces/IMatch";
-import { selectHasError, selectRequestsInProgress } from "../state/selectors";
+import {
+  selectHasError,
+  selectHasAuthError,
+  selectRequestsInProgress
+} from "../state/selectors";
 
 interface IProps {
   store: Store<IMatch>;
@@ -45,7 +49,6 @@ class Controls extends Component<IProps, IState> {
   }
 
   public render() {
-
     const handleCheckDocumentButtonClick = (): void => {
       if (!this.state.pluginState?.config.isActive) {
         this.props.onToggleActiveState();
@@ -65,7 +68,10 @@ class Controls extends Component<IProps, IState> {
               type="button"
               className="Button"
               onClick={handleCheckDocumentButtonClick}
-              disabled={this.state.pluginState && selectRequestsInProgress(this.state.pluginState)}
+              disabled={
+                this.state.pluginState &&
+                selectRequestsInProgress(this.state.pluginState)
+              }
             >
               Check document
             </button>
@@ -74,7 +80,10 @@ class Controls extends Component<IProps, IState> {
                 size="small"
                 aria-label="close Typerighter"
                 onClick={this.props.onToggleActiveState}
-                disabled={this.state.pluginState && selectRequestsInProgress(this.state.pluginState)}
+                disabled={
+                  this.state.pluginState &&
+                  selectRequestsInProgress(this.state.pluginState)
+                }
               >
                 <Close />
               </IconButton>
@@ -82,9 +91,26 @@ class Controls extends Component<IProps, IState> {
           </div>
         </div>
 
-        {this.state.pluginState && selectHasError(this.state.pluginState) && (
+        {this.state.pluginState &&
+          selectHasError(this.state.pluginState) &&
+          !selectHasAuthError(this.state.pluginState) && (
+            <div className="Controls__error-message">
+              Error fetching matches. Please try checking the document again.{" "}
+              {this.props.feedbackHref && (
+                <span>
+                  If the error persists, please{" "}
+                  <a href={this.getErrorFeedbackLink()} target="_blank">
+                    contact us
+                  </a>
+                  .
+                </span>
+              )}
+            </div>
+          )}
+
+        {this.state.pluginState && selectHasAuthError(this.state.pluginState) && (
           <div className="Controls__error-message">
-            Error fetching matches. Please try checking the document again.{" "}
+            Authentication error - please refresh the page.{" "}
             {this.props.feedbackHref && (
               <span>
                 If the error persists, please{" "}

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -49,8 +49,10 @@ class Controls extends Component<IProps, IState> {
   }
 
   public render() {
+    const pluginIsActive = this.state.pluginState?.config.isActive;
+
     const handleCheckDocumentButtonClick = (): void => {
-      if (!this.state.pluginState?.config.isActive) {
+      if (!pluginIsActive) {
         this.props.onToggleActiveState();
       }
       this.requestMatchesForDocument();
@@ -112,7 +114,7 @@ class Controls extends Component<IProps, IState> {
             >
               Check document
             </button>
-            {this.state.pluginState?.config.isActive && (
+            {pluginIsActive && (
               <IconButton
                 size="small"
                 aria-label="close Typerighter"
@@ -127,7 +129,7 @@ class Controls extends Component<IProps, IState> {
             )}
           </div>
         </div>
-        {renderErrorMessage()}
+        {pluginIsActive && renderErrorMessage()}
       </>
     );
   }

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -7,7 +7,7 @@ import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
 import { IMatch, ICategory } from "../interfaces/IMatch";
 import {
-  selectHasError,
+  selectHasGeneralError,
   selectHasAuthError,
   selectRequestsInProgress
 } from "../state/selectors";
@@ -60,6 +60,43 @@ class Controls extends Component<IProps, IState> {
       ? "Sidebar__header-container"
       : "Sidebar__header-container Sidebar__header-container--is-closed";
 
+    const renderErrorMessage = () => {
+      const pluginState = this.state.pluginState;
+
+      if (!pluginState) {
+        return;
+      }
+
+      const hasAuthError = selectHasAuthError(pluginState);
+      const hasGeneralError = selectHasGeneralError(pluginState);
+      const hasErrors: boolean = hasAuthError || hasGeneralError;
+
+      let errorMessage: string = "";
+      if (hasAuthError) {
+        errorMessage = "Authentication error - please refresh the page. ";
+      }
+      if (hasGeneralError && !hasAuthError) {
+        errorMessage =
+          "Error fetching matches. Please try checking the document again. ";
+      }
+      if (hasErrors) {
+        return (
+          <div className="Controls__error-message">
+            {errorMessage}
+            {this.props.feedbackHref && (
+              <span>
+                If the error persists, please{" "}
+                <a href={this.getErrorFeedbackLink()} target="_blank">
+                  contact us
+                </a>
+                .
+              </span>
+            )}
+          </div>
+        );
+      }
+    };
+
     return (
       <>
         <div className={headerContainerClasses}>
@@ -90,38 +127,7 @@ class Controls extends Component<IProps, IState> {
             )}
           </div>
         </div>
-
-        {this.state.pluginState &&
-          selectHasError(this.state.pluginState) &&
-          !selectHasAuthError(this.state.pluginState) && (
-            <div className="Controls__error-message">
-              Error fetching matches. Please try checking the document again.{" "}
-              {this.props.feedbackHref && (
-                <span>
-                  If the error persists, please{" "}
-                  <a href={this.getErrorFeedbackLink()} target="_blank">
-                    contact us
-                  </a>
-                  .
-                </span>
-              )}
-            </div>
-          )}
-
-        {this.state.pluginState && selectHasAuthError(this.state.pluginState) && (
-          <div className="Controls__error-message">
-            Authentication error - please refresh the page.{" "}
-            {this.props.feedbackHref && (
-              <span>
-                If the error persists, please{" "}
-                <a href={this.getErrorFeedbackLink()} target="_blank">
-                  contact us
-                </a>
-                .
-              </span>
-            )}
-          </div>
-        )}
+        {renderErrorMessage()}
       </>
     );
   }

--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -1,3 +1,5 @@
+import { PartialBy } from "../utils/types";
+
 export interface IRange {
   from: number;
   to: number;
@@ -30,14 +32,22 @@ export interface IWikiSuggestion {
   score: number;
 }
 
+export type TErrorType = "GENERAL_ERROR" | "AUTH_ERROR";
+
 export interface IMatchRequestError {
   requestId: string;
   // If we have an id, we can link the error to a specific block.
   // If not, we treat the error as nonspecific.
   blockId?: string;
   message: string;
-  categoryIds: string[]
+  categoryIds: string[];
+  type: TErrorType;
 }
+
+export type TMatchRequestErrorWithDefault = PartialBy<
+  IMatchRequestError,
+  "type"
+>;
 
 export interface IMatch<TSuggestion = ISuggestion> {
   matchId: string;
@@ -72,4 +82,3 @@ export type IMatchLibrary = Array<
     type: string;
   }>
 >;
-

--- a/src/ts/interfaces/IMatcherAdapter.ts
+++ b/src/ts/interfaces/IMatcherAdapter.ts
@@ -3,7 +3,7 @@ import {
   IMatch,
   ICategory,
   IMatcherResponse,
-  IMatchRequestError
+  TMatchRequestErrorWithDefault
 } from "./IMatch";
 
 /**
@@ -37,7 +37,7 @@ export type TMatchesReceivedCallback<
 > = (response: IMatcherResponse<TMatch>) => void;
 
 export type TRequestErrorCallback = (
-  matchRequestError: IMatchRequestError
+  matchRequestError: TMatchRequestErrorWithDefault
 ) => void;
 
 export type TRequestCompleteCallback = (requestId: string) => void;

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -110,17 +110,17 @@ export const selectAllAutoFixableMatches = <TMatch extends IMatch>(
     _ => _.replacement && _.replacement.text === _.message
   );
 
-export const selectHasError = <TMatch extends IMatch>(
+export const selectHasGeneralError = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
-): boolean => !!state.requestErrors && state.requestErrors.length > 0;
+): boolean => {
+  const generalErrors = state.requestErrors.filter(_ => _.type === "GENERAL_ERROR");
+  return !!state.requestErrors && generalErrors.length > 0};
 
 export const selectHasAuthError = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
 ): boolean => {
-  const authErrors = state.requestErrors.filter(_ =>
-    _.message.startsWith("401")
-  );
-  return authErrors.length > 0;
+  const authErrors = state.requestErrors.filter(_ => _.type === "AUTH_ERROR");
+  return !!state.requestErrors && authErrors.length > 0;
 };
 
 export const selectRequestsInProgress = <TMatch extends IMatch>(

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -1,9 +1,5 @@
 import { IMatch } from "../interfaces/IMatch";
-import {
-  IPluginState,
-  IBlockInFlight,
-  IBlocksInFlightState
-} from "./reducer";
+import { IPluginState, IBlockInFlight, IBlocksInFlightState } from "./reducer";
 
 export const selectMatchByMatchId = <TMatch extends IMatch>(
   state: IPluginState<TMatch>,
@@ -11,9 +7,7 @@ export const selectMatchByMatchId = <TMatch extends IMatch>(
 ): IMatch | undefined =>
   state.currentMatches.find(match => match.matchId === matchId);
 
-export const selectBlockQueriesInFlightForSet = <
-  TMatch extends IMatch
->(
+export const selectBlockQueriesInFlightForSet = <TMatch extends IMatch>(
   state: IPluginState<TMatch>,
   requestId: string
 ): IBlocksInFlightState | undefined => {
@@ -25,21 +19,14 @@ export const selectSingleBlockInFlightById = <TMatch extends IMatch>(
   requestId: string,
   blockId: string
 ): IBlockInFlight | undefined => {
-  const blocksInFlight = selectBlockQueriesInFlightForSet(
-    state,
-    requestId
-  );
+  const blocksInFlight = selectBlockQueriesInFlightForSet(state, requestId);
   if (!blocksInFlight) {
     return;
   }
-  return blocksInFlight.pendingBlocks.find(
-    _ => _.block.id === blockId
-  );
+  return blocksInFlight.pendingBlocks.find(_ => _.block.id === blockId);
 };
 
-export const selectBlockQueriesInFlightById = <
-  TMatch extends IMatch
->(
+export const selectBlockQueriesInFlightById = <TMatch extends IMatch>(
   state: IPluginState<TMatch>,
   requestId: string,
   blockIds: string[]
@@ -125,8 +112,16 @@ export const selectAllAutoFixableMatches = <TMatch extends IMatch>(
 
 export const selectHasError = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
-): boolean =>
-  !!state.requestErrors && state.requestErrors.length > 0;
+): boolean => !!state.requestErrors && state.requestErrors.length > 0;
+
+export const selectHasAuthError = <TMatch extends IMatch>(
+  state: IPluginState<TMatch>
+): boolean => {
+  const authErrors = state.requestErrors.filter(_ =>
+    _.message.startsWith("401")
+  );
+  return authErrors.length > 0;
+};
 
 export const selectRequestsInProgress = <TMatch extends IMatch>(
   state: IPluginState<TMatch>

--- a/src/ts/utils/types.ts
+++ b/src/ts/utils/types.ts
@@ -4,3 +4,5 @@ export type ArgumentTypes<F extends Function> = F extends (
 ) => any
   ? A
   : never;
+
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;


### PR DESCRIPTION
Co-authored-by: Jonathon Herbert <jonathon.herbert@guardian.co.uk>

## What does this change?
Currently, when there is an authentication error, the user sees an error message stating 'error fetching matches...'. This PR is to ensure the Typerighter plugin gives a clear error on authentication failures, so the user is prompted to refresh the page. This PR also addresses a UI bug which meant that error messages persisted when the plugin was closed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run the branch locally, delete any cookies on Composer that are allowing auth of Typerighter, and see an error message suggesting you refresh the page. 

## How can we measure success?
Users should be able to differentiate between authentication errors and errors in fetching matches in Typerighter.

## Images

### Before - all errors
![auth-error-before](https://user-images.githubusercontent.com/15648334/90658476-87f2b700-e23b-11ea-9e46-dd2070078175.gif)

### After - auth errors

![auth-error](https://user-images.githubusercontent.com/15648334/90658169-24688980-e23b-11ea-845a-b77d87e5dc1d.gif)

### After - match errors

![auth-error-after2](https://user-images.githubusercontent.com/15648334/90658703-cc7e5280-e23b-11ea-8c04-683c7e692d88.gif)

