### PR TITLE
Add Typerighter match telemetry events

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -66,14 +66,17 @@ if (editorElement && sidebarNode) {
     editorElement.getBoundingClientRect().height / 2 - menuHeight;
 
   const commands = createBoundCommands(view, getState);
+
+
+  const telemetryService = new TelemetryService("https://example.com") 
+  const typerighterTelemetryAdapter = new TyperighterTelemetryAdapter(telemetryService, "prosemirror-typerighter", "DEV");
+
   const matcherService = new MatcherService(
     store,
     commands,
-    new TyperighterAdapter("https://api.typerighter.local.dev-gutools.co.uk")
+    new TyperighterAdapter("https://api.typerighter.local.dev-gutools.co.uk"),
+    typerighterTelemetryAdapter
   );
-
-  const telemetryService = new TelemetryService("https://example.com")
-  const typerighterTelemetryAdapter = new TyperighterTelemetryAdapter(telemetryService, "prosemirror-typerighter", "DEV");
 
   createView({
     store,

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -59,7 +59,7 @@ const createView = ({
 
   // Finally, render our components.
   render(
-    <TelemetryContext.Provider value={{ telemetryAdapter: telemetryAdapter }}>
+    <TelemetryContext.Provider value={{ telemetryAdapter }}>
       <MatchOverlay
         store={store}
         applySuggestions={suggestionOpts => {

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -3,7 +3,8 @@ import {
   ISuggestionAcceptedEvent,
   TYPERIGHTER_TELEMETRY_TYPE,
   IMarkAsCorrectEvent,
-  ISidebarClickEvent
+  ISidebarClickEvent,
+  IMatchFoundEvent
 } from "../interfaces/ITelemetryData";
 import TelemetryService from './TelemetryService';
 
@@ -74,6 +75,17 @@ class TyperighterTelemetryAdapter {
         app: this.app,
         stage: this.stage,
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
+        value: 1,
+        eventTime: new Date().toISOString(),
+        tags
+    });
+  }
+
+  public matchFound(tags: IMatchFoundEvent["tags"]) {
+    this.telemetryService.addEvent({
+        app: this.app,
+        stage: this.stage,
+        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND,
         value: 1,
         eventTime: new Date().toISOString(),
         tags


### PR DESCRIPTION
## What does this change?

At the moment, we've no visibility of which matches are made in the document. 

This PR enqueues TYPERIGHTER_MATCH_FOUND events when matches are found in the document, via the [typerighter telemetry service](https://github.com/guardian/prosemirror-typerighter/pull/128). 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
1. Run this branch locally
2. Run `ts/add-telemetry-adapter-to-matcherservice` in Composer 
3. Use npm link
4. Check document using Typerighter and watch network requests. You should see requests that include 'TYPERIGHTER_MATCH_FOUND'.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We will receive events in the CELK stack for every Typerighter match found in a document.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
We could have done this in one of two ways –

 1. Use the UI store subscription to listen for new matches, which will involved writing code to figure out what's new
 2. Pass the telemetryService into the MatcherService, and create the events as matches come in

Approach 1 involves more code, but gives a simpler public API. Approach 2 involves less code, but means our MatcherService now has to care about the TelemetryService.

We've opted for approach 2 now, as we'd like to ship this to users ASAP, with the option to refactor for approach 1 further down the line.

