### PR TITLE
Send more match data via telemetry

### DIFF
--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -59,13 +59,7 @@ const SidebarMatch = ({
     e.preventDefault();
     e.stopPropagation();
 
-    telemetryAdapter?.sidebarMatchClicked({
-      documentUrl: document.URL,
-      ruleId: match.ruleId,
-      matchId: match.matchId,
-      matchedText: match.matchedText,
-      matchContext: match.matchContext
-    });
+    telemetryAdapter?.sidebarMatchClicked(match, document.URL);
 
     if (!editorScrollElement) {
       return;

--- a/src/ts/components/Suggestion.tsx
+++ b/src/ts/components/Suggestion.tsx
@@ -77,14 +77,11 @@ const Suggestion = ({ match, suggestion, applySuggestions }: IProps) => {
       }
     ]);
 
-    telemetryAdapter?.suggestionIsAccepted({
-      documentUrl: document.URL,
-      ruleId: match.ruleId,
-      matchId: match.matchId,
-      matchedText: match.matchedText,
-      matchContext: match.matchContext,
-      suggestion: suggestion.text
-    });
+    telemetryAdapter?.suggestionIsAccepted(
+      match,
+      document.URL,
+      suggestion.text
+    );
   };
   switch (suggestion.type) {
     case "TEXT_SUGGESTION": {

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -84,13 +84,7 @@ const createView = ({
             onMarkCorrect(match);
             // See the previous comment re: focusing in `applySuggestions`.
             view.focus();
-            telemetryAdapter?.matchIsMarkedAsCorrect({
-              documentUrl: document.URL,
-              ruleId: match.ruleId,
-              matchId: match.matchId,
-              matchedText: match.matchedText,
-              matchContext: match.matchContext
-            });
+            telemetryAdapter?.matchIsMarkedAsCorrect(match, document.URL);
           })
         }
         feedbackHref={feedbackHref}

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -1,3 +1,5 @@
+type TelemetryBool = 'true' | 'false';
+
 export interface ITelemetryEvent {
   /**
    * The application sending the event
@@ -55,6 +57,9 @@ interface IMatchEventTags {
   ruleId: string,
   suggestion?: string;
   matchId: string;
+  matchIsMarkedAsCorrect: TelemetryBool;
+  matchIsAdvisory: TelemetryBool;
+  matchHasReplacement: TelemetryBool;
   matchedText: string;
   matchContext: string;
 }

--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -1,5 +1,8 @@
 import { IBlock, IMatch, ICategory } from "../interfaces/IMatch";
-import { IMatcherAdapter, TMatchesReceivedCallback } from "../interfaces/IMatcherAdapter";
+import {
+  IMatcherAdapter,
+  TMatchesReceivedCallback
+} from "../interfaces/IMatcherAdapter";
 import Store, {
   STORE_EVENT_NEW_MATCHES,
   STORE_EVENT_NEW_DIRTIED_RANGES
@@ -25,7 +28,7 @@ class MatcherService<TMatch extends IMatch> {
     private adapter: IMatcherAdapter<TMatch>,
     private telemetryAdapter?: TyperighterTelemetryAdapter,
     // The initial throttle duration for pending requests.
-    private initialThrottle = 2000,
+    private initialThrottle = 2000
   ) {
     this.currentThrottle = this.initialThrottle;
     this.store.on(STORE_EVENT_NEW_MATCHES, (requestId, requestsInFlight) => {
@@ -37,15 +40,10 @@ class MatcherService<TMatch extends IMatch> {
   }
 
   private sendMatchTelemetryEvents = (matches: TMatch[]) => {
-    matches.forEach((match: TMatch) => this.telemetryAdapter?.matchFound({
-      documentUrl: document.URL,
-      ruleId: match.ruleId,
-      matchId: match.matchId,
-      matchedText: match.matchedText,
-      matchContext: match.matchContext
-    }));
-  }
-  
+    matches.forEach((match: TMatch) =>
+      this.telemetryAdapter?.matchFound(match, document.URL)
+    );
+  };
 
   /**
    * Get all of the available categories from the matcher service.
@@ -75,7 +73,7 @@ class MatcherService<TMatch extends IMatch> {
    * Fetch matches for a set of blocks.
    */
   public async fetchMatches(requestId: string, blocks: IBlock[]) {
-    const applyMatcherResponse: TMatchesReceivedCallback<TMatch> = (response) => {
+    const applyMatcherResponse: TMatchesReceivedCallback<TMatch> = response => {
       this.sendMatchTelemetryEvents(response.matches);
       this.commands.applyMatcherResponse(response);
     };

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -1,12 +1,9 @@
 import {
   ITyperighterTelemetryEvent,
-  ISuggestionAcceptedEvent,
   TYPERIGHTER_TELEMETRY_TYPE,
-  IMarkAsCorrectEvent,
-  ISidebarClickEvent,
-  IMatchFoundEvent
 } from "../interfaces/ITelemetryData";
 import TelemetryService from './TelemetryService';
+import { IMatch } from "..";
 
 class TyperighterTelemetryAdapter {
   constructor(
@@ -15,25 +12,32 @@ class TyperighterTelemetryAdapter {
     private stage: string
   ) {}
 
-  public suggestionIsAccepted(tags: ISuggestionAcceptedEvent["tags"]) {
+  public suggestionIsAccepted(match: IMatch, documentUrl: string, suggestion: string) {
     this.telemetryService.addEvent({
       app: this.app,
       stage: this.stage,
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUGGESTION_IS_ACCEPTED,
       value: 1,
       eventTime: new Date().toISOString(),
-      tags
+      tags: {
+        suggestion,
+        documentUrl,
+        ...this.getTelemetryTagsFromMatch(match)
+      }
     });
   }
 
-  public matchIsMarkedAsCorrect(tags: IMarkAsCorrectEvent["tags"]) {
+  public matchIsMarkedAsCorrect(match: IMatch, documentUrl: string) {
     this.telemetryService.addEvent({
       app: this.app,
       stage: this.stage,
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT,
       value: 1,
       eventTime: new Date().toISOString(),
-      tags
+      tags: {
+        documentUrl,
+        ...this.getTelemetryTagsFromMatch(match)
+      }
     });
   }
 
@@ -70,27 +74,43 @@ class TyperighterTelemetryAdapter {
     });
   }
 
-  public sidebarMatchClicked(tags: ISidebarClickEvent["tags"]) {
+  public sidebarMatchClicked(match: IMatch, documentUrl: string) {
     this.telemetryService.addEvent({
         app: this.app,
         stage: this.stage,
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
         value: 1,
         eventTime: new Date().toISOString(),
-        tags
+        tags: {
+          documentUrl,
+          ...this.getTelemetryTagsFromMatch(match)
+        }
     });
   }
 
-  public matchFound(tags: IMatchFoundEvent["tags"]) {
+  public matchFound(match: IMatch, documentUrl: string) {
     this.telemetryService.addEvent({
         app: this.app,
         stage: this.stage,
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND,
         value: 1,
         eventTime: new Date().toISOString(),
-        tags
+        tags: {
+          documentUrl,
+          ...this.getTelemetryTagsFromMatch(match)
+        }
     });
   }
+
+  private getTelemetryTagsFromMatch = (match: IMatch) => ({
+    ruleId: match.ruleId,
+    matchId: match.matchId,
+    matchedText: match.matchedText,
+    matchContext: match.matchContext,
+    matchHasReplacement: match.replacement ? 'true' : 'false',
+    matchIsAdvisory: 'false',
+    matchIsMarkedAsCorrect: match.markAsCorrect ? 'true' : 'false',
+  })
 }
 
 export default TyperighterTelemetryAdapter;

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -106,7 +106,6 @@ class TyperighterTelemetryAdapter {
     ruleId: match.ruleId,
     matchId: match.matchId,
     matchedText: match.matchedText,
-    matchContext: match.matchContext,
     matchHasReplacement: match.replacement ? 'true' : 'false',
     matchIsAdvisory: 'false',
     matchIsMarkedAsCorrect: match.markAsCorrect ? 'true' : 'false',


### PR DESCRIPTION
## What does this change?

Add more match information, in tags, to the telemetry data we're sending from prosemirror-typerighter. This is to enable us to filter for matches marked as 'advisory', matches without suggestions, and matches with suggestions in aggregate in our telemetry data. There's also a `markAsCorrect` property we can use to identify 'correct' matches.

It also removes the `matchContext` metric, which is primarily used for detecting bugs and contains data we don't want to retain in telemetry.

## How to test

Run locally, and take an action that includes a match – accepting a suggestion, marking as correct, clicking in the sidebar. When telemetry events are sent a few seconds later, you should see that they contain the information above.

## How can we measure success?

We can filter for advisory rules, matches without suggestions, 'correct' matches, and matches with suggestions in aggregate in our telemetry data.
