### PR TITLE
fix: 🐛 Fixes loading bar

### DIFF
--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -71,9 +71,9 @@ export const selectPercentRemaining = <TMatch extends IMatch>(
     state.requestsInFlight
   ).reduce(
     ([totalWorkAcc, remainingWorkAcc], queryState) => {
-      const allWork = queryState.totalBlocks * queryState.categoryIds.length;
+      const allWork = queryState.totalBlocks * Math.max(queryState.categoryIds.length, 1);
       const remainingWork = queryState.pendingBlocks.reduce(
-        (acc, block) => acc + block.pendingCategoryIds.length,
+        (acc, block) => acc + Math.max(block.pendingCategoryIds.length, 1),
         0
       );
       return [totalWorkAcc + allWork, remainingWorkAcc + remainingWork];

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -71,9 +71,10 @@ export const selectPercentRemaining = <TMatch extends IMatch>(
     state.requestsInFlight
   ).reduce(
     ([totalWorkAcc, remainingWorkAcc], queryState) => {
-      const allWork = queryState.totalBlocks * Math.max(queryState.categoryIds.length, 1);
+      const allCategories = queryState.categoryIds.length == 0;
+      const allWork = queryState.totalBlocks * (allCategories ? 1 : queryState.categoryIds.length);
       const remainingWork = queryState.pendingBlocks.reduce(
-        (acc, block) => acc + Math.max(block.pendingCategoryIds.length, 1),
+        (acc, block) => acc + (allCategories ? 1 : block.pendingCategoryIds.length),
         0
       );
       return [totalWorkAcc + allWork, remainingWorkAcc + remainingWork];

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -257,34 +257,32 @@ describe("selectors", () => {
       const input2 = createBlock(10, 15);
       const input3 = createBlock(15, 20);
       const input4 = createBlock(20, 25);
+      // let state = {
+      //   ...initialState,
+      //   requestsInFlight: {
+      //     ...createBlockQueriesInFlight([input1, input2]),
+      //     ...createBlockQueriesInFlight([input3], "set-id-2")
+      //   }
+      // };
+      // expect(selectPercentRemaining(state)).toEqual(100);
       let state = {
-        ...initialState,
-        requestsInFlight: {
-          ...createBlockQueriesInFlight([input1, input2]),
-          ...createBlockQueriesInFlight([input3], "set-id-2")
-        }
-      };
-      expect(selectPercentRemaining(state)).toEqual(100);
-      state = {
         ...initialState,
         requestsInFlight: {
           ...createBlockQueriesInFlight(
             [input1, input2],
             exampleRequestId,
-            exampleCategoryIds,
-            [],
-            3
+            ["set-id-2", "set-id-3"],
+            ["set-id-2"]
           ),
           ...createBlockQueriesInFlight(
-            [input3, input4],
+            [input3],
             "set-id-2",
             exampleCategoryIds,
             exampleCategoryIds,
-            2
           )
         }
       };
-      expect(selectPercentRemaining(state)).toEqual(40);
+      expect(selectPercentRemaining(state)).toEqual(60);
     });
   });
 });

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -13,6 +13,7 @@ import {
   exampleCategoryIds
 } from "../../test/helpers/fixtures";
 import { IMatch } from '../../interfaces/IMatch';
+import { omit } from "lodash";
 
 describe("selectors", () => {
   describe("selectMatchById", () => {
@@ -251,38 +252,59 @@ describe("selectors", () => {
       };
       expect(selectPercentRemaining(state)).toEqual(50);
     });
+    it("should select the percentage remaining for a single request for all categories", () => {
+      const { state: initialState } = createInitialData();
+      const input1 = createBlock(0, 5);
+      const input2 = createBlock(10, 15);
+      let state = {
+        ...initialState,
+        requestsInFlight: createBlockQueriesInFlight(
+          [input1, input2],
+          exampleRequestId,
+          []
+        )
+      };
+      expect(selectPercentRemaining(state)).toEqual(100);
+      state = {
+        ...initialState,
+        requestsInFlight: omit(state.requestsInFlight, exampleRequestId),
+      };
+      expect(selectPercentRemaining(state)).toEqual(0);
+    });
     it("should select the percentage remaining for multiple requests", () => {
       const { state: initialState } = createInitialData();
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       const input3 = createBlock(15, 20);
       const input4 = createBlock(20, 25);
-      // let state = {
-      //   ...initialState,
-      //   requestsInFlight: {
-      //     ...createBlockQueriesInFlight([input1, input2]),
-      //     ...createBlockQueriesInFlight([input3], "set-id-2")
-      //   }
-      // };
-      // expect(selectPercentRemaining(state)).toEqual(100);
       let state = {
+        ...initialState,
+        requestsInFlight: {
+          ...createBlockQueriesInFlight([input1, input2]),
+          ...createBlockQueriesInFlight([input3], "set-id-2")
+        }
+      };
+      expect(selectPercentRemaining(state)).toEqual(100);
+      state = {
         ...initialState,
         requestsInFlight: {
           ...createBlockQueriesInFlight(
             [input1, input2],
             exampleRequestId,
-            ["set-id-2", "set-id-3"],
-            ["set-id-2"]
+            exampleCategoryIds,
+            [],
+            3
           ),
           ...createBlockQueriesInFlight(
-            [input3],
+            [input3, input4],
             "set-id-2",
             exampleCategoryIds,
             exampleCategoryIds,
+            2
           )
         }
       };
-      expect(selectPercentRemaining(state)).toEqual(60);
+      expect(selectPercentRemaining(state)).toEqual(40);
     });
   });
 });


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR fixes the loading bar by accounting for the possibility of no categories.

This was an issue introduced by the ability to request a check with no categories, returning all default categories. In these circumstances the request blocks have no category ids associated, breaking how the remaining work percentage is calculated in the selector.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Load the Prosemirror-Typerighter client, make a request, observe the loading bar. It should fill in relation to the matches found.
