### PR TITLE
Preserve marks when issuing replacements – step 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -772,6 +772,24 @@
         }
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
@@ -841,6 +859,71 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@jest/types": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+      "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "@material-ui/core": {
       "version": "4.11.0",
@@ -1060,6 +1143,70 @@
         }
       }
     },
+    "@testing-library/dom": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.23.0.tgz",
+      "integrity": "sha512-H5m090auYH+obdZmsaYLrSWC5OauWD2CvNbz88KBxQJoXgkJzbU0DpAG8BS7Evj5WqCC3nAAKrLS6vw0ljUYLg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "dom-accessibility-api": "^0.5.1",
+        "pretty-format": "^26.4.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -1083,6 +1230,30 @@
       "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-6.0.5.tgz",
       "integrity": "sha512-rV8O2j/TIi0PtFCOlK55JnfKpE8Hm6PKFgrUZY/3FNHw4uBEMHnM+5ZickDO1duOyKxbpY3VES5T4NIwZXvodA==",
       "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
     },
     "@types/jest": {
       "version": "23.3.14",
@@ -1255,6 +1426,21 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/yargs": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+      "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
     },
     "abab": {
       "version": "2.0.3",
@@ -1699,6 +1885,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arr-diff": {
@@ -2833,6 +3029,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3367,6 +3569,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz",
+      "integrity": "sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==",
+      "dev": true
     },
     "dom-helpers": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-replace": "^2.3.3",
+    "@testing-library/dom": "^7.23.0",
     "@types/diff": "^4.0.2",
     "@types/fetch-mock": "^6.0.4",
     "@types/jest": "^23.3.2",

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -28,7 +28,7 @@ interface IViewOptions {
   // to place the match in the middle of the screen, as the size of the
   // document might change during the lifecycle of the page.
   getScrollOffset?: () => number;
-  telemetryService: TelemetryService;
+  telemetryService?: TelemetryService;
 }
 
 /**
@@ -71,7 +71,7 @@ const createView = ({
           (match => {
             commands.ignoreMatch(match.matchId);
             onMarkCorrect(match);
-            telemetryService.matchIsMarkedAsCorrect({
+            telemetryService?.matchIsMarkedAsCorrect({
               documentUrl: document.URL,
               ruleId: match.ruleId,
               matchId: match.matchId,

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -1,0 +1,38 @@
+import { getByText} from '@testing-library/dom';
+
+import { createEditor } from "./helpers/createEditor";
+import { createMatch } from "./helpers/fixtures";
+
+describe("Commands", () => {
+  describe("applySuggestionsCommand", () => {
+    it("should apply a suggestion to the document", () => {
+      const match = createMatch(4, 11, [
+        { text: "Example", type: "TEXT_SUGGESTION" }
+      ]);
+      const {
+        editorElement,
+        commands
+      } = createEditor("<p>An example sentence</p>", [match]);
+
+      commands.applySuggestions([{ text: "improved", matchId: match.matchId }]);
+
+      expect(getByText(editorElement, "An improved sentence")).toBeTruthy();
+    });
+
+    it("should keep marks when suggestions are applied", () => {
+      const match = createMatch(4, 11, [
+        { text: "Example", type: "TEXT_SUGGESTION" }
+      ]);
+      const {
+        editorElement,
+        commands
+      } = createEditor("<p>An <strong>example</strong> sentence</p>", [match]);
+
+      commands.applySuggestions([{ text: "improved", matchId: match.matchId }]);
+
+      // The found element's text node is missing 'improved', as that text is nested
+      const element = getByText(editorElement, "An sentence")
+      expect(element.innerHTML).toBe("An <strong>improved</strong> sentence")
+    });
+  });
+});

--- a/src/ts/test/helpers/createEditor.ts
+++ b/src/ts/test/helpers/createEditor.ts
@@ -1,0 +1,62 @@
+import { EditorState } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+import { Schema, DOMParser } from "prosemirror-model";
+import { marks, schema } from "prosemirror-schema-basic";
+import { addListNodes } from "prosemirror-schema-list";
+import { exampleSetup } from "prosemirror-example-setup";
+
+import createTyperighterPlugin from "../../createTyperighterPlugin";
+import { createBoundCommands } from "../../commands";
+import MatcherService from "../../services/MatcherService";
+import TyperighterAdapter from "../../services/adapters/TyperighterAdapter";
+import { IMatch } from "../..";
+
+export const createEditor = (htmlDoc: string, matches: IMatch[] = []) => {
+  const mySchema = new Schema({
+    nodes: addListNodes(schema.spec.nodes as any, "paragraph block*", "block"),
+    marks
+  });
+
+  const contentElement = document.createElement("content");
+  contentElement.innerHTML = htmlDoc;
+  const doc = DOMParser.fromSchema(mySchema).parse(contentElement);
+  if (contentElement && contentElement.parentElement) {
+    contentElement.parentElement.removeChild(contentElement);
+  }
+
+  const editorElement = document.createElement("div") as HTMLElement;
+  editorElement.id = "editor"
+
+  const overlayNode = document.createElement("div");
+  document.body.append(overlayNode);
+  const isElementPartOfTyperighterUI = (element: HTMLElement) =>
+    overlayNode.contains(element);
+
+  const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin({
+    isElementPartOfTyperighterUI,
+    matches
+  });
+
+  const view = new EditorView(editorElement!, {
+    state: EditorState.create({
+      doc,
+      plugins: [
+        ...exampleSetup({
+          schema: mySchema,
+          history: false
+        }),
+        validatorPlugin
+      ]
+    })
+  });
+
+  const commands = createBoundCommands(view, getState);
+  // @ts-ignore
+  const matcherService = new MatcherService(
+    store,
+    commands,
+    new TyperighterAdapter("https://api.typerighter.local.dev-gutools.co.uk")
+  );
+
+  return { editorElement, view, commands };
+};


### PR DESCRIPTION
## What does this change?

At the moment, when suggestions are applied to a document, they replace the entire range they're applied to with a new text node. This means that marks that applied to the previous range – e.g. bold styling, or link information – is lost.

This PR copies marks across when they span the whole of the range altered by the selection, preserving them in some, but not all circumstances.

Before

![preserve-marks-1-before](https://user-images.githubusercontent.com/7767575/92361017-abe04480-f0e5-11ea-9fa4-e05c8daf3be9.gif)

After

![preserve-marks-1-before](https://user-images.githubusercontent.com/7767575/92360916-7f2c2d00-f0e5-11ea-92dc-365e047b240f.gif)


This is better, but not quite ideal – marks within the selection that don't cover it will still be lost. For example, the applying the suggestion 'Example' to the text 'exa**mple**' will remove the bold stying, as it doesn't cover the whole range.

We can address this in a follow up PR by diffing the suggested text against what's being replacement, and only applying the above logic to the diff – in the above, only the replacement `e` -> `E` would be applied, preserving marks in the remainder of the range.

## How to test

Spin up an instance of the plugin locally. Does it behave as expected.

## How can we measure success?

The automated tests should pass, and the editor should behave as expected when suggestions are accepted when marks cover the whole of the affected range.

## Notes

The change here is quite simple, but difficult to test without running the entire editor and querying the DOM rather than e.g. plugin or editor state. They've been needed for a while, so I've added them in this PR.