### PR TITLE
feat: 🎸 Add matcherType to telemetry 

### DIFF
--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -50,6 +50,7 @@ export type TMatchRequestErrorWithDefault = PartialBy<
 >;
 
 export interface IMatch<TSuggestion = ISuggestion> {
+  matcherType: string
   matchId: string;
   from: number;
   to: number;

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -1,4 +1,4 @@
-type TelemetryBool = 'true' | 'false';
+type TelemetryBool = "true" | "false";
 
 export interface ITelemetryEvent {
   /**
@@ -35,7 +35,6 @@ export interface ITelemetryEvent {
   };
 }
 
-
 export enum TYPERIGHTER_TELEMETRY_TYPE {
   TYPERIGHTER_SUGGESTION_IS_ACCEPTED = "TYPERIGHTER_SUGGESTION_IS_ACCEPTED",
   TYPERIGHTER_MARK_AS_CORRECT = "TYPERIGHTER_MARK_AS_CORRECT",
@@ -54,7 +53,8 @@ export interface ITyperighterTelemetryEvent extends ITelemetryEvent {
 }
 
 interface IMatchEventTags {
-  ruleId: string,
+  matcherType: string;
+  ruleId: string;
   suggestion?: string;
   matchId: string;
   matchIsMarkedAsCorrect: TelemetryBool;

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -103,6 +103,7 @@ class TyperighterTelemetryAdapter {
   }
 
   private getTelemetryTagsFromMatch = (match: IMatch) => ({
+    matcherType: match.matcherType,
     ruleId: match.ruleId,
     matchId: match.matchId,
     matchedText: match.matchedText,

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -26,6 +26,7 @@ export const convertTyperighterResponse = (
     matchId: v4(),
     from: fromPos,
     to: toPos,
+    matcherType: rule.matcherType,
     category: rule.category,
     ruleId: rule.id,
     ...match

--- a/src/ts/services/adapters/interfaces/ITyperighter.ts
+++ b/src/ts/services/adapters/interfaces/ITyperighter.ts
@@ -36,6 +36,7 @@ export interface ITypeRighterType {
 }
 
 export interface ITypeRighterRule {
+  matcherType: string;
   category: ITypeRighterCategory;
   description: string;
   id: string;

--- a/src/ts/services/test/MatcherService.spec.ts
+++ b/src/ts/services/test/MatcherService.spec.ts
@@ -27,6 +27,7 @@ const createResponse = (strs: string[]): ITypeRighterResponse => ({
     message: "It's just a bunch of numbers, mate",
     shortMessage: "It's just a bunch of numbers, mate",
     rule: {
+      matcherType: "regex",
       category: {
         id: "numberCat",
         name: "The number category",

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -507,6 +507,7 @@ describe("Action handlers", () => {
     it("should add hover decorations", () => {
       const { state, tr } = createInitialData();
       const output: IMatch = {
+        matcherType: "regex",
         ruleId: "ruleId",
         matchId: "match-id",
         from: 0,
@@ -541,6 +542,7 @@ describe("Action handlers", () => {
     it("should remove hover decorations", () => {
       const { state, tr } = createInitialData();
       const output: IMatch = {
+        matcherType: "regex",
         ruleId: "ruleId",
         matchId: "match-id",
         from: 0,
@@ -580,6 +582,7 @@ describe("Action handlers", () => {
       const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
+          matcherType: "regex",
           ruleId: "ruleId",
           matchId: "match-id",
           from: 1,
@@ -625,6 +628,7 @@ describe("Action handlers", () => {
         ...state,
         currentMatches: [
           {
+            matcherType: "regex",
             ruleId: "ruleId",
             matchId: "match-id",
             text: "example",

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -130,6 +130,7 @@ describe("selectors", () => {
       const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
+          matcherType: "regex",
           ruleId: "ruleId",
           matchId: "match-id",
           from: 0,
@@ -166,6 +167,7 @@ describe("selectors", () => {
       const { state } = createInitialData();
       const currentMatches: IMatch[] = [
         {
+          matcherType: "regex",
           ruleId: "ruleId",
           matchId: "match-id",
           from: 0,

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -59,6 +59,7 @@ describe("createTyperighterPlugin", () => {
       matches: [
         {
           ...blocks[0],
+          matcherType: "regex",
           ruleId: "ruleId",
           matchId: "matchId",
           matchedText: blocks[0].text,

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -89,6 +89,7 @@ export const createMatcherResponse = (
       };
 
       const newMatch = {
+        matcherType: "regex",
         ruleId: "ruleId",
         category,
         matchedText: "block text",
@@ -126,6 +127,7 @@ export const createMatch = (
     colour: "eeeee"
   }
 ): IMatch => ({
+  matcherType: "regex",
   ruleId: "ruleId",
   category,
   matchedText: "block text",


### PR DESCRIPTION
## What does this change?
At the moment, our rules don't include the name of their matcher. This will be useful in determining whether rules from different matchers have different telemetry  profiles. This is the sister PR to [this Typerighter PR](https://github.com/guardian/typerighter/pull/77).

## How to test
Run the branch locally and click `check document`. You will see after a few seconds that `matcherType` appears in the telemetry event request.

## How can we measure success?
We will be able to determine whether rules from different matchers have different telemetry profiles.