### PR TITLE
Sort by matches

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -46,6 +46,15 @@
   justify-content: space-between;
 }
 
+.Sidebar__header-sort {
+  font-weight: normal;
+}
+
+.Sidebar__header-sort-dropdown {
+  margin-left: 5px;
+}
+
+
 .Sidebar__list {
   margin: 0;
   padding: 0;

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -95,7 +95,7 @@ interface IProps {
               Results {hasMatches && <span>({currentMatches.length}) </span>}
             </span>
             <span className="Sidebar__header-sort">
-              Summary view 
+              Sort by colour 
               <Switch
                 size="small"
                 checked={sortAndGroup}

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -97,7 +97,7 @@ interface IProps {
               Results {hasMatches && <span>({currentMatches.length}) </span>}
             </span>
             <span className="Sidebar__header-sort">
-              Sory By 
+              Sort by 
               <select className="Sidebar__header-sort-dropdown" value={matchSortBy} onChange={(event) => setMatchSortBy(event.target.value)}>
                 <option value={IMPORTANCE}>Importance</option>
                 <option value={APPEARANCE}>Appearance</option>

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -7,6 +7,9 @@ import { selectImportanceOrderedMatches, selectPercentRemaining } from "../state
 import SidebarMatch from "./SidebarMatch";
 import { IMatch } from "../interfaces/IMatch";
 
+const IMPORTANCE = "importance";
+const APPEARANCE = "appearance";
+
 interface IProps {
   store: Store<IMatch>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
@@ -33,9 +36,6 @@ interface IProps {
     editorScrollElement,
     getScrollOffset
   }: IProps) => {
-
-    const IMPORTANCE = "importance";
-    const APPEARANCE = "appearance";
 
     const [pluginState, setPluginState] = useState<IPluginState<IMatch> | undefined>(undefined);
     const [loadingBarVisible, setLoadingBarVisible] = useState<boolean>(false);

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -34,9 +34,12 @@ interface IProps {
     getScrollOffset
   }: IProps) => {
 
+    const IMPORTANCE = "importance";
+    const APPEARANCE = "appearance";
+
     const [pluginState, setPluginState] = useState<IPluginState<IMatch> | undefined>(undefined);
     const [loadingBarVisible, setLoadingBarVisible] = useState<boolean>(false);
-    const [matchSortBy, setMatchSortBy] = useState<string>("order");
+    const [matchSortBy, setMatchSortBy] = useState<string>(IMPORTANCE);
 
     const handleNewState = (pluginState: IPluginState<IMatch>) => {
       setPluginState({
@@ -70,19 +73,6 @@ interface IProps {
       return selectPercentRemaining(pluginState);
     };
 
-    const orderedMatches= () => {
-      if(!pluginState){
-        return []
-      }
-
-      switch(matchSortBy){
-        case "importance":
-          return selectImportanceOrderedMatches(pluginState);
-        default:
-          return currentMatches;
-      }
-    }
-  
     const maybeResetLoadingBar = () => {
       if (
         !pluginState ||
@@ -95,6 +85,7 @@ interface IProps {
     const { currentMatches = [], requestsInFlight, selectedMatch } = pluginState || { selectedMatch: undefined };
     const hasMatches = !!(currentMatches && currentMatches.length);
     const percentRemaining = getPercentRemaining();
+    const orderedMatches = matchSortBy === IMPORTANCE && pluginState ? selectImportanceOrderedMatches(pluginState) : currentMatches
     const isLoading =
       !!requestsInFlight && !!Object.keys(requestsInFlight).length;
 
@@ -108,8 +99,8 @@ interface IProps {
             <span className="Sidebar__header-sort">
               Sory By 
               <select className="Sidebar__header-sort-dropdown" value={matchSortBy} onChange={(event) => setMatchSortBy(event.target.value)}>
-                <option value="appearance">Appearance</option>
-                <option value="importance">Importance</option>
+                <option value={IMPORTANCE}>Importance</option>
+                <option value={APPEARANCE}>Appearance</option>
               </select>
             </span>
           </div>
@@ -134,7 +125,7 @@ interface IProps {
         <div className="Sidebar__content">
           {hasMatches && pluginState && (
             <ul className="Sidebar__list">
-              {orderedMatches().map(match => (
+              {orderedMatches.map(match => (
                 <li className="Sidebar__list-item" key={match.matchId}>
                   <SidebarMatch
                     matchColours={pluginState?.config.matchColours}

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -3,7 +3,7 @@ import sortBy from "lodash/sortBy";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { ApplySuggestionOptions } from "../commands";
 import { IPluginState } from "../state/reducer";
-import { selectPercentRemaining } from "../state/selectors";
+import { selectImportanceOrderedMatches, selectPercentRemaining } from "../state/selectors";
 import SidebarMatch from "./SidebarMatch";
 import { IMatch } from "../interfaces/IMatch";
 
@@ -36,6 +36,7 @@ interface IProps {
 
     const [pluginState, setPluginState] = useState<IPluginState<IMatch> | undefined>(undefined);
     const [loadingBarVisible, setLoadingBarVisible] = useState<boolean>(false);
+    const [matchSortBy, setMatchSortBy] = useState<string>("order");
 
     const handleNewState = (pluginState: IPluginState<IMatch>) => {
       setPluginState({
@@ -69,7 +70,18 @@ interface IProps {
       return selectPercentRemaining(pluginState);
     };
 
-    
+    const orderedMatches= () => {
+      if(!pluginState){
+        return []
+      }
+
+      switch(matchSortBy){
+        case "importance":
+          return selectImportanceOrderedMatches(pluginState);
+        default:
+          return currentMatches;
+      }
+    }
   
     const maybeResetLoadingBar = () => {
       if (
@@ -93,7 +105,13 @@ interface IProps {
             <span>
               Results {hasMatches && <span>({currentMatches.length}) </span>}
             </span>
-
+            <span className="Sidebar__header-sort">
+              Sory By 
+              <select className="Sidebar__header-sort-dropdown" value={matchSortBy} onChange={(event) => setMatchSortBy(event.target.value)}>
+                <option value="appearance">Appearance</option>
+                <option value="importance">Importance</option>
+              </select>
+            </span>
           </div>
           {contactHref && (
             <div className="Sidebar__header-contact">
@@ -116,7 +134,7 @@ interface IProps {
         <div className="Sidebar__content">
           {hasMatches && pluginState && (
             <ul className="Sidebar__list">
-              {currentMatches.map(match => (
+              {orderedMatches().map(match => (
                 <li className="Sidebar__list-item" key={match.matchId}>
                   <SidebarMatch
                     matchColours={pluginState?.config.matchColours}

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -6,9 +6,7 @@ import { IPluginState } from "../state/reducer";
 import { selectImportanceOrderedMatches, selectPercentRemaining } from "../state/selectors";
 import SidebarMatch from "./SidebarMatch";
 import { IMatch } from "../interfaces/IMatch";
-
-const IMPORTANCE = "importance";
-const APPEARANCE = "appearance";
+import { Switch } from "@material-ui/core";
 
 interface IProps {
   store: Store<IMatch>;
@@ -39,7 +37,7 @@ interface IProps {
 
     const [pluginState, setPluginState] = useState<IPluginState<IMatch> | undefined>(undefined);
     const [loadingBarVisible, setLoadingBarVisible] = useState<boolean>(false);
-    const [matchSortBy, setMatchSortBy] = useState<string>(IMPORTANCE);
+    const [sortAndGroup, setSortAndGroup] = useState<boolean>(true);
 
     const handleNewState = (pluginState: IPluginState<IMatch>) => {
       setPluginState({
@@ -85,7 +83,7 @@ interface IProps {
     const { currentMatches = [], requestsInFlight, selectedMatch } = pluginState || { selectedMatch: undefined };
     const hasMatches = !!(currentMatches && currentMatches.length);
     const percentRemaining = getPercentRemaining();
-    const orderedMatches = matchSortBy === IMPORTANCE && pluginState ? selectImportanceOrderedMatches(pluginState) : currentMatches
+    const orderedMatches = sortAndGroup && pluginState ? selectImportanceOrderedMatches(pluginState) : currentMatches
     const isLoading =
       !!requestsInFlight && !!Object.keys(requestsInFlight).length;
 
@@ -97,11 +95,14 @@ interface IProps {
               Results {hasMatches && <span>({currentMatches.length}) </span>}
             </span>
             <span className="Sidebar__header-sort">
-              Sort by 
-              <select className="Sidebar__header-sort-dropdown" value={matchSortBy} onChange={(event) => setMatchSortBy(event.target.value)}>
-                <option value={IMPORTANCE}>Importance</option>
-                <option value={APPEARANCE}>Appearance</option>
-              </select>
+              Summary view 
+              <Switch
+                size="small"
+                checked={sortAndGroup}
+                onChange={() => setSortAndGroup(!sortAndGroup)}
+                color="primary"
+                inputProps={{ 'aria-label': 'Summary view' }}
+              />
             </span>
           </div>
           {contactHref && (

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -1,4 +1,5 @@
-import { IMatch } from "../interfaces/IMatch";
+import { sortBy } from "lodash";
+import { IMatch, ISuggestion } from "../interfaces/IMatch";
 import { IPluginState, IBlockInFlight, IBlocksInFlightState } from "./reducer";
 
 export const selectMatchByMatchId = <TMatch extends IMatch>(
@@ -131,3 +132,17 @@ export const selectRequestsInProgress = <TMatch extends IMatch>(
 export const selectHasMatches = <TMatch extends IMatch>(
   state: IPluginState<TMatch>
 ): boolean => !!state.currentMatches && state.currentMatches.length > 0;
+
+export const selectImportanceOrderedMatches = <TMatch extends IMatch>(
+  state: IPluginState<TMatch>
+): IMatch<ISuggestion>[] => sortBy(state.currentMatches, match => {
+  if(match.matchedText == match.replacement?.text){
+    return 2;
+  }
+  else if(!match.replacement){
+    return 1;
+  }
+  else {
+    return 0;
+  }
+});


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the ability to sort Typerighter match results by importance (Red, ambder, green) or in order of appearance in the document. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Setup  the local Typerighter client, check the document, change the sort order of results. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users are able to see the match results in an order that is more appropriate for them.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![TRSORT](https://user-images.githubusercontent.com/4633246/94938177-633f5f80-04c8-11eb-8f03-ad41f0904462.gif)
