### PR TITLE
Add rule id to IMatch interface

### DIFF
--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -53,6 +53,7 @@ export interface IMatch<TSuggestion = ISuggestion> {
   matchId: string;
   from: number;
   to: number;
+  ruleId: string;
   matchedText: string;
   message: string;
   category: ICategory;

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -27,7 +27,7 @@ export const convertTyperighterResponse = (
     from: fromPos,
     to: toPos,
     category: rule.category,
-    rule,
+    ruleId: rule.id,
     ...match
   }))
 });

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -507,6 +507,7 @@ describe("Action handlers", () => {
     it("should add hover decorations", () => {
       const { state, tr } = createInitialData();
       const output: IMatch = {
+        ruleId: "ruleId",
         matchId: "match-id",
         from: 0,
         to: 5,
@@ -540,6 +541,7 @@ describe("Action handlers", () => {
     it("should remove hover decorations", () => {
       const { state, tr } = createInitialData();
       const output: IMatch = {
+        ruleId: "ruleId",
         matchId: "match-id",
         from: 0,
         to: 5,
@@ -578,6 +580,7 @@ describe("Action handlers", () => {
       const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
+          ruleId: "ruleId",
           matchId: "match-id",
           from: 1,
           to: 7,
@@ -622,6 +625,7 @@ describe("Action handlers", () => {
         ...state,
         currentMatches: [
           {
+            ruleId: "ruleId",
             matchId: "match-id",
             text: "example",
             from: 1,

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -129,6 +129,7 @@ describe("selectors", () => {
       const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
+          ruleId: "ruleId",
           matchId: "match-id",
           from: 0,
           to: 5,
@@ -164,6 +165,7 @@ describe("selectors", () => {
       const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
+          ruleId: "ruleId",
           matchId: "match-id",
           from: 0,
           to: 5,

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -59,6 +59,7 @@ describe("createTyperighterPlugin", () => {
       matches: [
         {
           ...blocks[0],
+          ruleId: "ruleId",
           matchId: "matchId",
           matchedText: blocks[0].text,
           message: "Example message",

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -89,6 +89,7 @@ export const createMatcherResponse = (
       };
 
       const newMatch = {
+        ruleId: "ruleId",
         category,
         matchedText: "block text",
         message: "annotation",
@@ -125,6 +126,7 @@ export const createMatch = (
     colour: "eeeee"
   }
 ): IMatch => ({
+  ruleId: "ruleId",
   category,
   matchedText: "block text",
   message: "annotation",


### PR DESCRIPTION
## What does this change?

Adds rule id to the `IMatch` interface in preparation for our telemetry work.

## How to test

This is a no-op – the tool should continue to work as expected.

## How can we measure success?

As above.