### PR TITLE
Remove emojis from cz commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "husky": {
     "hooks": {
-      "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
+      "prepare-commit-msg": "exec < /dev/tty && git cz --hook --disable-emoji || true"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## What does this change?

`git-cz` is ... too fun by default. This dials back the fun to acceptable levels, that is to say, it is no longer fun.

## How to test

Take a look at the commit message below and adjust your monocle accordingly.
