### PR TITLE
Set up telemetry service

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -16,6 +16,8 @@ import createView from "../src/ts/createView";
 import { createBoundCommands } from "../src/ts/commands";
 import MatcherService from "../src/ts/services/MatcherService";
 import { TyperighterAdapter } from "../src/ts";
+import { ITyperighterTelemetryEvent } from "../src/ts/interfaces/ITelemetryData";
+import TelemetryService from "../src/ts/services/TelemetryService";
 
 const mySchema = new Schema({
   nodes: addListNodes(schema.spec.nodes as any, "paragraph block*", "block"),
@@ -69,6 +71,11 @@ if (editorElement && sidebarNode) {
     commands,
     new TyperighterAdapter("https://api.typerighter.local.dev-gutools.co.uk")
   );
+
+  const stubTelemetrySender = (event: ITyperighterTelemetryEvent) =>
+  console.log(event);
+  const telemetryService = new TelemetryService(stubTelemetrySender);
+
   createView({
     store,
     matcherService,
@@ -79,7 +86,8 @@ if (editorElement && sidebarNode) {
     feedbackHref: "http://a-form-for-example.com",
     onMarkCorrect: match => console.info("Match ignored!", match),
     editorScrollElement: editorElement,
-    getScrollOffset
+    getScrollOffset,
+    telemetryService
   });
 
   // Handy debugging tools

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { v4 } from "uuid";
 import IconButton from "@material-ui/core/IconButton";
 import { Close } from "@material-ui/icons";
@@ -12,8 +12,7 @@ import {
   selectRequestsInProgress,
   selectPluginIsActive
 } from "../state/selectors";
-import TelemetryService from "../services/TelemetryService";
-import { ITyperighterTelemetryEvent } from "../interfaces/ITelemetryData";
+import TelemetryContext from "../contexts/TelemetryContext";
 
 interface IProps {
   store: Store<IMatch>;
@@ -53,6 +52,8 @@ const Controls = ({
 
     const [pluginState, setPluginState] = useState<IPluginState<IMatch> | undefined>(undefined);
     const [isLoadingCategories, setIsLoadingCategories] = useState<boolean>(false);
+
+    const{telemetryService} = useContext(TelemetryContext);
     
     const fetchAllCategories = async () => {
       setIsLoadingCategories(true);
@@ -84,19 +85,18 @@ const Controls = ({
       );
     };
 
-      const stubTelemetrySender = (event: ITyperighterTelemetryEvent) =>
-      console.log(event);
-      const telemetryService = new TelemetryService(stubTelemetrySender);
-
     const handleCheckDocumentButtonClick = (): void => {
       if (!pluginIsActive) {
         onToggleActiveState();
+        telemetryService?.typerighterIsOpened({documentUrl: document.URL})
       }
       requestMatches();
+      telemetryService?.documentIsChecked({documentUrl: document.URL})
+
     };
 
     const handleCloseButtonClick = (): void => {
-      telemetryService.typerighterIsClosed({documentUrl: document.URL});
+      telemetryService?.typerighterIsClosed({documentUrl: document.URL});
       onToggleActiveState();
     }
 

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -12,6 +12,8 @@ import {
   selectRequestsInProgress,
   selectPluginIsActive
 } from "../state/selectors";
+import TelemetryService from "../services/TelemetryService";
+import { ITyperighterTelemetryEvent } from "../interfaces/ITelemetryData";
 
 interface IProps {
   store: Store<IMatch>;
@@ -82,12 +84,21 @@ const Controls = ({
       );
     };
 
+      const stubTelemetrySender = (event: ITyperighterTelemetryEvent) =>
+      console.log(event);
+      const telemetryService = new TelemetryService(stubTelemetrySender);
+
     const handleCheckDocumentButtonClick = (): void => {
       if (!pluginIsActive) {
         onToggleActiveState();
       }
       requestMatches();
     };
+
+    const handleCloseButtonClick = (): void => {
+      telemetryService.typerighterIsClosed({documentUrl: document.URL});
+      onToggleActiveState();
+    }
 
     const headerContainerClasses = pluginIsActive
       ? "Sidebar__header-container"
@@ -130,7 +141,7 @@ const Controls = ({
       <>
         <div className={headerContainerClasses}>
           <div className="Sidebar__header">
-            <button
+          <button
               type="button"
               className="Button"
               onClick={handleCheckDocumentButtonClick}
@@ -146,7 +157,7 @@ const Controls = ({
               <IconButton
                 size="small"
                 aria-label="close Typerighter"
-                onClick={onToggleActiveState}
+                onClick={handleCloseButtonClick}
                 disabled={
                   pluginState &&
                   selectRequestsInProgress(pluginState)

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -31,8 +31,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       suggestions,
       replacement,
       markAsCorrect,
-      matchContext,
-      matchedText
+      matchContext
     } = match;
     const url = document.URL;
     const feedbackInfo = {
@@ -52,8 +51,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
         {suggestionsToRender && applySuggestions && !markAsCorrect && (
           <SuggestionList
             applySuggestions={applySuggestions}
-            matchId={matchId}
-            matchedText={matchedText}
+            match={match}
             suggestions={suggestionsToRender}
           />
         )}

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -1,6 +1,6 @@
 import compact from "lodash/compact";
 
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 
 import { IMatch } from "../interfaces/IMatch";
 import {
@@ -12,6 +12,7 @@ import titleCase from "lodash/startCase";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
 import { getHtmlFromMarkdown } from "../utils/dom";
+import TelemetryContext from "../contexts/TelemetryContext";
 
 interface IProps {
   match: IMatch;
@@ -37,10 +38,11 @@ const SidebarMatch = ({
   stopHighlight,
   selectedMatch,
   editorScrollElement,
-  getScrollOffset,
+  getScrollOffset
 }: IProps) => {
-
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const { telemetryService } = useContext(TelemetryContext);
 
   const color = getColourForMatch(match, matchColours, false).borderColour;
   const hasSuggestions = !!match.suggestions && !!match.suggestions.length;
@@ -57,10 +59,18 @@ const SidebarMatch = ({
     e.preventDefault();
     e.stopPropagation();
 
+    telemetryService?.sidebarMatchClicked({
+      documentUrl: document.URL,
+      ruleId: match.ruleId,
+      matchId: match.matchId,
+      matchedText: match.matchedText,
+      matchContext: match.matchContext
+    });
+
     if (!editorScrollElement) {
       return;
     }
-  
+
     const decorationElement = maybeGetDecorationElement(match.matchId);
 
     if (decorationElement) {
@@ -79,7 +89,6 @@ const SidebarMatch = ({
   const handleMouseLeave = () => {
     stopHighlight();
   };
-
 
   return (
     <div
@@ -128,8 +137,7 @@ const SidebarMatch = ({
             <div className="SidebarMatch__suggestion-list">
               <SuggestionList
                 applySuggestions={applySuggestions}
-                matchId={match.matchId}
-                matchedText={match.matchedText}
+                match={match}
                 suggestions={suggestions}
               />
             </div>

--- a/src/ts/components/SuggestionList.tsx
+++ b/src/ts/components/SuggestionList.tsx
@@ -1,51 +1,52 @@
-import React, { useState }  from "react";
-import { ISuggestion } from "../interfaces/IMatch";
+import React, { useState } from "react";
+import { ISuggestion, IMatch } from "../interfaces/IMatch";
 import Suggestion from "./Suggestion";
 import { ApplySuggestionOptions } from "../commands";
 
 interface IProps {
   suggestions: ISuggestion[];
-  matchId: string;
-  matchedText: string;
+  match: IMatch;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }
 
-const SuggestionList = ({ suggestions, matchId, matchedText, applySuggestions }: IProps) => {
+const SuggestionList = ({
+  suggestions,
+  match,
+  applySuggestions,
+}: IProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const firstSuggestion = suggestions[0];
   const otherSuggestions = suggestions.slice(1);
   return (
-    <div className="SidebarMatch__suggestion-list">
-      {suggestions.length ? (
-        <Suggestion
-          matchId={matchId}
-          matchedText={matchedText}
-          suggestion={firstSuggestion}
-          applySuggestions={applySuggestions}
-        />
-      ) : null}
-      {!!otherSuggestions.length ? (
-        <div
-          className="Button SuggestionList__see-more"
-          onClick={() => setIsOpen(!isOpen)}
-        >
-          See {!isOpen ? "more" : "fewer"} suggestions (
-          {otherSuggestions.length})
-        </div>
-      ) : null}
-      {isOpen && (
-        <>
-          {otherSuggestions.map(suggestion => (
-            <Suggestion
-              matchId={matchId}
-              matchedText={matchedText}
-              suggestion={suggestion}
-              applySuggestions={applySuggestions}
-            />
-          ))}
-        </>
-      )}
-    </div>
+      <div className="SidebarMatch__suggestion-list">
+        {suggestions.length ? (
+          <Suggestion
+            match={match}
+            suggestion={firstSuggestion}
+            applySuggestions={applySuggestions}
+          />
+        ) : null}
+        {!!otherSuggestions.length ? (
+          <div
+            className="Button SuggestionList__see-more"
+            onClick={() => setIsOpen(!isOpen)}
+          >
+            See {!isOpen ? "more" : "fewer"} suggestions (
+            {otherSuggestions.length})
+          </div>
+        ) : null}
+        {isOpen && (
+          <>
+            {otherSuggestions.map(suggestion => (
+              <Suggestion
+                match={match}
+                suggestion={suggestion}
+                applySuggestions={applySuggestions}
+              />
+            ))}
+          </>
+        )}
+      </div>
   );
 };
 

--- a/src/ts/contexts/TelemetryContext.ts
+++ b/src/ts/contexts/TelemetryContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+import TelemetryService from '../services/TelemetryService';
+
+const TelemetryContext = createContext({
+    telemetryService: undefined as TelemetryService | undefined
+});
+
+export default TelemetryContext

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -8,6 +8,7 @@ import { MatcherService } from ".";
 import { ILogger, consoleLogger } from "./utils/logger";
 import Sidebar from "./components/Sidebar";
 import TelemetryService from "./services/TelemetryService";
+import TelemetryContext from "./contexts/TelemetryContext";
 
 interface IViewOptions {
   store: Store<IMatch>;
@@ -40,6 +41,7 @@ interface IViewOptions {
 const createView = ({
   store,
   matcherService,
+  telemetryService,
   commands,
   sidebarNode,
   overlayNode,
@@ -57,35 +59,40 @@ const createView = ({
 
   // Finally, render our components.
   render(
-    <MatchOverlay
-      store={store}
-      applySuggestions={suggestionOpts => {
-        commands.applySuggestions(suggestionOpts);
-        commands.stopHover();
-      }}
-      onMarkCorrect={
-        onMarkCorrect &&
-        (match => {
-          commands.ignoreMatch(match.matchId);
-          onMarkCorrect(match);
-        })
-      }
-      feedbackHref={feedbackHref}
-      stopHover={commands.stopHover}
-    />,
+    <TelemetryContext.Provider value={{telemetryService}}>
+      <MatchOverlay
+        store={store}
+        applySuggestions={suggestionOpts => {
+          commands.applySuggestions(suggestionOpts);
+          commands.stopHover();
+        }}
+        onMarkCorrect={
+          onMarkCorrect &&
+          (match => {
+            commands.ignoreMatch(match.matchId);
+            onMarkCorrect(match);
+          })
+        }
+        feedbackHref={feedbackHref}
+        stopHover={commands.stopHover}
+      />
+    </TelemetryContext.Provider>,
     overlayNode
+    
   );
 
   render(
-    <Sidebar
-      store={store}
-      matcherService={matcherService}
-      commands={commands}
-      contactHref={contactHref}
-      feedbackHref={feedbackHref}
-      editorScrollElement={editorScrollElement}
-      getScrollOffset={getScrollOffset}
-    />,
+    <TelemetryContext.Provider value={{telemetryService}}>
+      <Sidebar
+        store={store}
+        matcherService={matcherService}
+        commands={commands}
+        contactHref={contactHref}
+        feedbackHref={feedbackHref}
+        editorScrollElement={editorScrollElement}
+        getScrollOffset={getScrollOffset}
+      />
+    </TelemetryContext.Provider>,
     sidebarNode
   );
 };

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -7,6 +7,7 @@ import { IMatch } from "./interfaces/IMatch";
 import { MatcherService } from ".";
 import { ILogger, consoleLogger } from "./utils/logger";
 import Sidebar from "./components/Sidebar";
+import TelemetryService from "./services/TelemetryService";
 
 interface IViewOptions {
   store: Store<IMatch>;
@@ -26,6 +27,7 @@ interface IViewOptions {
   // to place the match in the middle of the screen, as the size of the
   // document might change during the lifecycle of the page.
   getScrollOffset?: () => number;
+  telemetryService: TelemetryService;
 }
 
 /**

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -59,7 +59,7 @@ const createView = ({
 
   // Finally, render our components.
   render(
-    <TelemetryContext.Provider value={{telemetryService}}>
+    <TelemetryContext.Provider value={{ telemetryService }}>
       <MatchOverlay
         store={store}
         applySuggestions={suggestionOpts => {
@@ -71,6 +71,13 @@ const createView = ({
           (match => {
             commands.ignoreMatch(match.matchId);
             onMarkCorrect(match);
+            telemetryService.matchIsMarkedAsCorrect({
+              documentUrl: document.URL,
+              ruleId: match.ruleId,
+              matchId: match.matchId,
+              matchedText: match.matchedText,
+              matchContext: match.matchContext
+            });
           })
         }
         feedbackHref={feedbackHref}
@@ -78,11 +85,10 @@ const createView = ({
       />
     </TelemetryContext.Provider>,
     overlayNode
-    
   );
 
   render(
-    <TelemetryContext.Provider value={{telemetryService}}>
+    <TelemetryContext.Provider value={{ telemetryService }}>
       <Sidebar
         store={store}
         matcherService={matcherService}

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -11,7 +11,7 @@ interface ITelemetryEvent {
   };
 }
 
-enum TYPERIGHTER_TELEMETRY_TYPE {
+export enum TYPERIGHTER_TELEMETRY_TYPE {
   TYPERIGHTER_SUGGESTION_IS_ACCEPTED = "TYPERIGHTER_SUGGESTION_IS_ACCEPTED",
   TYPERIGHTER_MARK_AS_CORRECT = "TYPERIGHTER_MARK_AS_CORRECT",
   TYPERIGHTER_MATCH_FOUND = "TYPERIGHTER_MATCH_FOUND",
@@ -20,7 +20,7 @@ enum TYPERIGHTER_TELEMETRY_TYPE {
   TYPERIGHTER_SIDEBAR_MATCH_CLICK = "TYPERIGHTER_SIDEBAR_MATCH_CLICK"
 }
 
-interface ITyperighterTelemetryEvent extends ITelemetryEvent {
+export interface ITyperighterTelemetryEvent extends ITelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE;
   tags: ITelemetryEvent["tags"] & {
     // The URL of the resource containing the text that was scanned
@@ -35,38 +35,38 @@ interface IMatchEventTags {
   matchContext: string;
 }
 
-interface IMatchFoundEvent extends ITyperighterTelemetryEvent {
+export interface IMatchFoundEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND;
   value: 1;
   tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
 }
 
-interface ISuggestionEvent extends ITyperighterTelemetryEvent {
+export interface ISuggestionAcceptedEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUGGESTION_IS_ACCEPTED;
-  value: boolean;
+  value: 1;
   tags: ITyperighterTelemetryEvent["tags"] &
     IMatchEventTags & {
       suggestion: string;
     };
 }
 
-interface IMarkAsCorrectEvent extends ITyperighterTelemetryEvent {
+export interface IMarkAsCorrectEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT;
   value: 1;
   tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
 }
 
-interface ICheckDocumentEvent extends ITyperighterTelemetryEvent {
+export interface ICheckDocumentEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_CHECK_DOCUMENT;
   value: 1;
 }
 
-interface IOpenTyperighterEvent extends ITyperighterTelemetryEvent {
+export interface IOpenTyperighterEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED;
   value: boolean;
 }
 
-interface ISidebarClickEvent extends ITyperighterTelemetryEvent {
+export interface ISidebarClickEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK;
   value: 1;
   tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -29,9 +29,10 @@ export interface ITyperighterTelemetryEvent extends ITelemetryEvent {
 }
 
 interface IMatchEventTags {
-  ruleId: string;
+  ruleId: string,
   suggestion?: string;
-  match: string;
+  matchId: string;
+  matchedText: string;
   matchContext: string;
 }
 

--- a/src/ts/services/TelemetryService.ts
+++ b/src/ts/services/TelemetryService.ts
@@ -1,0 +1,67 @@
+import {
+  ITyperighterTelemetryEvent,
+  ISuggestionAcceptedEvent,
+  TYPERIGHTER_TELEMETRY_TYPE,
+  IMarkAsCorrectEvent,
+  ISidebarClickEvent
+} from "../interfaces/ITelemetryData";
+
+export default class TelemetryService {
+  constructor(
+    private sendTelemetryEvent: (event: ITyperighterTelemetryEvent) => void
+  ) {}
+
+  public suggestionIsAccepted(tags: ISuggestionAcceptedEvent["tags"]) {
+    this.sendTelemetryEvent({
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUGGESTION_IS_ACCEPTED,
+      value: 1,
+      eventTime: new Date().toISOString(),
+      tags
+    });
+  }
+
+  public matchIsMarkedAsCorrect(tags: IMarkAsCorrectEvent["tags"]) {
+    this.sendTelemetryEvent({
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT,
+      value: 1,
+      eventTime: new Date().toISOString(),
+      tags
+    });
+  }
+
+  public documentIsChecked(tags: ITyperighterTelemetryEvent["tags"]) {
+    this.sendTelemetryEvent({
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_CHECK_DOCUMENT,
+      value: 1,
+      eventTime: new Date().toISOString(),
+      tags
+    });
+  }
+
+  public typerighterIsOpened(tags: ITyperighterTelemetryEvent["tags"]) {
+    this.sendTelemetryEvent({
+        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
+        value: true,
+        eventTime: new Date().toISOString(),
+        tags
+    });
+  }
+
+  public typerighterIsClosed(tags: ITyperighterTelemetryEvent["tags"]) {
+    this.sendTelemetryEvent({
+        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
+        value: false,
+        eventTime: new Date().toISOString(),
+        tags
+    });
+  }
+
+  public sidebarMatchClicked(tags: ISidebarClickEvent["tags"]) {
+    this.sendTelemetryEvent({
+        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
+        value: 1,
+        eventTime: new Date().toISOString(),
+        tags
+    });
+  }
+}

--- a/src/ts/services/TelemetryService.ts
+++ b/src/ts/services/TelemetryService.ts
@@ -6,7 +6,7 @@ import {
   ISidebarClickEvent
 } from "../interfaces/ITelemetryData";
 
-export default class TelemetryService {
+class TelemetryService {
   constructor(
     private sendTelemetryEvent: (event: ITyperighterTelemetryEvent) => void
   ) {}
@@ -65,3 +65,5 @@ export default class TelemetryService {
     });
   }
 }
+
+export default TelemetryService;


### PR DESCRIPTION
## What does this change?
We will have an analytics client shortly, responsible for batching and submitting telemetry events. We'd like our Prosemirror plugin to send events when they occur, via that interface.

This PR implements an events service with prosemirror-typerighter that calls the appropriate code when events happen. The backend of the implementation logs to console for now.

## How to test
Run the branch locally and check the console for details of events triggered. You should see a separate log entry for:
- Checking document
- Using 'close' button
- Clicking on a sidebar match
- Accepting a suggestion
- Marking a match as correct.
