### PR TITLE
Focus the view when users click tooltip buttons

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -79,6 +79,7 @@ if (editorElement && sidebarNode) {
   );
 
   createView({
+    view,
     store,
     matcherService,
     commands,


### PR DESCRIPTION
## What does this change?

Manually focuses the editor element when buttons within the match tooltip that relate to the document are clicked – 'mark as correct', and 'apply suggestion'.

If we don't do this, the click unfocuses the editor. As a result, if users press Ctrl-Z to undo the change that's just been made, the Ctrl-Z keyboard event is captured by the browser, not the editor. The browser has its own, divergent opinion about the edit history of the contenteditable managed by the editor, and will produce unpredictable results.

Before:

![ctrlz-ko](https://user-images.githubusercontent.com/7767575/93430816-2580eb00-f8bb-11ea-9462-7c61fc7ffb52.gif)

After:

![ctrlz-ok](https://user-images.githubusercontent.com/7767575/93430812-23b72780-f8bb-11ea-93f7-44ca85c0555f.gif)

## How to test

Make some changes to a document in the editor, run a check, apply a tooltip action, and press Ctrl-Z. The document should undo the tooltip action as expected.

This is difficult to test without browser-based integration tests, which might be worth considering sooner rather than later given the growing complexity of the view.

## How can we measure success?

Users no longer experience bugs in undo behaviour when clicking tooltip actions that relate to the document.

## Have we considered potential risks?

This doesn't defend against Ctrl-Z actions outside of the document context – this will be left to the consumer app.

## Dev notes

To achieve this, we need the view available in `createView`, so this is a breaking change.