### PR TITLE
Get replacements from the match, not the rule

### DIFF
--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -30,7 +30,7 @@ export const convertTyperighterResponse = (
     message: match.shortMessage,
     category: match.rule.category,
     suggestions: match.suggestions,
-    replacement: match.rule.replacement,
+    replacement: match.replacement,
     markAsCorrect: match.markAsCorrect,
     matchContext: match.matchContext
   }))

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -22,17 +22,13 @@ export const convertTyperighterResponse = (
   requestId,
   categoryIds: response.categoryIds,
   blocks: response.blocks,
-  matches: response.matches.map(match => ({
+  matches: response.matches.map(({ fromPos, toPos, rule, ...match }) => ({
     matchId: v4(),
-    from: match.fromPos,
-    to: match.toPos,
-    matchedText: match.matchedText,
-    message: match.shortMessage,
-    category: match.rule.category,
-    suggestions: match.suggestions,
-    replacement: match.replacement,
-    markAsCorrect: match.markAsCorrect,
-    matchContext: match.matchContext
+    from: fromPos,
+    to: toPos,
+    category: rule.category,
+    rule,
+    ...match
   }))
 });
 

--- a/src/ts/services/adapters/interfaces/ITyperighter.ts
+++ b/src/ts/services/adapters/interfaces/ITyperighter.ts
@@ -19,6 +19,7 @@ export interface ITypeRighterMatch {
   toPos: number;
   matchedText: string;
   message: string;
+  replacement?: ISuggestion;
   shortMessage: string;
   rule: ITypeRighterRule;
   suggestions: ISuggestion[];


### PR DESCRIPTION
## What does this change?

At the moment, we use the replacement provided on a rule. But the combination of a rule and match can dynamically generated a replacement – for example, using regular expression groups.

Following a change to the [Typerighter service(https://github.com/guardian/typerighter/pull/67), this PR gets the replacement from the match, not the rule.

Before:

<img width="354" alt="Screenshot 2020-08-20 at 14 39 28" src="https://user-images.githubusercontent.com/7767575/90777672-a61bee00-e2f3-11ea-84d9-d48dcdefe742.png">

After:

<img width="354" alt="Screenshot 2020-08-20 at 14 38 56" src="https://user-images.githubusercontent.com/7767575/90777684-a916de80-e2f3-11ea-9787-a4ea50abcb76.png">

## How to test

Run the client against an instance of Typerighter that's up to date with [this PR](https://github.com/guardian/typerighter/pull/67). You should see replacements correctly derived.

