### PR TITLE
Check all categories by default

### DIFF
--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -19,7 +19,6 @@ interface IProps {
   setDebugState: (debug: boolean) => void;
   setRequestOnDocModified: (r: boolean) => void;
   requestMatchesForDocument: (requestId: string, categoryIds: string[]) => void;
-  fetchCategories: () => Promise<ICategory[]>;
   getCurrentCategories: () => ICategory[];
   addCategory: (id: string) => void;
   removeCategory: (id: string) => void;
@@ -46,39 +45,21 @@ const getErrorFeedbackLink = (
 const Controls = ({
   store,
   requestMatchesForDocument,
-  fetchCategories,
   getCurrentCategories,
   feedbackHref,
   onToggleActiveState,
-  addCategory
 }: IProps) => {
   const [pluginState, setPluginState] = useState<
     IPluginState<IMatch> | undefined
   >(undefined);
-  const [isLoadingCategories, setIsLoadingCategories] = useState<boolean>(
-    false
-  );
 
   const { telemetryAdapter } = useContext(TelemetryContext);
-
-  const fetchAllCategories = async () => {
-    setIsLoadingCategories(true);
-    try {
-      const allCategories = await fetchCategories();
-      allCategories.forEach(category => addCategory(category.id));
-      setIsLoadingCategories(false);
-    } catch (e) {
-      setIsLoadingCategories(false);
-    }
-  };
 
   useEffect(() => {
     store.on(STORE_EVENT_NEW_STATE, newState => {
       setPluginState(newState);
     });
     setPluginState(store.getState());
-
-    fetchAllCategories();
   }, []);
 
   const pluginIsActive = pluginState && selectPluginIsActive(pluginState);
@@ -152,10 +133,7 @@ const Controls = ({
             type="button"
             className="Button"
             onClick={handleCheckDocumentButtonClick}
-            disabled={
-              isLoadingCategories ||
-              (pluginState && selectRequestsInProgress(pluginState))
-            }
+            disabled={pluginState && selectRequestsInProgress(pluginState)}
           >
             Check document
           </button>

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -57,7 +57,6 @@ const Sidebar = ({
               commands.setConfigValue("requestMatchesOnDocModified", value)
             }
             requestMatchesForDocument={commands.requestMatchesForDocument}
-            fetchCategories={matcherService.fetchCategories}
             getCurrentCategories={matcherService.getCurrentCategories}
             addCategory={matcherService.addCategory}
             removeCategory={matcherService.removeCategory}

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -52,7 +52,6 @@ class TyperighterAdapter implements IMatcherAdapter {
       const body = {
         requestId,
         blocks: [input],
-        categoryIds
       };
       try {
         const response = await fetch(`${this.url}/check`, {


### PR DESCRIPTION
## What does this change?
Currently  we manually specify all of the categories Typerighter must check on each request. As a result, the plugin asks for the current categories from the server before it's able to make requests to check documents. Related to this [Typerighter PR](https://github.com/guardian/typerighter/pull/70).

There are two problems with this:

1. there's a wait before you can hit 'Check document' when the plugin starts up
2. if the category list expands whilst the tool is in use, the plugin will miss categories. If it shrinks, the user sees an error.

This PR makes the change to remove category information from the request the plugin makes. 

## How to test
Run the branch locally (replacing `http://example.com` with the correct `telemetryService` link in `pages/index.ts`).
Check document and see that requests no longer contain categories.

## How can we measure success?
By default, Typerighter checks incoming requests with every category.