### PR TITLE
Add filter functionality, pt. 1 – add filter state and predicate to plugin state

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -68,7 +68,7 @@ if (editorElement && sidebarNode) {
   const commands = createBoundCommands(view, getState);
 
 
-  const telemetryService = new TelemetryService("https://example.com") 
+  const telemetryService = new TelemetryService("https://example.com")
   const typerighterTelemetryAdapter = new TyperighterTelemetryAdapter(telemetryService, "prosemirror-typerighter", "DEV");
 
   const matcherService = new MatcherService(

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -5,7 +5,7 @@ import { DeleteForever } from "@material-ui/icons";
 
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { IPluginState } from "../state/reducer";
-import { IMatch, ICategory } from "../interfaces/IMatch";
+import { ICategory } from "../interfaces/IMatch";
 import {
   selectHasGeneralError,
   selectHasAuthError,
@@ -14,8 +14,8 @@ import {
 } from "../state/selectors";
 import TelemetryContext from "../contexts/TelemetryContext";
 
-interface IProps {
-  store: Store<IMatch>;
+interface IProps<TPluginState extends IPluginState> {
+  store: Store<TPluginState>;
   clearMatches: () => void;
   setDebugState: (debug: boolean) => void;
   setRequestOnDocModified: (r: boolean) => void;
@@ -27,7 +27,7 @@ interface IProps {
 }
 
 const getErrorFeedbackLink = (
-  pluginState: IPluginState<IMatch> | undefined,
+  pluginState: IPluginState | undefined,
   feedbackHref: string | undefined
 ) => {
   const errorLmit = 10;
@@ -42,15 +42,15 @@ const getErrorFeedbackLink = (
 /**
  * Controls to open and close Typerighter and check document.
  */
-const Controls = ({
+const Controls = <TPluginState extends IPluginState>({
   store,
   clearMatches,
   requestMatchesForDocument,
   getCurrentCategories,
   feedbackHref
-}: IProps) => {
+}: IProps<TPluginState>) => {
   const [pluginState, setPluginState] = useState<
-    IPluginState<IMatch> | undefined
+    TPluginState | undefined
   >(undefined);
 
   const { telemetryAdapter } = useContext(TelemetryContext);

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -3,14 +3,14 @@ import React, { Component } from "react";
 import { IMatch } from "../interfaces/IMatch";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
-import { getColourForMatch, IMatchColours } from "../utils/decoration";
+import { getColourForMatch, IMatchTypeToColourMap } from "../utils/decoration";
 import { Check } from "@material-ui/icons";
 import { getHtmlFromMarkdown } from "../utils/dom";
 
 interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
   match: TMatch;
-  matchColours: IMatchColours;
+  matchColours: IMatchTypeToColourMap;
   feedbackHref?: string;
   onMarkCorrect?: (match: IMatch) => void;
 }

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -4,12 +4,12 @@ import { IPluginState } from "../state/reducer";
 import { selectMatchByMatchId } from "../state/selectors";
 import { IMatch } from "../interfaces/IMatch";
 import { maybeGetDecorationElement } from "../utils/decoration";
-import Store, { IStoreEvents, STORE_EVENT_NEW_STATE } from "../state/store";
+import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { ApplySuggestionOptions } from "../commands";
 import { usePopper } from "react-popper";
 
-interface IProps<TMatch extends IMatch> {
-  store: Store<TMatch, IStoreEvents<TMatch>>;
+interface IProps<TPluginState extends IPluginState> {
+  store: Store<TPluginState>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   stopHover: () => void;
   feedbackHref?: string;
@@ -19,13 +19,13 @@ interface IProps<TMatch extends IMatch> {
 /**
  * An overlay to display match tooltips.
  */
-const matchOverlay = <TMatch extends IMatch = IMatch>({
+const matchOverlay = <TPluginState extends IPluginState>({
   applySuggestions,
   feedbackHref,
   onMarkCorrect,
   stopHover,
   store
-}: IProps<TMatch>) => {
+}: IProps<TPluginState>) => {
   const [pluginState, setPluginState] = useState<IPluginState | undefined>(
     undefined
   );

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -5,11 +5,10 @@ import { ApplySuggestionOptions } from "../commands";
 import { IPluginState } from "../state/reducer";
 import { selectImportanceOrderedMatches, selectPercentRemaining } from "../state/selectors";
 import SidebarMatch from "./SidebarMatch";
-import { IMatch } from "../interfaces/IMatch";
 import { Switch } from "@material-ui/core";
 
-interface IProps {
-  store: Store<IMatch>;
+interface IProps<TPluginState extends IPluginState> {
+  store: Store<TPluginState>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   applyAutoFixableSuggestions: () => void;
   selectMatch: (matchId: string) => void;
@@ -24,7 +23,7 @@ interface IProps {
  * Displays current matches and allows users to apply suggestions.
  */
 
-  const Results =  ({
+  const Results = <TPluginState extends IPluginState>({
     store,
     applySuggestions,
     selectMatch,
@@ -33,22 +32,22 @@ interface IProps {
     contactHref,
     editorScrollElement,
     getScrollOffset
-  }: IProps) => {
+  }: IProps<TPluginState>) => {
 
-    const [pluginState, setPluginState] = useState<IPluginState<IMatch> | undefined>(undefined);
+    const [pluginState, setPluginState] = useState<TPluginState | undefined>(undefined);
     const [loadingBarVisible, setLoadingBarVisible] = useState<boolean>(false);
     const [sortAndGroup, setSortAndGroup] = useState<boolean>(true);
 
-    const handleNewState = (pluginState: IPluginState<IMatch>) => {
+    const handleNewState = (incomingState: TPluginState) => {
       setPluginState({
-          ...pluginState,
-          currentMatches: sortBy(pluginState.currentMatches, "from")
-        
+          ...incomingState,
+          currentMatches: sortBy(incomingState.currentMatches, "from")
+
       });
       const oldKeys = pluginState
         ? Object.keys(pluginState.requestsInFlight)
         : [];
-      const newKeys = Object.keys(pluginState.requestsInFlight);
+      const newKeys = Object.keys(incomingState.requestsInFlight);
       if (oldKeys.length && !newKeys.length) {
         setTimeout(maybeResetLoadingBar, 300);
       }
@@ -57,7 +56,7 @@ interface IProps {
       }
     };
 
-    useEffect(() => {   
+    useEffect(() => {
       store.on(STORE_EVENT_NEW_STATE, newState => {
         handleNewState(newState);
       });
@@ -79,7 +78,7 @@ interface IProps {
         setLoadingBarVisible(false);
       }
     };
-    
+
     const { currentMatches = [], requestsInFlight, selectedMatch } = pluginState || { selectedMatch: undefined };
     const hasMatches = !!(currentMatches && currentMatches.length);
     const percentRemaining = getPercentRemaining();
@@ -95,7 +94,7 @@ interface IProps {
               Results {hasMatches && <span>({currentMatches.length}) </span>}
             </span>
             <span className="Sidebar__header-sort">
-              Sort by colour 
+              Sort by colour
               <Switch
                 size="small"
                 checked={sortAndGroup}

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -8,9 +8,9 @@ import { IMatch } from ".././interfaces/IMatch";
 import { MatcherService } from "..";
 import { IPluginState } from "../state/reducer";
 
-interface IProps {
-  store: Store<IMatch>;
-  matcherService: MatcherService<IMatch>;
+interface IProps<TPluginState extends IPluginState> {
+  store: Store<TPluginState>;
+  matcherService: MatcherService<TPluginState["filterState"], IMatch>;
   commands: Commands;
   contactHref?: string;
   feedbackHref?: string;
@@ -18,7 +18,7 @@ interface IProps {
   getScrollOffset: () => number;
 }
 
-const Sidebar = ({
+const Sidebar = <TPluginState extends IPluginState>({
   store,
   matcherService,
   commands,
@@ -26,7 +26,7 @@ const Sidebar = ({
   editorScrollElement,
   getScrollOffset,
   feedbackHref
-}: IProps) => {
+}: IProps<TPluginState>) => {
   const [pluginState, setPluginState] = useState<IPluginState | undefined>(
     undefined
   );

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -16,7 +16,7 @@ import TelemetryContext from "../contexts/TelemetryContext";
 
 interface IProps {
   match: IMatch;
-  matchColours: IMatchTypeToColourMap;
+  matchColours?: IMatchTypeToColourMap;
   applySuggestions: (suggestions: ApplySuggestionOptions) => void;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;
@@ -44,7 +44,9 @@ const SidebarMatch = ({
 
   const { telemetryAdapter } = useContext(TelemetryContext);
 
-  const color = getColourForMatch(match, matchColours, false).borderColour;
+  const color = matchColours
+    ? getColourForMatch(match, matchColours, false).borderColour
+    : undefined;
   const hasSuggestions = !!match.suggestions && !!match.suggestions.length;
   const suggestions = compact([
     match.replacement,

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -4,7 +4,7 @@ import React, { useState, useContext } from "react";
 
 import { IMatch } from "../interfaces/IMatch";
 import {
-  IMatchColours,
+  IMatchTypeToColourMap,
   getColourForMatch,
   maybeGetDecorationElement
 } from "../utils/decoration";
@@ -16,7 +16,7 @@ import TelemetryContext from "../contexts/TelemetryContext";
 
 interface IProps {
   match: IMatch;
-  matchColours: IMatchColours;
+  matchColours: IMatchTypeToColourMap;
   applySuggestions: (suggestions: ApplySuggestionOptions) => void;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -102,7 +102,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
   type TPluginState = IPluginState<TFilterState, TMatch>;
 
   // Set up our store, which we'll use to notify consumer code of state updates.
-  const store = new Store();
+  const store = new Store<TPluginState>();
   const reducer = createReducer<TPluginState>(
     expandRanges,
     ignoreMatch,

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -9,7 +9,7 @@ import { createInitialState, createReducer } from "./state/reducer";
 import { selectNewBlockInFlight } from "./state/selectors";
 import {
   DECORATION_ATTRIBUTE_ID,
-  IMatchColours,
+  IMatchTypeToColourMap,
   defaultMatchColours
 } from "./utils/decoration";
 import { EditorView } from "prosemirror-view";
@@ -54,7 +54,7 @@ export interface IPluginOptions<TMatch extends IMatch = IMatch> {
   /**
    * The colours to use for document matches.
    */
-  matchColours?: IMatchColours;
+  matchColours?: IMatchTypeToColourMap;
 
   /**
    * Is the given element part of the typerighter UI, but not

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -24,7 +24,7 @@ import Store, {
   STORE_EVENT_NEW_DIRTIED_RANGES
 } from "./state/store";
 import { startHoverCommand, stopHoverCommand } from "./commands";
-import { IFilterMatches, maybeResetHoverStates } from "./utils/plugin";
+import { TFilterMatches, maybeResetHoverStates } from "./utils/plugin";
 import { pluginKey } from "./utils/plugin";
 
 export type ExpandRanges = (ranges: IRange[], doc: Node<any>) => IRange[];
@@ -33,7 +33,7 @@ export interface IFilterOptions<TFilterState, TMatch extends IMatch> {
   /**
    * A function to filter matches given a user-defined filter state.
    */
-  filterMatches: IFilterMatches<TFilterState, TMatch>;
+  filterMatches: TFilterMatches<TFilterState, TMatch>;
 
   /**
    * The initial state to pass to the filter predicate.

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -110,7 +110,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
 
   // Set up our store, which we'll use to notify consumer code of state updates.
   const store = new Store();
-  const reducer = createReducer(expandRanges, ignoreMatch);
+  const reducer = createReducer<TPluginState>(expandRanges, ignoreMatch);
 
   const plugin: Plugin = new Plugin({
     key: pluginKey,

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -10,11 +10,12 @@ import Sidebar from "./components/Sidebar";
 import TyperighterTelemetryAdapter from "./services/TyperighterTelemetryAdapter";
 import TelemetryContext from "./contexts/TelemetryContext";
 import { EditorView } from "prosemirror-view";
+import { IPluginState } from "./state/reducer";
 
-interface IViewOptions {
+interface IViewOptions<TPluginState extends IPluginState> {
   view: EditorView;
-  store: Store<IMatch>;
-  matcherService: MatcherService<IMatch>;
+  store: Store<TPluginState>;
+  matcherService: MatcherService<TPluginState["filterState"], IMatch>;
   commands: Commands;
   sidebarNode: Element;
   overlayNode: Element;
@@ -40,7 +41,7 @@ interface IViewOptions {
  *  - The plugin configuration pane
  *  - The plugin results pane
  */
-const createView = ({
+const createView = <TPluginState extends IPluginState>({
   view,
   store,
   matcherService,
@@ -54,7 +55,7 @@ const createView = ({
   onMarkCorrect,
   editorScrollElement,
   getScrollOffset = () => 50
-}: IViewOptions) => {
+}: IViewOptions<TPluginState>) => {
   // Create our overlay node, which is responsible for displaying
   // match messages when the user hovers over highlighted ranges.
   overlayNode.classList.add("TyperighterPlugin__tooltip-overlay");

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,5 +1,5 @@
 import { IMatch, IBlock } from './interfaces/IMatch'
-import { IStore } from './state/store';
+import Store from './state/store';
 import createTyperighterPlugin from "./createTyperighterPlugin";
 import MatcherService from "./services/MatcherService";
 import TelemetryService from "./services/TelemetryService";
@@ -22,5 +22,5 @@ export {
   createTyperighterPlugin,
   IMatch,
   IBlock,
-  IStore
+  Store
 };

--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -69,10 +69,10 @@ export interface IBlockResult {
   id: string;
 }
 
-export interface IMatcherResponse<TBlockMatch extends IMatch = IMatch> {
+export interface IMatcherResponse<MatchesType extends IMatch[] = IMatch[]> {
   blocks: IBlock[];
   categoryIds: string[];
-  matches: TBlockMatch[];
+  matches: MatchesType;
   requestId: string;
 }
 

--- a/src/ts/interfaces/IMatcherAdapter.ts
+++ b/src/ts/interfaces/IMatcherAdapter.ts
@@ -34,7 +34,7 @@ export declare class IMatcherAdapter<
 
 export type TMatchesReceivedCallback<
   TMatch extends IMatch = IMatch
-> = (response: IMatcherResponse<TMatch>) => void;
+> = (response: IMatcherResponse<TMatch[]>) => void;
 
 export type TRequestErrorCallback = (
   matchRequestError: TMatchRequestErrorWithDefault

--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -11,19 +11,20 @@ import { Commands } from "../commands";
 import { selectAllBlockQueriesInFlight } from "../state/selectors";
 import { v4 } from "uuid";
 import TyperighterTelemetryAdapter from "./TyperighterTelemetryAdapter";
+import { IPluginState } from "../state/reducer";
 
 /**
  * A matcher service to manage the interaction between the prosemirror-typerighter plugin
  * and the remote matching service.
  */
-class MatcherService<TMatch extends IMatch> {
+class MatcherService<TFilterState, TMatch extends IMatch> {
   // The current throttle duration, which increases during backoff.
   private currentThrottle: number;
   private currentCategories = [] as ICategory[];
   private allCategories = [] as ICategory[];
   private requestPending = false;
   constructor(
-    private store: Store<TMatch>,
+    private store: Store<IPluginState<TFilterState, TMatch>>,
     private commands: Commands,
     private adapter: IMatcherAdapter<TMatch>,
     private telemetryAdapter?: TyperighterTelemetryAdapter,

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -21,6 +21,7 @@ export const REMOVE_MATCH = "REMOVE_MATCH" as const;
 export const REMOVE_ALL_MATCHES = "REMOVE_ALL_MATCHES" as const;
 export const APPLY_NEW_DIRTY_RANGES = "HANDLE_NEW_DIRTY_RANGES" as const;
 export const SET_CONFIG_VALUE = "SET_CONFIG_VALUE" as const;
+export const SET_FILTER_STATE = "SET_FILTER_STATE" as const;
 
 /**
  * Action creators.
@@ -125,6 +126,18 @@ export const removeAllMatches = () => ({
 });
 export type ActionRemoveAllMatches = ReturnType<typeof removeAllMatches>;
 
+export const setFilterState = <TPluginState extends IPluginState>(
+  filterState: TPluginState["filterState"]
+) => ({
+  type: SET_FILTER_STATE,
+  payload: { filterState }
+});
+// tslint:disable-next-line:interface-over-type-literal
+export type ActionSetFilterState<TPluginState extends IPluginState> = {
+  type: typeof SET_FILTER_STATE;
+  payload: { filterState: TPluginState["filterState"] };
+};
+
 export type Action<TPluginState extends IPluginState> =
   | ActionNewHoverIdReceived
   | ActionNewHighlightIdReceived
@@ -137,4 +150,5 @@ export type Action<TPluginState extends IPluginState> =
   | ActionHandleNewDirtyRanges
   | ActionSetConfigValue
   | ActionRemoveMatch
-  | ActionRemoveAllMatches;
+  | ActionRemoveAllMatches
+  | ActionSetFilterState<TPluginState>;

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -1,10 +1,9 @@
 import {
   IMatchRequestError,
   IMatcherResponse,
-  IRange,
-  IMatch
+  IRange
 } from "../interfaces/IMatch";
-import { IPluginConfig } from "./reducer";
+import { IPluginConfig, IPluginState } from "./reducer";
 
 /**
  * Action types.
@@ -49,16 +48,18 @@ export type ActionRequestMatchesForDocument = ReturnType<
   typeof requestMatchesForDocument
 >;
 
-export const requestMatchesSuccess = <TBlockMatches extends IMatch>(
-  response: IMatcherResponse<TBlockMatches>
+export const requestMatchesSuccess = <TPluginState extends IPluginState>(
+  response: IMatcherResponse<TPluginState["currentMatches"]>
 ) => ({
   type: REQUEST_SUCCESS,
   payload: { response }
 });
+// We must repeat ourselves here, as ReturnType doesn't play nicely with type parameters.
+// See https://github.com/microsoft/TypeScript/issues/26856
 // tslint:disable-next-line:interface-over-type-literal
-export type ActionRequestMatchesSuccess<TMatch extends IMatch> = {
+export type ActionRequestMatchesSuccess<TPluginState extends IPluginState> = {
   type: "REQUEST_SUCCESS";
-  payload: { response: IMatcherResponse<TMatch> };
+  payload: { response: IMatcherResponse<TPluginState["currentMatches"]> };
 };
 
 export const requestError = (matchRequestError: IMatchRequestError) => ({
@@ -73,22 +74,19 @@ export const requestMatchesComplete = (requestId: string) => ({
 });
 export type ActionRequestComplete = ReturnType<typeof requestMatchesComplete>;
 
-export const newHoverIdReceived = (
-  matchId: string | undefined
-) => ({
+export const newHoverIdReceived = (matchId: string | undefined) => ({
   type: NEW_HOVER_ID,
   payload: { matchId }
 });
 export type ActionNewHoverIdReceived = ReturnType<typeof newHoverIdReceived>;
 
-export const newHighlightIdReceived = (
-  matchId: string | undefined
-) => ({
+export const newHighlightIdReceived = (matchId: string | undefined) => ({
   type: NEW_HIGHLIGHT_ID,
   payload: { matchId }
 });
-export type ActionNewHighlightIdReceived = ReturnType<typeof newHighlightIdReceived>;
-
+export type ActionNewHighlightIdReceived = ReturnType<
+  typeof newHighlightIdReceived
+>;
 
 export const applyNewDirtiedRanges = (ranges: IRange[]) => ({
   type: APPLY_NEW_DIRTY_RANGES,
@@ -127,10 +125,10 @@ export const removeAllMatches = () => ({
 });
 export type ActionRemoveAllMatches = ReturnType<typeof removeAllMatches>;
 
-export type Action<TMatch extends IMatch> =
+export type Action<TPluginState extends IPluginState> =
   | ActionNewHoverIdReceived
   | ActionNewHighlightIdReceived
-  | ActionRequestMatchesSuccess<TMatch>
+  | ActionRequestMatchesSuccess<TPluginState>
   | ActionRequestMatchesForDirtyRanges
   | ActionRequestMatchesForDocument
   | ActionRequestError

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -60,6 +60,7 @@ export const deriveFilteredDecorations = <TPluginState extends IPluginState>(
     newState.filterState,
     newState.currentMatches
   );
+  const filteredMatchIds = filteredMatches.map(_ => _.matchId);
 
   const matchIdsWithDecorations = newState.decorations
     .find()
@@ -77,7 +78,7 @@ export const deriveFilteredDecorations = <TPluginState extends IPluginState>(
   const decorationsToRemove = newState.decorations.find(
     undefined,
     undefined,
-    spec => !filteredMatches.includes(spec.id)
+    spec => !filteredMatchIds.includes(spec.id)
   );
 
   const decorations = newState.decorations

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -8,7 +8,7 @@ import {
   createDecorationsForMatches
 } from "../utils/decoration";
 import { DecorationSet } from "prosemirror-view";
-import { IFilterMatches } from "../utils/plugin";
+import { TFilterMatches } from "../utils/plugin";
 import { Node } from "prosemirror-model";
 
 export const addMatchesToState = <TPluginState extends IPluginState>(
@@ -35,8 +35,8 @@ export const addMatchesToState = <TPluginState extends IPluginState>(
 export const shouldFilterDecorations = <TPluginState extends IPluginState>(
   oldState: TPluginState,
   newState: TPluginState,
-  filterMatches?: IFilterMatches<TPluginState["filterState"]>
-): filterMatches is IFilterMatches<TPluginState["filterState"]> => {
+  filterMatches?: TFilterMatches<TPluginState["filterState"]>
+): filterMatches is TFilterMatches<TPluginState["filterState"]> => {
   const matchesChanged = oldState.currentMatches !== newState.currentMatches;
   const filterStateChanged = oldState.filterState !== newState.filterState;
   const noFilterApplied = !oldState.filterState && !newState.filterState;
@@ -50,7 +50,7 @@ export const shouldFilterDecorations = <TPluginState extends IPluginState>(
 export const deriveFilteredDecorations = <TPluginState extends IPluginState>(
   doc: Node,
   newState: TPluginState,
-  filterMatches: IFilterMatches<
+  filterMatches: TFilterMatches<
     TPluginState["filterState"],
     TPluginState["currentMatches"][number]
   >

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -30,9 +30,9 @@ export const addMatchesToState = <TPluginState extends IPluginState>(
 };
 
 /**
- * Should we filter our decorations with the filterMatches predicate?
+ * Is the current filter state stale, given the incoming state?
  */
-export const shouldFilterDecorations = <TPluginState extends IPluginState>(
+export const isFilterStateStale = <TPluginState extends IPluginState>(
   oldState: TPluginState,
   newState: TPluginState,
   filterMatches?: TFilterMatches<TPluginState["filterState"]>

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -37,14 +37,13 @@ export const shouldFilterDecorations = <TPluginState extends IPluginState>(
   newState: TPluginState,
   filterMatches?: IFilterMatches<TPluginState["filterState"]>
 ): filterMatches is IFilterMatches<TPluginState["filterState"]> => {
-  const matchesChanged = oldState.currentMatches === newState.currentMatches;
-  const filterStateChanged = oldState.filterState === newState.filterState;
+  const matchesChanged = oldState.currentMatches !== newState.currentMatches;
+  const filterStateChanged = oldState.filterState !== newState.filterState;
   const noFilterApplied = !oldState.filterState && !newState.filterState;
 
   return (
     !!filterMatches &&
-    ((!filterStateChanged && !matchesChanged) ||
-      (matchesChanged && !noFilterApplied))
+    (filterStateChanged || (matchesChanged && !noFilterApplied))
   );
 };
 

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -1,13 +1,13 @@
-import { IPluginState, IIgnoreMatch, includeAllMatches } from "./reducer";
+import { IPluginState, IIgnoreMatchPredicate, includeAllMatches } from "./reducer";
 import { IMatch } from "../interfaces/IMatch";
 import { createDecorationsForMatch } from "../utils/decoration";
 import { DecorationSet } from "prosemirror-view";
 
-export const addMatchesToState = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>,
+export const addMatchesToState = <TFilterState, TMatch extends IMatch>(
+  state: IPluginState<TFilterState, TMatch>,
   doc: any,
   matches: TMatch[],
-  ignoreMatch: IIgnoreMatch = includeAllMatches
+  ignoreMatch: IIgnoreMatchPredicate = includeAllMatches
 ) => {
   const matchesToApply = matches.filter(match => !ignoreMatch(match));
   const decorations = matchesToApply.reduce(

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -1,12 +1,20 @@
-import { IPluginState, IIgnoreMatchPredicate, includeAllMatches } from "./reducer";
-import { IMatch } from "../interfaces/IMatch";
-import { createDecorationsForMatch } from "../utils/decoration";
+import {
+  IPluginState,
+  IIgnoreMatchPredicate,
+  includeAllMatches
+} from "./reducer";
+import {
+  createDecorationsForMatch,
+  createDecorationsForMatches
+} from "../utils/decoration";
 import { DecorationSet } from "prosemirror-view";
+import { IFilterMatches } from "../utils/plugin";
+import { Node } from "prosemirror-model";
 
-export const addMatchesToState = <TFilterState, TMatch extends IMatch>(
-  state: IPluginState<TFilterState, TMatch>,
+export const addMatchesToState = <TPluginState extends IPluginState>(
+  state: TPluginState,
   doc: any,
-  matches: TMatch[],
+  matches: Array<TPluginState["currentMatches"][number]>,
   ignoreMatch: IIgnoreMatchPredicate = includeAllMatches
 ) => {
   const matchesToApply = matches.filter(match => !ignoreMatch(match));
@@ -17,6 +25,68 @@ export const addMatchesToState = <TFilterState, TMatch extends IMatch>(
   return {
     ...state,
     currentMatches: matchesToApply,
+    decorations
+  };
+};
+
+/**
+ * Should we filter our decorations with the filterMatches predicate?
+ */
+export const shouldFilterDecorations = <TPluginState extends IPluginState>(
+  oldState: TPluginState,
+  newState: TPluginState,
+  filterMatches?: IFilterMatches<TPluginState["filterState"]>
+): filterMatches is IFilterMatches<TPluginState["filterState"]> => {
+  const matchesChanged = oldState.currentMatches === newState.currentMatches;
+  const filterStateChanged = oldState.filterState === newState.filterState;
+  const noFilterApplied = !oldState.filterState && !newState.filterState;
+
+  return (
+    !!filterMatches &&
+    ((!filterStateChanged && !matchesChanged) ||
+      (matchesChanged && !noFilterApplied))
+  );
+};
+
+export const deriveFilteredDecorations = <TPluginState extends IPluginState>(
+  doc: Node,
+  newState: TPluginState,
+  filterMatches: IFilterMatches<
+    TPluginState["filterState"],
+    TPluginState["currentMatches"][number]
+  >
+): TPluginState => {
+  const filteredMatches = filterMatches(
+    newState.filterState,
+    newState.currentMatches
+  );
+
+  const matchIdsWithDecorations = newState.decorations
+    .find()
+    .map(_ => _.spec.id);
+
+  const matchesWithoutDecorations = filteredMatches.filter(
+    match => !matchIdsWithDecorations.includes(match.matchId)
+  );
+
+  const decorationsToAdd = createDecorationsForMatches(
+    matchesWithoutDecorations,
+    newState.config.matchColours
+  );
+
+  const decorationsToRemove = newState.decorations.find(
+    undefined,
+    undefined,
+    spec => !filteredMatches.includes(spec.id)
+  );
+
+  const decorations = newState.decorations
+    .remove(decorationsToRemove)
+    .add(doc, decorationsToAdd);
+
+  return {
+    ...newState,
+    filteredMatches,
     decorations
   };
 };

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -168,7 +168,7 @@ export const createInitialState = <
   matches = [],
   ignoreMatch = includeAllMatches,
   matchColours = defaultMatchColours,
-  filterOptions = undefined
+  filterOptions
 }: IInitialStateOpts<TFilterState, TMatch>): IPluginState<
   TFilterState,
   TMatch

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -41,7 +41,7 @@ import {
   DECORATION_MATCH,
   createDecorationsForMatch,
   createDecorationsForMatches,
-  IMatchColours,
+  IMatchTypeToColourMap,
   defaultMatchColours
 } from "../utils/decoration";
 import {
@@ -94,7 +94,7 @@ export interface IPluginConfig {
   // and expanded ranges.
   debug: boolean;
   // The colours to use when rendering matches
-  matchColours: IMatchColours;
+  matchColours: IMatchTypeToColourMap;
 }
 
 export interface IPluginState<TMatches extends IMatch = IMatch> {
@@ -136,7 +136,7 @@ export const createInitialState = <TMatch extends IMatch>(
   doc: Node,
   matches: TMatch[] = [],
   ignoreMatch: IIgnoreMatch = includeAllMatches,
-  matchColours: IMatchColours = defaultMatchColours
+  matchColours: IMatchTypeToColourMap = defaultMatchColours
 ): IPluginState<TMatch> => {
   const initialState: IPluginState<TMatch> = {
     config: {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -23,7 +23,9 @@ import {
   SET_CONFIG_VALUE,
   Action,
   ActionRequestComplete,
-  ActionRemoveMatch
+  ActionRemoveMatch,
+  SET_FILTER_STATE,
+  ActionSetFilterState
 } from "./actions";
 import {
   IMatch,
@@ -217,6 +219,8 @@ export const createReducer = <TPluginState extends IPluginState>(
         return handleNewDirtyRanges(tr, state, action);
       case SET_CONFIG_VALUE:
         return handleSetConfigValue(tr, state, action);
+      case SET_FILTER_STATE:
+        return handleSetFilterState(tr, state, action);
       default:
         return state;
     }
@@ -732,12 +736,19 @@ const handleSetConfigValue = <TPluginState extends IPluginState>(
   _: Transaction,
   state: TPluginState,
   { payload: { key, value } }: ActionSetConfigValue
-): TPluginState => {
-  return {
-    ...state,
-    config: {
-      ...state.config,
-      [key]: value
-    }
-  };
-};
+): TPluginState => ({
+  ...state,
+  config: {
+    ...state.config,
+    [key]: value
+  }
+});
+
+const handleSetFilterState = <TPluginState extends IPluginState>(
+  _: Transaction,
+  state: TPluginState,
+  { payload: { filterState } }: ActionSetFilterState<TPluginState>
+): TPluginState => ({
+  ...state,
+  filterState
+});

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -52,7 +52,7 @@ import {
   findOverlappingRangeIndex,
   removeOverlappingRanges
 } from "../utils/range";
-import { ExpandRanges } from "../createTyperighterPlugin";
+import { ExpandRanges, IFilterOptions } from "../createTyperighterPlugin";
 import { getBlocksFromDocument } from "../utils/prosemirror";
 import { Node } from "prosemirror-model";
 import {
@@ -64,6 +64,7 @@ import {
 import { Mapping } from "prosemirror-transform";
 import { createBlock } from "../utils/block";
 import { addMatchesToState } from "./helpers";
+import { IDefaultFilterState } from "../utils/plugin";
 
 export interface IBlockInFlight {
   // The categories that haven't yet reported for this block.
@@ -76,8 +77,8 @@ export interface IBlockInFlight {
  * Handy when, for example, consumers know that parts of the document are
  * exempt from checks.
  */
-export type IIgnoreMatch = (match: IMatch) => boolean;
-export const includeAllMatches: IIgnoreMatch = () => false;
+export type IIgnoreMatchPredicate = (match: IMatch) => boolean;
+export const includeAllMatches: IIgnoreMatchPredicate = () => false;
 
 export interface IBlocksInFlightState {
   totalBlocks: number;
@@ -97,7 +98,10 @@ export interface IPluginConfig {
   matchColours: IMatchTypeToColourMap;
 }
 
-export interface IPluginState<TMatches extends IMatch = IMatch> {
+export interface IPluginState<
+  TFilterState = IDefaultFilterState,
+  TMatches extends IMatch = IMatch
+> {
   config: IPluginConfig;
   // The current decorations the plugin is applying to the document.
   decorations: DecorationSet;
@@ -124,7 +128,19 @@ export interface IPluginState<TMatches extends IMatch = IMatch> {
   };
   // The current error message.
   requestErrors: IMatchRequestError[];
+  // The current state of the filter
+  filterState: TFilterState;
 }
+
+type TReducerHandler<
+  TFilterType,
+  TAction extends Action<TMatch>,
+  TMatch extends IMatch = IMatch
+> = (
+  tr: Transaction,
+  state: IPluginState<TFilterType, TMatch>,
+  action: TAction
+) => IPluginState<TFilterType, TMatch>;
 
 // The transaction meta key that namespaces our actions.
 export const PROSEMIRROR_TYPERIGHTER_ACTION = "PROSEMIRROR_TYPERIGHTER_ACTION";
@@ -132,13 +148,14 @@ export const PROSEMIRROR_TYPERIGHTER_ACTION = "PROSEMIRROR_TYPERIGHTER_ACTION";
 /**
  * Initial state.
  */
-export const createInitialState = <TMatch extends IMatch>(
+export const createInitialState = <TFilterState, TMatch extends IMatch>(
   doc: Node,
   matches: TMatch[] = [],
-  ignoreMatch: IIgnoreMatch = includeAllMatches,
+  filterState: TFilterState,
+  ignoreMatch: IIgnoreMatchPredicate = includeAllMatches,
   matchColours: IMatchTypeToColourMap = defaultMatchColours
-): IPluginState<TMatch> => {
-  const initialState: IPluginState<TMatch> = {
+): IPluginState<TFilterState, TMatch> => {
+  const initialState: IPluginState<TFilterState, TMatch> = {
     config: {
       debug: false,
       requestMatchesOnDocModified: false,
@@ -155,25 +172,31 @@ export const createInitialState = <TMatch extends IMatch>(
     highlightId: undefined,
     requestsInFlight: {},
     requestPending: false,
-    requestErrors: []
+    requestErrors: [],
+    filterState
   };
-  return addMatchesToState(initialState, doc, matches, ignoreMatch);
+  return addMatchesToState<TFilterState, TMatch>(
+    initialState,
+    doc,
+    matches,
+    ignoreMatch
+  );
 };
 
 export const createReducer = (
   expandRanges: ExpandRanges,
-  ignoreMatch: IIgnoreMatch = includeAllMatches
+  ignoreMatch: IIgnoreMatchPredicate = includeAllMatches
 ) => {
   const handleMatchesRequestForDirtyRanges = createHandleMatchesRequestForDirtyRanges(
     expandRanges
   );
-  const handleNewHoverId = createHandleNewFocusState('hoverId');
-  const handleNewHighlightId = createHandleNewFocusState('highlightId');
-  return <TMatch extends IMatch>(
+  const handleNewHoverId = createHandleNewFocusState("hoverId");
+  const handleNewHighlightId = createHandleNewFocusState("highlightId");
+  return <TFilterState, TMatch extends IMatch>(
     tr: Transaction,
-    incomingState: IPluginState<TMatch>,
+    incomingState: IPluginState<TFilterState, TMatch>,
     action?: Action<TMatch>
-  ): IPluginState<TMatch> => {
+  ): IPluginState<TFilterState, TMatch> => {
     // There are certain things we need to do every time the document is changed, e.g. mapping ranges.
     const state = tr.docChanged
       ? getNewStateFromTransaction(tr, incomingState)
@@ -220,10 +243,10 @@ export const createReducer = (
  * We need to respond to each transaction in our reducer, whether or not there's
  * an action present, in order to maintain mappings and respond to user input.
  */
-const getNewStateFromTransaction = <TMatch extends IMatch>(
+const getNewStateFromTransaction = <TFilterState, TMatch extends IMatch>(
   tr: Transaction,
-  incomingState: IPluginState<TMatch>
-): IPluginState<TMatch> => {
+  incomingState: IPluginState<TFilterState, TMatch>
+): IPluginState<TFilterState, TMatch> => {
   const mappedRequestsInFlight = Object.entries(
     incomingState.requestsInFlight
   ).reduce((acc, [requestId, requestsInFlight]) => {
@@ -256,11 +279,11 @@ const getNewStateFromTransaction = <TMatch extends IMatch>(
 /**
  * Handle the selection of a hover id.
  */
-const handleSelectMatch = <TMatch extends IMatch>(
+const handleSelectMatch = <TFilterState, TMatch extends IMatch>(
   _: unknown,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   action: ActionSelectMatch
-): IPluginState<TMatch> => {
+): IPluginState<TFilterState, TMatch> => {
   return {
     ...state,
     selectedMatch: action.payload.matchId
@@ -270,11 +293,11 @@ const handleSelectMatch = <TMatch extends IMatch>(
 /**
  * Remove a match and its decoration from the state.
  */
-const handleRemoveMatch = <TMatch extends IMatch>(
+const handleRemoveMatch = <TFilterState, TMatch extends IMatch>(
   _: unknown,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { id } }: ActionRemoveMatch
-): IPluginState<TMatch> => {
+): IPluginState<TFilterState, TMatch> => {
   const decorationToRemove = state.decorations.find(
     undefined,
     undefined,
@@ -301,11 +324,11 @@ const handleRemoveAllMatches = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
 ): IPluginState<TMatch> => {
   const decorationToRemove = state.decorations.find();
-  
+
   const decorations = decorationToRemove
     ? state.decorations.remove(decorationToRemove)
     : state.decorations;
-  
+
   return {
     ...state,
     decorations,
@@ -317,13 +340,13 @@ const handleRemoveAllMatches = <TMatch extends IMatch>(
 /**
  * Handle the receipt of a new focus state.
  */
-const createHandleNewFocusState = (focusState: "highlightId" | "hoverId") => <
-  TMatch extends IMatch
->(
-  tr: Transaction,
-  state: IPluginState<TMatch>,
-  action: ActionNewHoverIdReceived | ActionNewHighlightIdReceived
-): IPluginState<TMatch> => {
+const createHandleNewFocusState = <TFilterState, TMatch extends IMatch>(
+  focusState: "highlightId" | "hoverId"
+): TReducerHandler<
+  TFilterState,
+  ActionNewHoverIdReceived | ActionNewHighlightIdReceived,
+  TMatch
+> => (tr, state, action) => {
   let decorations = state.decorations;
   const incomingHoverId = action.payload.matchId;
   const currentHoverId = state[focusState];
@@ -366,9 +389,9 @@ const createHandleNewFocusState = (focusState: "highlightId" | "hoverId") => <
   };
 };
 
-const handleNewDirtyRanges = <TMatch extends IMatch>(
+const handleNewDirtyRanges = <TFilterState, TMatch extends IMatch>(
   tr: Transaction,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { ranges: dirtiedRanges } }: ActionHandleNewDirtyRanges
 ) => {
   // Map our dirtied ranges through the current transaction, and append any new ranges it has dirtied.
@@ -404,9 +427,9 @@ const handleNewDirtyRanges = <TMatch extends IMatch>(
  */
 const createHandleMatchesRequestForDirtyRanges = (
   expandRanges: ExpandRanges
-) => <TMatch extends IMatch>(
+) => <TFilterState, TMatch extends IMatch>(
   tr: Transaction,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { requestId, categoryIds } }: ActionRequestMatchesForDirtyRanges
 ) => {
   const ranges = expandRanges(state.dirtiedRanges, tr.doc);
@@ -419,9 +442,9 @@ const createHandleMatchesRequestForDirtyRanges = (
 /**
  * Handle a matches request for the entire document.
  */
-const handleMatchesRequestForDocument = <TMatch extends IMatch>(
+const handleMatchesRequestForDocument = <TFilterState, TMatch extends IMatch>(
   tr: Transaction,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { requestId, categoryIds } }: ActionRequestMatchesForDocument
 ) => {
   return handleRequestStart(
@@ -438,10 +461,10 @@ const handleRequestStart = (
   requestId: string,
   blocks: IBlock[],
   categoryIds: string[]
-) => <TMatch extends IMatch>(
+) => <TFilterState, TMatch extends IMatch>(
   tr: Transaction,
-  state: IPluginState<TMatch>
-): IPluginState<TMatch> => {
+  state: IPluginState<TFilterState, TMatch>
+): IPluginState<TFilterState, TMatch> => {
   // Replace any debug decorations, if they exist.
   const decorations = state.config.debug
     ? removeDecorationsFromRanges(state.decorations, blocks, [
@@ -476,8 +499,8 @@ const handleRequestStart = (
   };
 };
 
-const amendBlockQueriesInFlight = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>,
+const amendBlockQueriesInFlight = <TFilterState, TMatch extends IMatch>(
+  state: IPluginState<TFilterState, TMatch>,
   requestId: string,
   blockId: string,
   categoryIds: string[]
@@ -522,13 +545,14 @@ const amendBlockQueriesInFlight = <TMatch extends IMatch>(
 /**
  * Handle a response, decorating the document with any matches we've received.
  */
-const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatch) => <
+const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
+  TFilterState,
   TMatch extends IMatch
 >(
   tr: Transaction,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { response } }: ActionRequestMatchesSuccess<TMatch>
-): IPluginState<TMatch> => {
+): IPluginState<TFilterState, TMatch> => {
   if (!response) {
     return state;
   }
@@ -617,9 +641,9 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatch) => <
 /**
  * Handle a matches request error.
  */
-const handleMatchesRequestError = <TMatch extends IMatch>(
+const handleMatchesRequestError = <TFilterState, TMatch extends IMatch>(
   tr: Transaction,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { matchRequestError } }: ActionRequestError
 ) => {
   const { requestId, blockId, categoryIds } = matchRequestError;
@@ -694,9 +718,9 @@ const handleMatchesRequestError = <TMatch extends IMatch>(
   };
 };
 
-const handleRequestComplete = <TMatch extends IMatch>(
+const handleRequestComplete = <TFilterState, TMatch extends IMatch>(
   _: Transaction,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { requestId } }: ActionRequestComplete
 ) => {
   const requestInFlight = selectBlockQueriesInFlightForSet(state, requestId);
@@ -718,9 +742,9 @@ const handleRequestComplete = <TMatch extends IMatch>(
   };
 };
 
-const handleSetConfigValue = <TMatch extends IMatch>(
+const handleSetConfigValue = <TFilterState, TMatch extends IMatch>(
   _: Transaction,
-  state: IPluginState<TMatch>,
+  state: IPluginState<TFilterState, TMatch>,
   { payload: { key, value } }: ActionSetConfigValue
 ) => {
   return {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -68,7 +68,7 @@ import { createBlock } from "../utils/block";
 import {
   addMatchesToState,
   deriveFilteredDecorations,
-  shouldFilterDecorations
+  isFilterStateStale
 } from "./helpers";
 import { TFilterMatches } from "../utils/plugin";
 
@@ -168,7 +168,7 @@ export const createInitialState = <
   matches = [],
   ignoreMatch = includeAllMatches,
   matchColours = defaultMatchColours,
-  filterOptions
+  filterOptions = undefined
 }: IInitialStateOpts<TFilterState, TMatch>): IPluginState<
   TFilterState,
   TMatch
@@ -277,7 +277,7 @@ export const createReducer = <TPluginState extends IPluginState>(
 
     const newState = applyNewState();
 
-    if (!shouldFilterDecorations(state, newState, filterMatches)) {
+    if (!isFilterStateStale(state, newState, filterMatches)) {
       return newState;
     }
 

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -70,7 +70,7 @@ import {
   deriveFilteredDecorations,
   shouldFilterDecorations
 } from "./helpers";
-import { IFilterMatches } from "../utils/plugin";
+import { TFilterMatches } from "../utils/plugin";
 
 export interface IBlockInFlight {
   // The categories that haven't yet reported for this block.
@@ -216,7 +216,7 @@ export const createInitialState = <
 export const createReducer = <TPluginState extends IPluginState>(
   expandRanges: ExpandRanges,
   ignoreMatch: IIgnoreMatchPredicate = includeAllMatches,
-  filterMatches?: IFilterMatches<
+  filterMatches?: TFilterMatches<
     TPluginState["filterState"],
     TPluginState["currentMatches"][0]
   >

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -3,13 +3,13 @@ import { IMatch, ISuggestion } from "../interfaces/IMatch";
 import { IPluginState, IBlockInFlight, IBlocksInFlightState } from "./reducer";
 
 export const selectMatchByMatchId = (
-  state: IPluginState<any>,
+  state: IPluginState<unknown>,
   matchId: string
 ): IMatch | undefined =>
   state.currentMatches.find(match => match.matchId === matchId);
 
 export const selectBlockQueriesInFlightForSet = (
-  state: IPluginState,
+  state: IPluginState<unknown>,
   requestId: string
 ): IBlocksInFlightState | undefined => {
   return state.requestsInFlight[requestId];
@@ -65,17 +65,18 @@ export const selectNewBlockInFlight = (
     [] as TSelectRequestInFlight
   );
 
-export const selectPercentRemaining = (
-  state: IPluginState
-) => {
+export const selectPercentRemaining = (state: IPluginState) => {
   const [totalWork, totalRemainingWork] = Object.values(
     state.requestsInFlight
   ).reduce(
     ([totalWorkAcc, remainingWorkAcc], queryState) => {
       const allCategories = queryState.categoryIds.length === 0;
-      const allWork = queryState.totalBlocks * (allCategories ? 1 : queryState.categoryIds.length);
+      const allWork =
+        queryState.totalBlocks *
+        (allCategories ? 1 : queryState.categoryIds.length);
       const remainingWork = queryState.pendingBlocks.reduce(
-        (acc, block) => acc + (allCategories ? 1 : block.pendingCategoryIds.length),
+        (acc, block) =>
+          acc + (allCategories ? 1 : block.pendingCategoryIds.length),
         0
       );
       return [totalWorkAcc + allWork, remainingWorkAcc + remainingWork];
@@ -112,37 +113,34 @@ export const selectAllAutoFixableMatches = <T, TMatch extends IMatch>(
     _ => _.replacement && _.replacement.text === _.message
   );
 
-export const selectHasGeneralError = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
-): boolean => {
-  const generalErrors = state.requestErrors.filter(_ => _.type === "GENERAL_ERROR");
-  return generalErrors.length > 0};
+export const selectHasGeneralError = (state: IPluginState): boolean => {
+  const generalErrors = state.requestErrors.filter(
+    _ => _.type === "GENERAL_ERROR"
+  );
+  return generalErrors.length > 0;
+};
 
-export const selectHasAuthError = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
-): boolean => {
+export const selectHasAuthError = (state: IPluginState): boolean => {
   const authErrors = state.requestErrors.filter(_ => _.type === "AUTH_ERROR");
   return authErrors.length > 0;
 };
 
-export const selectRequestsInProgress = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
-): boolean => !!Object.keys(state.requestsInFlight).length;
+export const selectRequestsInProgress = (state: IPluginState): boolean =>
+  !!Object.keys(state.requestsInFlight).length;
 
 export const selectHasMatches = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
+  state: IPluginState<unknown, TMatch>
 ): boolean => !!state.currentMatches && state.currentMatches.length > 0;
 
 export const selectImportanceOrderedMatches = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
-): IMatch<ISuggestion>[] => sortBy(state.currentMatches, match => {
-  if(match.matchedText == match.replacement?.text){
-    return 2;
-  }
-  else if(!match.replacement){
-    return 1;
-  }
-  else {
-    return 0;
-  }
-});
+  state: IPluginState<unknown, TMatch>
+): Array<IMatch<ISuggestion>> =>
+  sortBy(state.currentMatches, match => {
+    if (match.matchedText === match.replacement?.text) {
+      return 2;
+    } else if (!match.replacement) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -2,21 +2,21 @@ import { sortBy } from "lodash";
 import { IMatch, ISuggestion } from "../interfaces/IMatch";
 import { IPluginState, IBlockInFlight, IBlocksInFlightState } from "./reducer";
 
-export const selectMatchByMatchId = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>,
+export const selectMatchByMatchId = (
+  state: IPluginState<any>,
   matchId: string
 ): IMatch | undefined =>
   state.currentMatches.find(match => match.matchId === matchId);
 
-export const selectBlockQueriesInFlightForSet = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>,
+export const selectBlockQueriesInFlightForSet = (
+  state: IPluginState,
   requestId: string
 ): IBlocksInFlightState | undefined => {
   return state.requestsInFlight[requestId];
 };
 
-export const selectSingleBlockInFlightById = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>,
+export const selectSingleBlockInFlightById = (
+  state: IPluginState,
   requestId: string,
   blockId: string
 ): IBlockInFlight | undefined => {
@@ -27,8 +27,8 @@ export const selectSingleBlockInFlightById = <TMatch extends IMatch>(
   return blocksInFlight.pendingBlocks.find(_ => _.block.id === blockId);
 };
 
-export const selectBlockQueriesInFlightById = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>,
+export const selectBlockQueriesInFlightById = (
+  state: IPluginState,
   requestId: string,
   blockIds: string[]
 ): IBlockInFlight[] =>
@@ -36,8 +36,8 @@ export const selectBlockQueriesInFlightById = <TMatch extends IMatch>(
     .map(blockId => selectSingleBlockInFlightById(state, requestId, blockId))
     .filter(_ => !!_) as IBlockInFlight[];
 
-export const selectAllBlockQueriesInFlight = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
+export const selectAllBlockQueriesInFlight = (
+  state: IPluginState
 ): IBlockInFlight[] =>
   Object.values(state.requestsInFlight).reduce(
     (acc, value) => acc.concat(value.pendingBlocks),
@@ -50,9 +50,9 @@ type TSelectRequestInFlight = Array<
   }
 >;
 
-export const selectNewBlockInFlight = <TMatch extends IMatch>(
-  oldState: IPluginState<TMatch>,
-  newState: IPluginState<TMatch>
+export const selectNewBlockInFlight = (
+  oldState: IPluginState,
+  newState: IPluginState
 ): TSelectRequestInFlight =>
   Object.keys(newState.requestsInFlight).reduce(
     (acc, requestId) =>
@@ -65,14 +65,14 @@ export const selectNewBlockInFlight = <TMatch extends IMatch>(
     [] as TSelectRequestInFlight
   );
 
-export const selectPercentRemaining = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
+export const selectPercentRemaining = (
+  state: IPluginState
 ) => {
   const [totalWork, totalRemainingWork] = Object.values(
     state.requestsInFlight
   ).reduce(
     ([totalWorkAcc, remainingWorkAcc], queryState) => {
-      const allCategories = queryState.categoryIds.length == 0;
+      const allCategories = queryState.categoryIds.length === 0;
       const allWork = queryState.totalBlocks * (allCategories ? 1 : queryState.categoryIds.length);
       const remainingWork = queryState.pendingBlocks.reduce(
         (acc, block) => acc + (allCategories ? 1 : block.pendingCategoryIds.length),
@@ -85,8 +85,8 @@ export const selectPercentRemaining = <TMatch extends IMatch>(
   return totalRemainingWork ? (totalRemainingWork / totalWork) * 100 : 0;
 };
 
-export const selectSuggestionAndRange = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>,
+export const selectSuggestionAndRange = (
+  state: IPluginState,
   matchId: string,
   suggestionIndex: number
 ) => {
@@ -105,8 +105,8 @@ export const selectSuggestionAndRange = <TMatch extends IMatch>(
   };
 };
 
-export const selectAllAutoFixableMatches = <TMatch extends IMatch>(
-  state: IPluginState<TMatch>
+export const selectAllAutoFixableMatches = <T, TMatch extends IMatch>(
+  state: IPluginState<T, TMatch>
 ): TMatch[] =>
   state.currentMatches.filter(
     _ => _.replacement && _.replacement.text === _.message

--- a/src/ts/state/store.ts
+++ b/src/ts/state/store.ts
@@ -1,6 +1,6 @@
 import { IPluginState } from "./reducer";
 import { ArgumentTypes } from "../utils/types";
-import { IMatch, IBlock } from "../interfaces/IMatch";
+import { IBlock } from "../interfaces/IMatch";
 
 export const STORE_EVENT_NEW_MATCHES = "STORE_EVENT_NEW_MATCHES";
 export const STORE_EVENT_NEW_STATE = "STORE_EVENT_NEW_STATE";
@@ -10,27 +10,27 @@ type STORE_EVENT_NEW_MATCHES = typeof STORE_EVENT_NEW_MATCHES;
 type STORE_EVENT_NEW_STATE = typeof STORE_EVENT_NEW_STATE;
 type STORE_EVENT_NEW_DIRTIED_RANGES = typeof STORE_EVENT_NEW_DIRTIED_RANGES;
 
-export interface IStoreEvents<TMatch extends IMatch> {
+export interface IStoreEvents<TPluginState extends IPluginState> {
   [STORE_EVENT_NEW_MATCHES]: (
     requestId: string,
     blocks: IBlock[]
   ) => void;
-  [STORE_EVENT_NEW_STATE]: (state: IPluginState<TMatch>) => void;
+  [STORE_EVENT_NEW_STATE]: (state: TPluginState) => void;
   [STORE_EVENT_NEW_DIRTIED_RANGES]: () => void;
 }
 
-type EventNames = keyof IStoreEvents<IMatch>;
+type EventNames = keyof IStoreEvents<IPluginState>;
 
 /**
  * A store to allow consumers to subscribe to state updates.
  */
 class Store<
-  TMatch extends IMatch,
-  TStoreEvents extends IStoreEvents<TMatch> = IStoreEvents<
-    TMatch
+  TPluginState extends IPluginState,
+  TStoreEvents extends IStoreEvents<TPluginState> = IStoreEvents<
+    TPluginState
   >
 > {
-  private state: IPluginState<TMatch> | undefined;
+  private state: TPluginState | undefined;
   private subscribers: {
     [EventName in EventNames]: Array<TStoreEvents[EventName]>
   } = {
@@ -95,11 +95,9 @@ class Store<
   /**
    * Update the store's reference to the plugin state.
    */
-  private updateState(state: IPluginState<TMatch>) {
+  private updateState(state: TPluginState) {
     this.state = state;
   }
 }
-
-export type IStore<TMatch extends IMatch = IMatch> = Store<TMatch>;
 
 export default Store;

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -1,0 +1,122 @@
+import { identity } from "lodash";
+import { DecorationSet } from "prosemirror-view";
+import { IMatch } from "../..";
+import {
+  createInitialTr,
+  createMatch,
+  createStateWithMatches,
+  defaultDoc
+} from "../../test/helpers/fixtures";
+import {
+  getNewDecorationsForCurrentMatches,
+  MatchType
+} from "../../utils/decoration";
+import { filterByMatchState, IDefaultFilterState } from "../../utils/plugin";
+import { expandRangesToParentBlockNode } from "../../utils/range";
+import { deriveFilteredDecorations, isFilterStateStale } from "../helpers";
+import { createReducer, IPluginState } from "../reducer";
+
+describe("State helpers", () => {
+  const getStateWithFilter = <TFilterState extends unknown>(
+    matchesToAdd: IMatch[],
+    filterState: TFilterState
+  ) => {
+    const { state, matches } = createStateWithMatches(
+      createReducer(expandRangesToParentBlockNode),
+      matchesToAdd
+    );
+    const tr = createInitialTr(defaultDoc);
+    return {
+      tr,
+      matches,
+      state: {
+        ...state,
+        filterState
+      } as IPluginState<TFilterState>
+    };
+  };
+
+  describe("isFilterStateStale", () => {
+    it("should report fresh when the filter state is undefined", () => {
+      const matches = [] as IMatch[];
+      const { state: oldState } = getStateWithFilter(matches, undefined);
+      const { state: newState } = getStateWithFilter(matches, undefined);
+      const isStale = isFilterStateStale(oldState, newState, identity);
+      expect(isStale).toBe(false);
+    });
+    it("should report fresh when the filter state is undefined and the matches change", () => {
+      const { state: oldState } = getStateWithFilter([] as IMatch[], undefined);
+      const { state: newState } = getStateWithFilter(
+        [createMatch(1, 2)],
+        undefined
+      );
+      const isStale = isFilterStateStale(oldState, newState, identity);
+      expect(isStale).toBe(false);
+    });
+    it("should report stale when the filter state changes", () => {
+      const oldFilterState = [] as MatchType[];
+      const newFilterState = [MatchType.CORRECT];
+      const matches = [] as IMatch[];
+      const { state: oldState } = getStateWithFilter(matches, oldFilterState);
+      const { state: newState } = getStateWithFilter(matches, newFilterState);
+      const isStale = isFilterStateStale(oldState, newState, identity);
+      expect(isStale).toBe(true);
+    });
+    it("should report stale when the matches change and the filter state remains the same", () => {
+      const filterState = [] as MatchType[];
+      const oldMatches = [] as IMatch[];
+      const newMatches = [createMatch(1, 2)];
+      const { state: oldState } = getStateWithFilter(oldMatches, filterState);
+      const { state: newState } = getStateWithFilter(newMatches, filterState);
+      const isStale = isFilterStateStale(oldState, newState, identity);
+      expect(isStale).toBe(true);
+    });
+  });
+
+  describe("deriveFilterDecorations", () => {
+    it("should handle empty filters and matches", () => {
+      const { tr, state } = getStateWithFilter([], []);
+      const { filteredMatches, decorations } = deriveFilteredDecorations(
+        tr.doc,
+        state as IPluginState<IDefaultFilterState>,
+        filterByMatchState
+      );
+      expect(filteredMatches).toEqual([]);
+      expect(decorations).toEqual(new DecorationSet());
+    });
+    it("should handle a no-op filter state, adding matches to the filtered state", () => {
+      const matches = [createMatch(1, 4), createMatch(4, 7)];
+      const { tr, state } = getStateWithFilter(matches, []);
+      const {
+        currentMatches,
+        filteredMatches,
+        decorations
+      } = deriveFilteredDecorations(
+        tr.doc,
+        state as IPluginState<IDefaultFilterState>,
+        filterByMatchState
+      );
+      expect(filteredMatches).toEqual(currentMatches);
+      expect(decorations).toEqual(
+        getNewDecorationsForCurrentMatches(matches, new DecorationSet(), tr.doc)
+      );
+    });
+    it("should remove matches when they don't pass the filter", () => {
+      const matches = [createMatch(1, 4), createMatch(4, 7)];
+      const { tr, state } = getStateWithFilter(matches, [MatchType.DEFAULT]);
+      const {
+        currentMatches,
+        filteredMatches,
+        decorations
+      } = deriveFilteredDecorations(
+        tr.doc,
+        state as IPluginState<IDefaultFilterState>,
+        filterByMatchState
+      );
+
+      expect(currentMatches).toEqual(matches);
+      expect(filteredMatches).toEqual([]);
+      expect(decorations).toEqual(new DecorationSet());
+    });
+  });
+});

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -10,7 +10,7 @@ import {
   requestMatchesSuccess,
   newHoverIdReceived,
   requestMatchesComplete as requestComplete,
-  removeMatch, 
+  removeMatch,
   removeAllMatches
 } from "../actions";
 import { selectBlockQueriesInFlightForSet } from "../selectors";
@@ -34,36 +34,11 @@ import {
   createInitialData,
   defaultDoc,
   createMatch,
-  ICreateMatcherResponseSpec
+  createStateWithMatches
 } from "../../test/helpers/fixtures";
 import { createBlockId } from "../../utils/block";
-import { getBlocksFromDocument } from "../../utils/prosemirror";
 
 const reducer = createReducer(expandRangesToParentBlockNode);
-
-/**
- * Create a plugin state, creating the given matches and
- * their decorations from the given spec.
- */
-const createStateWithMatches = (
-  localReducer: ReturnType<typeof createReducer>,
-  matches: ICreateMatcherResponseSpec[]
-): { state: IPluginState; matches: IMatch[] } => {
-  const docTime = 1337;
-  const { state, tr } = createInitialData(defaultDoc, docTime);
-
-  let localState = localReducer(
-    tr,
-    state,
-    requestMatchesForDocument(exampleRequestId, exampleCategoryIds)
-  );
-  const block = getBlocksFromDocument(defaultDoc, docTime)[0];
-  const matchesWithBlock = matches.map(match => ({ ...match, block }));
-  const response = createMatcherResponse(matchesWithBlock, exampleRequestId);
-  localState = localReducer(tr, localState, requestMatchesSuccess(response));
-
-  return { matches: response.matches, state: localState };
-};
 
 describe("Action handlers", () => {
   describe("No action", () => {
@@ -727,7 +702,7 @@ describe("Action handlers", () => {
         createMatcherResponse([{ from: 20, to: 25 }])];
 
       let newState = matcherResponses.reduce((acc, cur) => {
-        const error: IMatchRequestError = { 
+        const error: IMatchRequestError = {
           requestId: cur.requestId,
           message: "An error occured",
           categoryIds: cur.categoryIds,

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -13,15 +13,18 @@ import createTyperighterPlugin, {
 } from "../createTyperighterPlugin";
 import { createMatch, createMatcherResponse } from "./helpers/fixtures";
 import { createBoundCommands } from "../commands";
-import { IMatcherResponse } from "../interfaces/IMatch";
+import { IMatch, IMatcherResponse } from "../interfaces/IMatch";
 import { getBlocksFromDocument } from "../utils/prosemirror";
-import { createDecorationsForMatches } from "../utils/decoration";
+import { createDecorationsForMatches, MatchType } from "../utils/decoration";
+import { filterByMatchState, IDefaultFilterState } from "../utils/plugin";
 
 const doc = createDoc(p("Example text to check"), p("More text to check"));
 const blocks = getBlocksFromDocument(doc);
 const matches = [createMatch(1)];
 
-const createPlugin = (opts?: IPluginOptions) => {
+const createPlugin = <TFilterState = unknown>(
+  opts?: IPluginOptions<TFilterState>
+) => {
   const { plugin, getState, store } = createTyperighterPlugin({
     matches,
     ...opts
@@ -100,7 +103,6 @@ describe("createTyperighterPlugin", () => {
     const decorationsSpecsToExpect = getDecorationSpecs(
       createDecorationsForMatches(matches)
     );
-
     expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
   });
   it("should add matches and their decorations on init", () => {
@@ -144,5 +146,41 @@ describe("createTyperighterPlugin", () => {
 
     const pluginMatches = getState(view.state).currentMatches;
     expect(pluginMatches).toEqual([]);
+  });
+  it("should filter matches with the supplied predicate when the plugin initialises", () => {
+    const correctMatches = [{ ...createMatch(1), markAsCorrect: true }];
+    const { view } = createPlugin<IDefaultFilterState>({
+      matches: correctMatches,
+      filterOptions: {
+        filterMatches: filterByMatchState,
+        initialFilterState: [MatchType.HAS_REPLACEMENT]
+      }
+    });
+    const decorationSpecs = getDecorationSpecsFromDoc(view);
+    const decorationsSpecsToExpect = getDecorationSpecs([]);
+    expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
+  });
+  it("should filter matches with the supplied predicate when the plugin initialises", () => {
+    const matchesWithReplacements: IMatch[] = [
+      {
+        ...createMatch(1),
+        replacement: { text: "replacement text", type: "TEXT_SUGGESTION" }
+      }
+    ];
+    const { view, commands } = createPlugin<IDefaultFilterState>({
+      matches: matchesWithReplacements,
+      filterOptions: {
+        filterMatches: filterByMatchState,
+        initialFilterState: []
+      }
+    });
+
+    commands.setFilterState([MatchType.HAS_REPLACEMENT]);
+
+    const decorationSpecs = getDecorationSpecsFromDoc(view);
+    const decorationsSpecsToExpect = getDecorationSpecs(
+      createDecorationsForMatches(matchesWithReplacements)
+    );
+    expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
   });
 });

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -21,6 +21,10 @@ import { filterByMatchState, IDefaultFilterState } from "../utils/plugin";
 const doc = createDoc(p("Example text to check"), p("More text to check"));
 const blocks = getBlocksFromDocument(doc);
 const matches = [createMatch(1)];
+const matchWithReplacement: IMatch = {
+  ...createMatch(5),
+  replacement: { text: "replacement text", type: "TEXT_SUGGESTION" }
+};
 
 const createPlugin = <TFilterState = unknown>(
   opts?: IPluginOptions<TFilterState>
@@ -147,41 +151,54 @@ describe("createTyperighterPlugin", () => {
     const pluginMatches = getState(view.state).currentMatches;
     expect(pluginMatches).toEqual([]);
   });
-  it("should filter matches with the supplied predicate when the plugin initialises", () => {
-    const correctMatches = [{ ...createMatch(1), markAsCorrect: true }];
-    const { view } = createPlugin<IDefaultFilterState>({
-      matches: correctMatches,
-      filterOptions: {
-        filterMatches: filterByMatchState,
-        initialFilterState: [MatchType.HAS_REPLACEMENT]
-      }
+  describe("filtering matchers", () => {
+    const filterOptions = {
+      filterMatches: filterByMatchState,
+      initialFilterState: [MatchType.HAS_REPLACEMENT]
+    };
+    it("should filter matches with the supplied predicate when the plugin initialises – remove matches", () => {
+      const correctMatches = [{ ...createMatch(1), markAsCorrect: true }];
+      const { view } = createPlugin<IDefaultFilterState>({
+        matches: correctMatches,
+        filterOptions
+      });
+      const decorationSpecs = getDecorationSpecsFromDoc(view);
+      const decorationsSpecsToExpect = getDecorationSpecs([]);
+      expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
     });
-    const decorationSpecs = getDecorationSpecsFromDoc(view);
-    const decorationsSpecsToExpect = getDecorationSpecs([]);
-    expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
-  });
-  it("should filter matches with the supplied predicate when the filter state changes", () => {
-    const matchesWithReplacements: IMatch[] = [
-      {
-        ...createMatch(1),
-        replacement: { text: "replacement text", type: "TEXT_SUGGESTION" }
-      }
-    ];
-    const { view, commands } = createPlugin<IDefaultFilterState>({
-      matches: matchesWithReplacements,
-      filterOptions: {
-        filterMatches: filterByMatchState,
-        initialFilterState: []
-      }
+    it("should filter matches with the supplied predicate when the plugin initialises – retain matches", () => {
+      const correctMatches = [
+        { ...createMatch(1), markAsCorrect: true },
+        matchWithReplacement
+      ];
+      const { view } = createPlugin<IDefaultFilterState>({
+        matches: correctMatches,
+        filterOptions
+      });
+      const decorationSpecs = getDecorationSpecsFromDoc(view);
+      const decorationsSpecsToExpect = getDecorationSpecs(
+        createDecorationsForMatches([matchWithReplacement])
+      );
+      expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
     });
+    it("should filter matches with the supplied predicate when the plugin initialises", () => {
+      const matchesWithReplacements: IMatch[] = [
+        matchWithReplacement,
+        createMatch(2),
+        createMatch(3)
+      ];
+      const { view, commands } = createPlugin<IDefaultFilterState>({
+        matches: matchesWithReplacements,
+        filterOptions
+      });
 
-    commands.setFilterState([MatchType.HAS_REPLACEMENT]);
+      commands.setFilterState([MatchType.HAS_REPLACEMENT]);
 
-    const decorationSpecs = getDecorationSpecsFromDoc(view);
-    const decorationsSpecsToExpect = getDecorationSpecs(
-      createDecorationsForMatches(matchesWithReplacements)
-    );
-    expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
+      const decorationSpecs = getDecorationSpecsFromDoc(view);
+      const decorationsSpecsToExpect = getDecorationSpecs(
+        createDecorationsForMatches([matchesWithReplacements[0]])
+      );
+      expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
+    });
   });
 });
-

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -154,7 +154,7 @@ describe("createTyperighterPlugin", () => {
   describe("filtering matchers", () => {
     const filterOptions = {
       filterMatches: filterByMatchState,
-      initialFilterState: [MatchType.HAS_REPLACEMENT]
+      initialFilterState: [MatchType.CORRECT]
     };
     it("should filter matches with the supplied predicate when the plugin initialises – remove matches", () => {
       const correctMatches = [{ ...createMatch(1), markAsCorrect: true }];
@@ -192,7 +192,7 @@ describe("createTyperighterPlugin", () => {
         filterOptions
       });
 
-      commands.setFilterState([MatchType.HAS_REPLACEMENT]);
+      commands.setFilterState([MatchType.DEFAULT]);
 
       const decorationSpecs = getDecorationSpecsFromDoc(view);
       const decorationsSpecsToExpect = getDecorationSpecs(

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -160,7 +160,7 @@ describe("createTyperighterPlugin", () => {
     const decorationsSpecsToExpect = getDecorationSpecs([]);
     expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
   });
-  it("should filter matches with the supplied predicate when the plugin initialises", () => {
+  it("should filter matches with the supplied predicate when the filter state changes", () => {
     const matchesWithReplacements: IMatch[] = [
       {
         ...createMatch(1),
@@ -184,3 +184,4 @@ describe("createTyperighterPlugin", () => {
     expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
   });
 });
+

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -195,7 +195,8 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       trHistory: [tr],
       requestsInFlight: {},
       requestPending: false,
-      requestErrors: []
+      requestErrors: [],
+      filterState: undefined
     } as IPluginState
   };
 };

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -125,7 +125,7 @@ export const createMatch = (
     id: "1",
     name: "Cat",
     colour: "eeeee"
-  }
+  },
 ): IMatch => ({
   matcherType: "regex",
   ruleId: "ruleId",
@@ -177,6 +177,7 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
   return {
     tr,
     state: {
+      filterState: undefined,
       config: {
         debug: false,
         requestMatchesOnDocModified: true,

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -199,8 +199,7 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       trHistory: [tr],
       requestsInFlight: {},
       requestPending: false,
-      requestErrors: [],
-      filterState: undefined
+      requestErrors: []
     } as IPluginState
   };
 };

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -189,6 +189,7 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       decorations: DecorationSet.create(tr.doc, []),
       dirtiedRanges: [],
       currentMatches: [],
+      filteredMatches: [],
       selectedMatch: undefined,
       hoverId: undefined,
       highlightId: undefined,

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -5,9 +5,8 @@ import { IRange, IMatch } from "../interfaces/IMatch";
 
 export enum MatchType {
   HAS_REPLACEMENT = "HAS_REPLACEMENT",
-  ADVISORY = "ADVISORY",
   DEFAULT = "DEFAULT",
-  CORRECT = "CORRECT",
+  CORRECT = "CORRECT"
 }
 
 export interface IMatchTypeToColourMap {
@@ -162,9 +161,16 @@ export const getColourForMatch = (
   matchColours: IMatchTypeToColourMap,
   isSelected: boolean
 ): { backgroundColour: string; borderColour: string } => {
-  const matchType = getMatchType(match);
   const backgroundOpacity = isSelected ? "50" : "07";
+  const matchType = getMatchType(match);
+  return getColourForMatchType(matchType, matchColours, backgroundOpacity);
+};
 
+export const getColourForMatchType = (
+  matchType: MatchType,
+  matchColours: IMatchTypeToColourMap,
+  backgroundOpacity: string = "99"
+): { backgroundColour: string; borderColour: string } => {
   switch (matchType) {
     case MatchType.CORRECT:
       return {

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -3,20 +3,27 @@ import { Node } from "prosemirror-model";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { IRange, IMatch } from "../interfaces/IMatch";
 
-export interface IMatchColours {
-  unambiguous: string;
-  unambiguousOpacity: string;
-  ambiguous: string;
-  ambiguousOpacity: string;
+export enum MatchType {
+  HAS_REPLACEMENT,
+  ADVISORY,
+  DEFAULT,
+  CORRECT
+}
+
+export interface IMatchTypeToColourMap {
+  hasSuggestion: string;
+  hasSuggestionOpacity: string;
+  default: string;
+  defaultOpacity: string;
   correct: string;
   correctOpacity: string;
 }
 
 export const defaultMatchColours = {
-  unambiguous: "#d90000",
-  unambiguousOpacity: "FF",
-  ambiguous: "#ffa500",
-  ambiguousOpacity: "AD",
+  hasSuggestion: "#d90000",
+  hasSuggestionOpacity: "FF",
+  default: "#ffa500",
+  defaultOpacity: "AD",
   correct: "#228816",
   correctOpacity: "FF"
 };
@@ -89,7 +96,7 @@ export const getNewDecorationsForCurrentMatches = (
   outputs: IMatch[],
   decorationSet: DecorationSet,
   doc: Node,
-  matchColours: IMatchColours = defaultMatchColours
+  matchColours: IMatchTypeToColourMap = defaultMatchColours
 ) => {
   const decorationsToAdd = createDecorationsForMatches(outputs, matchColours);
 
@@ -101,14 +108,18 @@ export const getNewDecorationsForCurrentMatches = (
  */
 export const createDecorationsForMatch = (
   match: IMatch,
-  matchColours: IMatchColours = defaultMatchColours,
+  matchColours: IMatchTypeToColourMap = defaultMatchColours,
   isSelected = false
 ) => {
   const className = isSelected
     ? `${DecorationClassMap[DECORATION_MATCH]} ${DecorationClassMap[DECORATION_MATCH_IS_SELECTED]}`
     : DecorationClassMap[DECORATION_MATCH];
 
-  const {backgroundColour, borderColour} = getColourForMatch(match, matchColours, isSelected);
+  const { backgroundColour, borderColour } = getColourForMatch(
+    match,
+    matchColours,
+    isSelected
+  );
   const style = `background-color: ${backgroundColour}; border-bottom: 2px solid ${borderColour}`;
 
   const spec = createDecorationSpecFromMatch(match);
@@ -128,44 +139,54 @@ export const createDecorationsForMatch = (
   return decorations;
 };
 
-export const createDecorationSpecFromMatch = (match: IMatch) =>
-  ({
-    type: DECORATION_MATCH,
-    id: match.matchId,
-    categoryId: match.category.id,
-    inclusiveStart: false,
-    inclusiveEnd: false
-  });
+export const createDecorationSpecFromMatch = (match: IMatch) => ({
+  type: DECORATION_MATCH,
+  id: match.matchId,
+  categoryId: match.category.id,
+  inclusiveStart: false,
+  inclusiveEnd: false
+});
+
+export const getMatchType = (match: IMatch): MatchType => {
+  if (match.markAsCorrect) {
+    return MatchType.CORRECT;
+  }
+  if (match.replacement) {
+    return MatchType.HAS_REPLACEMENT;
+  }
+  return MatchType.DEFAULT;
+};
 
 export const getColourForMatch = (
   match: IMatch,
-  matchColours: IMatchColours,
+  matchColours: IMatchTypeToColourMap,
   isSelected: boolean
-) : {backgroundColour: string, borderColour: string} => {
-
+): { backgroundColour: string; borderColour: string } => {
+  const matchType = getMatchType(match);
   const backgroundOpacity = isSelected ? "50" : "07";
 
-  if (match.markAsCorrect) {
-    return {
-      backgroundColour: `${matchColours.correct}${backgroundOpacity}`,
-      borderColour: `${matchColours.correct}${matchColours.correctOpacity}`
-    };
+  switch (matchType) {
+    case MatchType.CORRECT:
+      return {
+        backgroundColour: `${matchColours.correct}${backgroundOpacity}`,
+        borderColour: `${matchColours.correct}${matchColours.correctOpacity}`
+      };
+    case MatchType.HAS_REPLACEMENT:
+      return {
+        backgroundColour: `${matchColours.hasSuggestion}${backgroundOpacity}`,
+        borderColour: `${matchColours.hasSuggestion}${matchColours.hasSuggestionOpacity}`
+      };
+    default:
+      return {
+        backgroundColour: `${matchColours.default}${backgroundOpacity}`,
+        borderColour: `${matchColours.default}${matchColours.defaultOpacity}`
+      };
   }
-  if (match.replacement) {
-    return {
-      backgroundColour: `${matchColours.unambiguous}${backgroundOpacity}`,
-      borderColour: `${matchColours.unambiguous}${matchColours.unambiguousOpacity}`
-    };
-  }
-  return {
-    backgroundColour: `${matchColours.ambiguous}${backgroundOpacity}`,
-    borderColour: `${matchColours.ambiguous}${matchColours.ambiguousOpacity}`
-  };
 };
 
 export const createDecorationsForMatches = (
   matches: IMatch[],
-  matchColours: IMatchColours = defaultMatchColours
+  matchColours: IMatchTypeToColourMap = defaultMatchColours
 ) => flatten(matches.map(_ => createDecorationsForMatch(_, matchColours)));
 
 export const findSingleDecoration = (
@@ -179,6 +200,7 @@ export const findSingleDecoration = (
   return decorations[0];
 };
 
-export const maybeGetDecorationElement = (matchId: string): HTMLElement | null => document.querySelector(
-    `[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`
-  )
+export const maybeGetDecorationElement = (
+  matchId: string
+): HTMLElement | null =>
+  document.querySelector(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -4,10 +4,10 @@ import { Decoration, DecorationSet } from "prosemirror-view";
 import { IRange, IMatch } from "../interfaces/IMatch";
 
 export enum MatchType {
-  HAS_REPLACEMENT,
-  ADVISORY,
-  DEFAULT,
-  CORRECT
+  HAS_REPLACEMENT = "HAS_REPLACEMENT",
+  ADVISORY = "ADVISORY",
+  DEFAULT = "DEFAULT",
+  CORRECT = "CORRECT",
 }
 
 export interface IMatchTypeToColourMap {

--- a/src/ts/utils/plugin.ts
+++ b/src/ts/utils/plugin.ts
@@ -37,7 +37,7 @@ export type IDefaultFilterState = MatchType[];
  * A function that, receiving a filter state, returns a filtered list of matches.
  * Generic to allow plugin consumers to apply their own filter behaviour.
  */
-export type IFilterMatches<
+export type TFilterMatches<
   TFilterState,
   TMatch extends IMatch = IMatch
 > = (
@@ -45,7 +45,7 @@ export type IFilterMatches<
   matches: TMatch[]
 ) => TMatch[];
 
-export const filterByMatchState: IFilterMatches<IDefaultFilterState> = (
+export const filterByMatchState: TFilterMatches<IDefaultFilterState> = (
   filterState,
   matches
 ) => matches.filter(match => !filterState.includes(getMatchType(match)));

--- a/src/ts/utils/plugin.ts
+++ b/src/ts/utils/plugin.ts
@@ -48,4 +48,4 @@ export type IFilterMatches<
 export const filterByMatchState: IFilterMatches<IDefaultFilterState> = (
   filterState,
   matches
-) => matches.filter(match => filterState.includes(getMatchType(match)));
+) => matches.filter(match => !filterState.includes(getMatchType(match)));

--- a/src/ts/utils/plugin.ts
+++ b/src/ts/utils/plugin.ts
@@ -3,7 +3,6 @@ import { EditorView } from "prosemirror-view";
 import { PluginKey } from "prosemirror-state";
 import { getMatchType, MatchType } from "./decoration";
 import { IMatch } from "..";
-import { ISuggestion } from "../interfaces/IMatch";
 
 export const pluginKey = new PluginKey("prosemirror-typerighter");
 
@@ -40,11 +39,11 @@ export type IDefaultFilterState = MatchType[];
  */
 export type IFilterMatches<
   TFilterState,
-  TSuggestion extends ISuggestion = ISuggestion
+  TMatch extends IMatch = IMatch
 > = (
   filterState: TFilterState,
-  matches: Array<IMatch<TSuggestion>>
-) => Array<IMatch<TSuggestion>>;
+  matches: TMatch[]
+) => TMatch[];
 
 export const filterByMatchState: IFilterMatches<IDefaultFilterState> = (
   filterState,

--- a/src/ts/utils/plugin.ts
+++ b/src/ts/utils/plugin.ts
@@ -1,10 +1,17 @@
 import { stopHoverCommand, stopHighlightCommand } from "../commands";
 import { EditorView } from "prosemirror-view";
 import { PluginKey } from "prosemirror-state";
+import { getMatchType, MatchType } from "./decoration";
+import { IMatch } from "..";
+import { ISuggestion } from "../interfaces/IMatch";
 
 export const pluginKey = new PluginKey("prosemirror-typerighter");
 
-export const maybeResetHoverStates = (view: EditorView, ignoreElement: (e: HTMLElement) => boolean, event: Event) => {
+export const maybeResetHoverStates = (
+  view: EditorView,
+  ignoreElement: (e: HTMLElement) => boolean,
+  event: Event
+) => {
   // If we're leaving the editor node to mouse over something that we consider part of
   // the prosemirror-typerighter UI, ignore this event – we're still within relevant UI,
   // and shouldn't reset our highlight or hover states.
@@ -23,4 +30,23 @@ export const maybeResetHoverStates = (view: EditorView, ignoreElement: (e: HTMLE
   if (pluginState.highlightId) {
     return stopHighlightCommand()(view.state, view.dispatch);
   }
-}
+};
+
+export type IDefaultFilterState = MatchType[];
+
+/**
+ * A function that, receiving a filter state, returns a filtered list of matches.
+ * Generic to allow plugin consumers to apply their own filter behaviour.
+ */
+export type IFilterMatches<
+  TFilterState,
+  TSuggestion extends ISuggestion = ISuggestion
+> = (
+  filterState: TFilterState,
+  matches: Array<IMatch<TSuggestion>>
+) => Array<IMatch<TSuggestion>>;
+
+export const filterByMatchState: IFilterMatches<IDefaultFilterState> = (
+  filterState,
+  matches
+) => matches.filter(match => filterState.includes(getMatchType(match)));

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -1,4 +1,9 @@
-import { createDecorationsForMatch, defaultMatchColours } from "../decoration";
+import {
+  createDecorationsForMatch,
+  defaultMatchColours,
+  getMatchType,
+  MatchType
+} from "../decoration";
 import { createMatch } from "../../test/helpers/fixtures";
 import { IMatch } from "../../interfaces/IMatch";
 
@@ -17,8 +22,7 @@ describe("Decoration utils", () => {
             attrs: {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
-              style:
-                `background-color: ${defaultMatchColours.ambiguous}07; border-bottom: 2px solid ${defaultMatchColours.ambiguous}${defaultMatchColours.ambiguousOpacity}`
+              style: `background-color: ${defaultMatchColours.default}07; border-bottom: 2px solid ${defaultMatchColours.default}${defaultMatchColours.defaultOpacity}`
             },
             spec: {
               categoryId: "1",
@@ -41,8 +45,7 @@ describe("Decoration utils", () => {
             attrs: {
               class: "MatchDecoration",
               "data-match-id": "0-from:0-to:5--match-0",
-              style:
-                `background-color: ${defaultMatchColours.correct}07; border-bottom: 2px solid ${defaultMatchColours.correct}${defaultMatchColours.correctOpacity}`
+              style: `background-color: ${defaultMatchColours.correct}07; border-bottom: 2px solid ${defaultMatchColours.correct}${defaultMatchColours.correctOpacity}`
             },
             spec: {
               categoryId: "1",
@@ -54,6 +57,23 @@ describe("Decoration utils", () => {
           }
         }
       ]);
+    });
+  });
+  describe("getMatchType", () => {
+    const defaultMatch = createMatch(0, 5);
+    it("gives a MatchType of CORRECT when markAsCorrect is set", () => {
+      const match = { ...defaultMatch, markAsCorrect: true };
+      expect(getMatchType(match)).toBe(MatchType.CORRECT);
+    });
+    it("gives a matchType of HAS_REPLACEMENT when a replacement is available", () => {
+      const match = {
+        ...defaultMatch,
+        replacement: { text: "u r wrong", type: "TEXT_SUGGESTION" as const }
+      };
+      expect(getMatchType(match)).toBe(MatchType.HAS_REPLACEMENT);
+    });
+    it("gives a match type of DEFAULT when none of the above apply", () => {
+      expect(getMatchType(defaultMatch)).toBe(MatchType.DEFAULT);
     });
   });
 });


### PR DESCRIPTION
## What does this change?

Adds the ability to pass arbitrary filter state, and a filter predicate, to the plugin. Decorations and matches are filtered by the predicate when either the matches or the filter state changes.

This is part 1 of 2 – the next PR will add the UI changes that make altering this state possible.

## How to test

This is a no-op – the automated tests should pass.

## How can we measure success?

The API looks sane, and the automated tests cover the cases we expect.

## Dev notes

This is a large PR! But, don't be alarmed. Most of the changes are related to an interface refactor that's largely ergonomic. 

There are two reasons it's so big –

- Adding another type parameter to the `IPluginState` interface meant a refactor to avoid having to pass `TMatch` and `TFilterState` to almost everything they touched was desirable – most of the time in functions that care about plugin state, we specific a generic plugin state that inherits from `IPluginState` and pass it transparently through
- For performance reasons, we need to cache the filtered state! My initial take recomputed the decorations on every keystroke, but with 200+ decorations to filter every time, this quickly becomes sluggish. This is in part because it's not possible to filter a `DecorationSet` directly – you must extract its decorations, filter them, and construct a new `DecorationSet`, and I suspect Prosemirror does more work than necessary when this happens as it's dealing with a whole new set of object identities.

I've added an – enum  👀  – to codify the match types, which were previous encoded in property names.

The filtering logic itself is kept in `/state/helpers.ts`.
