### PR TITLE
Add first draft of telemetry interface

### DIFF
--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -1,0 +1,73 @@
+interface ITelemetryEvent {
+  // The type of event we're sending, e.g. 'TYPERIGHTER_SUGGESTION_ACCEPTED' | 'TYPERIGHTER_MATCH_CREATED'
+  type: string;
+  // The value of the event in question
+  value: boolean | number;
+  // The time the event occurred (not the time it was queued, or sent), in ISO-8601 date format
+  eventTime: string;
+  // The event metadata – any additional context we'd like to provide
+  tags: {
+    [key: string]: string | number | boolean;
+  };
+}
+
+enum TYPERIGHTER_TELEMETRY_TYPE {
+  TYPERIGHTER_SUGGESTION_IS_ACCEPTED = "TYPERIGHTER_SUGGESTION_IS_ACCEPTED",
+  TYPERIGHTER_MARK_AS_CORRECT = "TYPERIGHTER_MARK_AS_CORRECT",
+  TYPERIGHTER_MATCH_FOUND = "TYPERIGHTER_MATCH_FOUND",
+  TYPERIGHTER_CHECK_DOCUMENT = "TYPERIGHTER_CHECK_DOCUMENT",
+  TYPERIGHTER_OPEN_STATE_CHANGED = "TYPERIGHTER_OPEN_STATE_CHANGED",
+  TYPERIGHTER_SIDEBAR_MATCH_CLICK = "TYPERIGHTER_SIDEBAR_MATCH_CLICK"
+}
+
+interface ITyperighterTelemetryEvent extends ITelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE;
+  tags: ITelemetryEvent["tags"] & {
+    // The URL of the resource containing the text that was scanned
+    documentUrl: string;
+  };
+}
+
+interface IMatchEventTags {
+  ruleId: string;
+  suggestion?: string;
+  match: string;
+  matchContext: string;
+}
+
+interface IMatchFoundEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND;
+  value: 1;
+  tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
+}
+
+interface ISuggestionEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUGGESTION_IS_ACCEPTED;
+  value: boolean;
+  tags: ITyperighterTelemetryEvent["tags"] &
+    IMatchEventTags & {
+      suggestion: string;
+    };
+}
+
+interface IMarkAsCorrectEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT;
+  value: 1;
+  tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
+}
+
+interface ICheckDocumentEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_CHECK_DOCUMENT;
+  value: 1;
+}
+
+interface IOpenTyperighterEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED;
+  value: boolean;
+}
+
+interface ISidebarClickEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK;
+  value: 1;
+  tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
+}


### PR DESCRIPTION
## What does this change?

Adds a file containing a first pass at some interfaces for telemetry events. These events correspond to user actions that plugin users are likely to find useful in providing actionable information about tool/rule usage.

There's no runtime behaviour yet – implementation will come later once this approach has had some 👀 .

## How to test

- Do the particular events defined in this PR provide enough information to be actionable, alone or in aggregate?
- Do the more general definitions for `ITelemetryEvent` and `ITyperighterTelemetryEvent` provide interfaces that are extensible enough in the face of future events, or changes to existing events?

## How can we measure success?

We have a set of interfaces that when implemented and sent to a telemetry service provide actionable insights into user behaviour. Questions might include (but are definitely not limited to):

- Are users turning the tool off?
- Are particular rules being used?
- Are particular rules being ignored?
- Are particular rules too 'noisy'?
- Are suggestions being accepted?

