### PR TITLE
fix: 🐛 Adds the rule id to the feedback form

### DIFF
--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -31,7 +31,8 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       suggestions,
       replacement,
       markAsCorrect,
-      matchContext
+      matchContext,
+      ruleId
     } = match;
     const url = document.URL;
     const feedbackInfo = {
@@ -42,7 +43,8 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       replacement,
       url,
       matchContext,
-      markAsCorrect
+      markAsCorrect,
+      ruleId
     };
 
     const suggestionsToRender = replacement ? [replacement] : suggestions || [];


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the rule id to the "issue with result" feedback link. This should make it easier to identify the rule which has caused the issue.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Submit an issue with a rule, look at the "Technical Context" and observe the rule id has been included.

