### PR TITLE
fix: 🐛 Remove height widget decorations – they're redundant

### DIFF
--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -334,8 +334,7 @@ const createHandleNewFocusState = (focusState: "highlightId" | "hoverId") => <
       createDecorationsForMatch(
         output,
         state.config.matchColours,
-        hoverData.isSelected,
-        false
+        hoverData.isSelected
       )
     );
   }, decorations);

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -97,26 +97,12 @@ export const getNewDecorationsForCurrentMatches = (
 };
 
 /**
- * Create a height marker element. Used to determine the height
- * of a single line of inline content, which is useful when we're
- * calculating where to place tooltips as the user hovers over multi-
- * line spans.
- */
-const createHeightMarkerElement = (id: string) => {
-  const element = document.createElement("span");
-  element.setAttribute(DECORATION_ATTRIBUTE_HEIGHT_MARKER_ID, id);
-  element.className = DecorationClassMap[DECORATION_MATCH_HEIGHT_MARKER];
-  return element;
-};
-
-/**
  * Create decorations for the given match.
  */
 export const createDecorationsForMatch = (
   match: IMatch,
   matchColours: IMatchColours = defaultMatchColours,
-  isSelected = false,
-  addWidgetDecorations = true
+  isSelected = false
 ) => {
   const className = isSelected
     ? `${DecorationClassMap[DECORATION_MATCH]} ${DecorationClassMap[DECORATION_MATCH_IS_SELECTED]}`
@@ -139,15 +125,6 @@ export const createDecorationsForMatch = (
     )
   ];
 
-  if (addWidgetDecorations) {
-    decorations.push(
-      Decoration.widget(match.from, createHeightMarkerElement(match.matchId), {
-        type: DECORATION_MATCH_HEIGHT_MARKER,
-        id: match.matchId,
-        categoryId: match.category.id
-      } as any)
-    );
-  }
   return decorations;
 };
 

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -27,18 +27,6 @@ describe("Decoration utils", () => {
               type: "DECORATION_MATCH"
             }
           }
-        },
-        {
-          from: 0,
-          to: 0,
-          type: {
-            side: 0,
-            spec: {
-              categoryId: "1",
-              id: "0-from:0-to:5--match-0",
-              type: "DECORATION_MATCH_HEIGHT_MARKER"
-            }
-          }
         }
       ]);
     });
@@ -62,18 +50,6 @@ describe("Decoration utils", () => {
               inclusiveEnd: false,
               inclusiveStart: false,
               type: "DECORATION_MATCH"
-            }
-          }
-        },
-        {
-          from: 0,
-          to: 0,
-          type: {
-            side: 0,
-            spec: {
-              categoryId: "1",
-              id: "0-from:0-to:5--match-0",
-              type: "DECORATION_MATCH_HEIGHT_MARKER"
             }
           }
         }


### PR DESCRIPTION
## What does this change?

Height widget decorations are no longer needed since we moved our
[tooltip implementation to Popper.js](#112). Worse still – they cause a bug that prevents users selecting the left hand side of the annotated range.

This PR removes them, and the bug.

Before:

![drag-ko](https://user-images.githubusercontent.com/7767575/94290397-084ebb00-ff52-11ea-9f9a-35dea90e9244.gif)

After:

![drag-ok](https://user-images.githubusercontent.com/7767575/94290402-0a187e80-ff52-11ea-9a82-0719bed769d5.gif)


## How to test

Running the demo locally, attempt to select the left hand side of a matched range.

## How can we measure success?

The selection behaviour above should now be as expected.
