### PR TITLE
Group matches by rule ID

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -38,9 +38,9 @@
 }
 
 .Sidebar__header-contact {
-  margin-top: 5px;
   margin-left: auto;
   font-size: $font-size-small;
+  max-width: 130px;
 }
 
 .Sidebar__header {

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -74,10 +74,6 @@
   font-weight: normal;
 }
 
-.Sidebar__header-sort-dropdown {
-  margin-left: 5px;
-}
-
 .Sidebar__list {
   margin: 0;
   padding: 0;

--- a/src/css/SidebarMatch.scss
+++ b/src/css/SidebarMatch.scss
@@ -71,7 +71,7 @@
 }
 
 .SidebarMatch__subset-list:first-child {
-  border-top: 2px solid $sidebar-border-color;
+  border-top: 1px solid $sidebar-border-color;
 }
 
 .SidebarMatch__group-container {

--- a/src/css/SidebarMatch.scss
+++ b/src/css/SidebarMatch.scss
@@ -5,10 +5,6 @@
   }
 }
 
-.SidebarMatch__list-item:last-child {
-  border-bottom: none;
-}
-
 .SidebarMatch__header {
   display: flex;
   justify-content: space-between;
@@ -27,7 +23,7 @@
 
 .SidebarMatch__header-description {
   font-size: $font-size-small;
-  color: $text-color-secondary
+  color: $text-color-secondary;
 }
 
 .SidebarMatch__header-group {
@@ -60,20 +56,24 @@
   text-align: right;
 }
 
-.SidebarMatch__content {
-  margin-top: ($gutter-width / 2) ;
-  font-size: $font-size-small;
-}
-
 .SidebarMatch__suggestion-list {
-  margin-top: ($gutter-width / 2) ;
+  margin-top: ($gutter-width / 2);
 }
 
 .SidebarMatch__list-title {
   font-style: italic;
-  margin-bottom: ($gutter-width / 2) ;
+  margin-bottom: ($gutter-width / 2);
 }
 
 .SidebarMatch__subset-list {
-  margin-left: 10px;
+  border-left: 10px solid $sidebar-border-color;
+  margin: 0;
+}
+
+.SidebarMatch__subset-list:first-child {
+  border-top: 2px solid $sidebar-border-color;
+}
+
+.SidebarMatch__group-container {
+  margin: 0;
 }

--- a/src/css/SidebarMatch.scss
+++ b/src/css/SidebarMatch.scss
@@ -30,8 +30,9 @@
   color: $text-color-secondary
 }
 
-.SidebarMatch__header-meta {
+.SidebarMatch__header-group {
   margin-left: auto;
+  display: flex;
 }
 
 .SidebarMatch__header-range,
@@ -71,4 +72,8 @@
 .SidebarMatch__list-title {
   font-style: italic;
   margin-bottom: ($gutter-width / 2) ;
+}
+
+.SidebarMatch__subset-list {
+  margin-left: 10px;
 }

--- a/src/ts/components/MatchSnippet.tsx
+++ b/src/ts/components/MatchSnippet.tsx
@@ -1,0 +1,77 @@
+import React, { useContext } from "react";
+import { IMatch } from "..";
+import SidebarMatchContainer from "./SidebarMatchContainer";
+import { getColourForMatch, IMatchTypeToColourMap } from "../utils/decoration";
+import { createScrollToRangeHandler } from "../utils/component";
+import TelemetryContext from "../contexts/TelemetryContext";
+
+interface IProps {
+  match: IMatch;
+  matchColours?: IMatchTypeToColourMap;
+  indicateHighlight: (blockId: string, _?: any) => void;
+  stopHighlight: () => void;
+  getScrollOffset: () => number;
+  editorScrollElement: Element;
+}
+
+const emboldenMatchInMatchContext = (text: string): string => {
+  return text.replace("[[", "<strong>").replace("]]", "</strong>");
+};
+
+const MatchSnippet = ({
+  match,
+  matchColours,
+  indicateHighlight,
+  stopHighlight,
+  getScrollOffset,
+  editorScrollElement
+}: IProps) => {
+  const handleMouseEnter = () => {
+    indicateHighlight(match.matchId);
+  };
+
+  const handleMouseLeave = () => {
+    stopHighlight();
+  };
+  const { telemetryAdapter } = useContext(TelemetryContext);
+
+  const scrollToRange = createScrollToRangeHandler(
+    match,
+    getScrollOffset,
+    editorScrollElement,
+    telemetryAdapter
+  );
+
+  const color = matchColours
+    ? getColourForMatch(match, matchColours, false).borderColour
+    : undefined;
+
+  return (
+    <>
+      <li className="Sidebar__list-item SidebarMatch__subset-list">
+        <SidebarMatchContainer
+          style={{ borderLeft: `2px solid ${color}` }}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          onClick={scrollToRange}
+          title="Click to scroll to this match"
+        >
+          <div className={"SidebarMatch__header"}>
+            <div className="SidebarMatch__header-label">
+              <div>
+                <div
+                  className="SidebarMatch__header-description"
+                  dangerouslySetInnerHTML={{
+                    __html: emboldenMatchInMatchContext(match.matchContext)
+                  }}
+                ></div>
+              </div>
+            </div>
+          </div>
+        </SidebarMatchContainer>
+      </li>
+    </>
+  );
+};
+
+export default MatchSnippet;

--- a/src/ts/components/MatchSnippet.tsx
+++ b/src/ts/components/MatchSnippet.tsx
@@ -14,8 +14,18 @@ interface IProps {
   editorScrollElement: Element;
 }
 
-const emboldenMatchInMatchContext = (text: string): string => {
-  return text.replace("[[", "<strong>").replace("]]", "</strong>");
+const getMatchContext = (match: IMatch) => {
+
+    const { matchedText, subsequentText, precedingText} = match
+
+    const matchLength = matchedText.length;
+    const maxLength = 50;
+    const contextLength = (maxLength - matchLength) / 2;
+
+    const before = `${precedingText.length > contextLength ? "..." : ""}${precedingText.substr(precedingText.length - contextLength)}`;
+    const after = `${subsequentText.substr(0, contextLength)}${subsequentText.length > contextLength ? "..." : ""}`;
+
+    return `${before}<strong>${matchedText}</strong>${after}`;
 };
 
 const MatchSnippet = ({
@@ -62,7 +72,7 @@ const MatchSnippet = ({
                 <div
                   className="SidebarMatch__header-description"
                   dangerouslySetInnerHTML={{
-                    __html: emboldenMatchInMatchContext(match.matchContext)
+                    __html: getMatchContext(match)
                   }}
                 ></div>
               </div>

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -4,11 +4,13 @@ import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { ApplySuggestionOptions } from "../commands";
 import { IPluginState } from "../state/reducer";
 import { selectMatches, selectPercentRemaining } from "../state/selectors";
-import SidebarMatch from "./SidebarMatch";
 import { Switch } from "@material-ui/core";
 import FilterResults from "./FilterResults";
 import { MatchType } from "../utils/decoration";
 import TelemetryContext from "../contexts/TelemetryContext";
+import { chain } from "lodash";
+import _ from "lodash";
+import SidebarMatchGroup from "./SidebarMatchGroup";
 
 interface IProps<TPluginState extends IPluginState> {
   store: Store<TPluginState>;
@@ -94,6 +96,10 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
     : [];
   const isLoading =
     !!requestsInFlight && !!Object.keys(requestsInFlight).length;
+    const groupedCurrentMatches = chain(orderedMatches)
+    .groupBy("ruleId")
+    .map((matches, _) => matches)
+    .value();
 
 
   return (
@@ -145,20 +151,34 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
       <div className="Sidebar__content">
         {hasMatches && pluginState && (
           <ul className="Sidebar__list">
-            {orderedMatches.map(match => (
-              <li className="Sidebar__list-item" key={match.matchId}>
-                <SidebarMatch
-                  matchColours={pluginState?.config.matchColours}
-                  match={match}
-                  selectedMatch={selectedMatch}
-                  applySuggestions={applySuggestions}
-                  selectMatch={selectMatch}
-                  indicateHighlight={indicateHighlight}
-                  stopHighlight={stopHighlight}
-                  editorScrollElement={editorScrollElement}
-                  getScrollOffset={getScrollOffset}
-                />
-              </li>
+            {/* {orderedMatches.map(match => (
+                <li className="Sidebar__list-item" key={match.matchId}>
+                  <div>{match.ruleId}</div>
+                  <SidebarMatch
+                    matchColours={pluginState?.config.matchColours}
+                    match={match}
+                    selectedMatch={selectedMatch}
+                    selectMatch={selectMatch}
+                    indicateHighlight={indicateHighlight}
+                    stopHighlight={stopHighlight}
+                    editorScrollElement={editorScrollElement}
+                    getScrollOffset={getScrollOffset}
+                  />
+                </li>
+              ))} */}
+
+            {groupedCurrentMatches.map(group => (
+              <SidebarMatchGroup
+                matchColours={pluginState?.config.matchColours}
+                matchGroup={group}
+                selectedMatch={selectedMatch}
+                applySuggestions={applySuggestions}
+                selectMatch={selectMatch}
+                indicateHighlight={indicateHighlight}
+                stopHighlight={stopHighlight}
+                editorScrollElement={editorScrollElement}
+                getScrollOffset={getScrollOffset}
+              />
             ))}
           </ul>
         )}

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -97,7 +97,7 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
     : [];
   const isLoading =
     !!requestsInFlight && !!Object.keys(requestsInFlight).length;
-    const groupedCurrentMatches = chain(orderedMatches)
+  const groupedCurrentMatches = chain(orderedMatches)
     .groupBy("ruleId")
     .map((matches, _) => matches)
     .value();
@@ -152,37 +152,37 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
       <div className="Sidebar__content">
         {hasMatches && pluginState && (
           <ul className="Sidebar__list">
-            {sortAndGroup ? groupedCurrentMatches.map(group => (
-              <SidebarMatchGroup
-                matchColours={pluginState?.config.matchColours}
-                matchGroup={group}
-                selectedMatch={selectedMatch}
-                applySuggestions={applySuggestions}
-                selectMatch={selectMatch}
-                indicateHighlight={indicateHighlight}
-                stopHighlight={stopHighlight}
-                editorScrollElement={editorScrollElement}
-                getScrollOffset={getScrollOffset}
-              />
-            )) : 
-            orderedMatches.map(match => (
-              <li className="Sidebar__list-item" key={match.matchId}>
-                <SidebarMatch
-                  matchColours={pluginState?.config.matchColours}
-                  match={match}
-                  selectedMatch={selectedMatch}
-                  selectMatch={selectMatch}
-                  applySuggestions={applySuggestions}
-                  indicateHighlight={indicateHighlight}
-                  stopHighlight={stopHighlight}
-                  editorScrollElement={editorScrollElement}
-                  getScrollOffset={getScrollOffset}
-                  isGroup={false}
-                  isSubset={false}
-                />
-              </li>
-            ))}
-
+            {sortAndGroup
+              ? groupedCurrentMatches.map(group => (
+                  <SidebarMatchGroup
+                    matchColours={pluginState?.config.matchColours}
+                    matchGroup={group}
+                    selectedMatch={selectedMatch}
+                    applySuggestions={applySuggestions}
+                    selectMatch={selectMatch}
+                    indicateHighlight={indicateHighlight}
+                    stopHighlight={stopHighlight}
+                    editorScrollElement={editorScrollElement}
+                    getScrollOffset={getScrollOffset}
+                  />
+                ))
+              : orderedMatches.map(match => (
+                  <li className="Sidebar__list-item" key={match.matchId}>
+                    <SidebarMatch
+                      matchColours={pluginState?.config.matchColours}
+                      match={match}
+                      selectedMatch={selectedMatch}
+                      selectMatch={selectMatch}
+                      applySuggestions={applySuggestions}
+                      indicateHighlight={indicateHighlight}
+                      stopHighlight={stopHighlight}
+                      editorScrollElement={editorScrollElement}
+                      getScrollOffset={getScrollOffset}
+                      isGroup={false}
+                      isSubset={false}
+                    />
+                  </li>
+                ))}
           </ul>
         )}
         {!hasMatches && (

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -11,6 +11,7 @@ import TelemetryContext from "../contexts/TelemetryContext";
 import { chain } from "lodash";
 import _ from "lodash";
 import SidebarMatchGroup from "./SidebarMatchGroup";
+import SidebarMatch from "./SidebarMatch";
 
 interface IProps<TPluginState extends IPluginState> {
   store: Store<TPluginState>;
@@ -110,7 +111,7 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
             Results {hasMatches && <span>({filteredMatches.length}) </span>}
           </span>
           <span className="Sidebar__header-sort">
-            Sort by colour
+            Summary view
             <Switch
               size="small"
               checked={sortAndGroup}
@@ -151,23 +152,7 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
       <div className="Sidebar__content">
         {hasMatches && pluginState && (
           <ul className="Sidebar__list">
-            {/* {orderedMatches.map(match => (
-                <li className="Sidebar__list-item" key={match.matchId}>
-                  <div>{match.ruleId}</div>
-                  <SidebarMatch
-                    matchColours={pluginState?.config.matchColours}
-                    match={match}
-                    selectedMatch={selectedMatch}
-                    selectMatch={selectMatch}
-                    indicateHighlight={indicateHighlight}
-                    stopHighlight={stopHighlight}
-                    editorScrollElement={editorScrollElement}
-                    getScrollOffset={getScrollOffset}
-                  />
-                </li>
-              ))} */}
-
-            {groupedCurrentMatches.map(group => (
+            {sortAndGroup ? groupedCurrentMatches.map(group => (
               <SidebarMatchGroup
                 matchColours={pluginState?.config.matchColours}
                 matchGroup={group}
@@ -179,7 +164,25 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
                 editorScrollElement={editorScrollElement}
                 getScrollOffset={getScrollOffset}
               />
+            )) : 
+            orderedMatches.map(match => (
+              <li className="Sidebar__list-item" key={match.matchId}>
+                <SidebarMatch
+                  matchColours={pluginState?.config.matchColours}
+                  match={match}
+                  selectedMatch={selectedMatch}
+                  selectMatch={selectMatch}
+                  applySuggestions={applySuggestions}
+                  indicateHighlight={indicateHighlight}
+                  stopHighlight={stopHighlight}
+                  editorScrollElement={editorScrollElement}
+                  getScrollOffset={getScrollOffset}
+                  isGroup={false}
+                  isSubset={false}
+                />
+              </li>
             ))}
+
           </ul>
         )}
         {!hasMatches && (

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -1,21 +1,17 @@
 import React, { useState, useEffect, useContext } from "react";
 import sortBy from "lodash/sortBy";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
-import { ApplySuggestionOptions } from "../commands";
 import { IPluginState } from "../state/reducer";
 import { selectMatches, selectPercentRemaining } from "../state/selectors";
 import { Switch } from "@material-ui/core";
 import FilterResults from "./FilterResults";
 import { MatchType } from "../utils/decoration";
 import TelemetryContext from "../contexts/TelemetryContext";
-import { chain } from "lodash";
 import _ from "lodash";
-import SidebarMatchGroup from "./SidebarMatchGroup";
-import SidebarMatch from "./SidebarMatch";
+import SidebarMatches from "./SidebarMatches";
 
 interface IProps<TPluginState extends IPluginState> {
   store: Store<TPluginState>;
-  applySuggestions: (opts: ApplySuggestionOptions) => void;
   applyAutoFixableSuggestions: () => void;
   applyFilterState: (filterState: MatchType[]) => void;
   selectMatch: (matchId: string) => void;
@@ -32,7 +28,6 @@ interface IProps<TPluginState extends IPluginState> {
 
 const Results = <TPluginState extends IPluginState<MatchType[]>>({
   store,
-  applySuggestions,
   selectMatch,
   indicateHighlight,
   stopHighlight,
@@ -97,10 +92,6 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
     : [];
   const isLoading =
     !!requestsInFlight && !!Object.keys(requestsInFlight).length;
-  const groupedCurrentMatches = chain(orderedMatches)
-    .groupBy("ruleId")
-    .map((matches, _) => matches)
-    .value();
 
 
   return (
@@ -150,42 +141,18 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
       </div>
 
       <div className="Sidebar__content">
-        {hasMatches && pluginState && (
-          <ul className="Sidebar__list">
-            {sortAndGroup
-              ? groupedCurrentMatches.map((group, index) => (
-                  <SidebarMatchGroup
-                    matchColours={pluginState?.config.matchColours}
-                    matchGroup={group}
-                    selectedMatch={selectedMatch}
-                    applySuggestions={applySuggestions}
-                    selectMatch={selectMatch}
-                    indicateHighlight={indicateHighlight}
-                    stopHighlight={stopHighlight}
-                    editorScrollElement={editorScrollElement}
-                    getScrollOffset={getScrollOffset}
-                    key={index}
-                  />
-                ))
-              : orderedMatches.map(match => (
-                  <li className="Sidebar__list-item" key={match.matchId}>
-                    <SidebarMatch
-                      matchColours={pluginState?.config.matchColours}
-                      match={match}
-                      selectedMatch={selectedMatch}
-                      selectMatch={selectMatch}
-                      applySuggestions={applySuggestions}
-                      indicateHighlight={indicateHighlight}
-                      stopHighlight={stopHighlight}
-                      editorScrollElement={editorScrollElement}
-                      getScrollOffset={getScrollOffset}
-                      isGroup={false}
-                      isSubset={false}
-                    />
-                  </li>
-                ))}
-          </ul>
-        )}
+          <SidebarMatches
+            matches={orderedMatches}
+            matchColours={pluginState?.config.matchColours}
+            selectedMatch={selectedMatch}
+            selectMatch={selectMatch}
+            indicateHighlight={indicateHighlight}
+            stopHighlight={stopHighlight}
+            editorScrollElement={editorScrollElement}
+            getScrollOffset={getScrollOffset}
+            isSummaryView={sortAndGroup}
+          />
+
         {!hasMatches && (
           <div className="Sidebar__awaiting-match">No matches to report.</div>
         )}

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -153,7 +153,7 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
         {hasMatches && pluginState && (
           <ul className="Sidebar__list">
             {sortAndGroup
-              ? groupedCurrentMatches.map(group => (
+              ? groupedCurrentMatches.map((group, index) => (
                   <SidebarMatchGroup
                     matchColours={pluginState?.config.matchColours}
                     matchGroup={group}
@@ -164,6 +164,7 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
                     stopHighlight={stopHighlight}
                     editorScrollElement={editorScrollElement}
                     getScrollOffset={getScrollOffset}
+                    key={index}
                   />
                 ))
               : orderedMatches.map(match => (

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -58,7 +58,6 @@ const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
           />
           <Results
             store={store}
-            applySuggestions={commands.applySuggestions}
             applyAutoFixableSuggestions={commands.applyAutoFixableSuggestions}
             applyFilterState={commands.setFilterState}
             selectMatch={commands.selectMatch}

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -30,7 +30,7 @@ interface IProps {
  * Display information for a single match
  */
 
-const SidebarMatch : React.StatelessComponent<IProps> = ({
+const SidebarMatch = ({
   match,
   matchColours,
   indicateHighlight,
@@ -124,6 +124,8 @@ const SidebarMatch : React.StatelessComponent<IProps> = ({
           selectedMatch === match.matchId
             ? "SidebarMatch__container--is-selected"
             : ""
+        } ${
+          isGroup && !isSubset && "SidebarMatch__group-container"
         }`}
         style={{ borderLeft: `2px solid ${color}` }}
         onMouseEnter={handleMouseEnter}
@@ -149,9 +151,9 @@ const SidebarMatch : React.StatelessComponent<IProps> = ({
           </div>
         </div>
       </div>
-      {isOpen && (
+      {isOpen && isGroup && (
         <div className="SidebarMatch__content">
-          {isGroup && children}
+          {children}
         </div>
       )}
     </>

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -95,6 +95,27 @@ const SidebarMatch = ({
     }
   };
 
+  const emboldenMatchInMatchContext = (text: string): string => {
+    return text.replace("[", "<strong>").replace("]", "</strong>");
+  };
+
+  const getDescription = () => {
+    return isSubset ? (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: emboldenMatchInMatchContext(match.matchContext)
+        }}
+      ></div>
+    ) : (
+      <div
+        className="SidebarMatch__header-description"
+        dangerouslySetInnerHTML={{
+          __html: getHtmlFromMarkdown(match.message)
+        }}
+      ></div>
+    );
+  };
+
   return (
     <>
       <div
@@ -115,21 +136,13 @@ const SidebarMatch = ({
               <div className="SidebarMatch__header-match-text">
                 {isSubset ? "" : match.matchedText}
               </div>
-              <div
-                className="SidebarMatch__header-description"
-                dangerouslySetInnerHTML={{
-                  // __html: getHtmlFromMarkdown(match.message)
-                  __html: isSubset
-                    ? getHtmlFromMarkdown(match.matchContext)
-                    : getHtmlFromMarkdown(match.message)
-                }}
-              ></div>
+              {getDescription()}
             </div>
 
             {isGroup && (
               <div className="SidebarMatch__header-group">
-                ({numberOfGroupedMatches && <div>{numberOfGroupedMatches}</div>}) 
-                <div>{isOpen ? <ArrowDropUp /> : <ArrowDropDown />}</div>
+                ({numberOfGroupedMatches && <div>{numberOfGroupedMatches}</div>}
+                )<div>{isOpen ? <ArrowDropUp /> : <ArrowDropDown />}</div>
               </div>
             )}
           </div>

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -97,12 +97,13 @@ const SidebarMatch = ({
   };
 
   const emboldenMatchInMatchContext = (text: string): string => {
-    return text.replace("[", "<strong>").replace("]", "</strong>");
+    return text.replace("[[", "<strong>").replace("]]", "</strong>");
   };
 
   const getDescription = () => {
     return isSubset ? (
       <div
+        className="SidebarMatch__header-description"
         dangerouslySetInnerHTML={{
           __html: emboldenMatchInMatchContext(match.matchContext)
         }}

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -30,7 +30,7 @@ interface IProps {
  * Display information for a single match
  */
 
-const SidebarMatch = ({
+const SidebarMatch : React.StatelessComponent<IProps> = ({
   match,
   matchColours,
   indicateHighlight,
@@ -40,9 +40,10 @@ const SidebarMatch = ({
   getScrollOffset,
   isGroup,
   isSubset,
-  showAllMatches,
+  children,
   numberOfGroupedMatches
-}: IProps) => {
+}: React.PropsWithChildren<IProps>) => {
+
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const { telemetryAdapter } = useContext(TelemetryContext);
@@ -150,7 +151,7 @@ const SidebarMatch = ({
       </div>
       {isOpen && (
         <div className="SidebarMatch__content">
-          {isGroup && showAllMatches && showAllMatches()}
+          {isGroup && children}
         </div>
       )}
     </>

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -8,8 +8,7 @@ import {
 import { ApplySuggestionOptions } from "../commands";
 import { getHtmlFromMarkdown } from "../utils/dom";
 import TelemetryContext from "../contexts/TelemetryContext";
-// import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
-// import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUp';
+import { ArrowDropDown, ArrowDropUp } from "@material-ui/icons";
 
 interface IProps {
   match: IMatch;
@@ -24,6 +23,7 @@ interface IProps {
   isGroup: boolean;
   isSubset: boolean;
   showAllMatches?: () => JSX.Element;
+  numberOfGroupedMatches?: number;
 }
 
 /**
@@ -40,10 +40,10 @@ const SidebarMatch = ({
   getScrollOffset,
   isGroup,
   isSubset,
-  showAllMatches
-}: IProps) => {  
+  showAllMatches,
+  numberOfGroupedMatches
+}: IProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-
 
   const { telemetryAdapter } = useContext(TelemetryContext);
 
@@ -83,53 +83,63 @@ const SidebarMatch = ({
     stopHighlight();
   };
 
+  const getTitleText = (): string => {
+    if (isGroup) {
+      if (isOpen) {
+        return "Click to hide all matches for this rule";
+      } else {
+        return "Click to show all matches for this rule";
+      }
+    } else {
+      return "Click to scroll to this match";
+    }
+  };
+
   return (
     <>
-    <div
-      className={`SidebarMatch__container ${
-        selectedMatch === match.matchId
-          ? "SidebarMatch__container--is-selected"
-          : ""
-      }`}
-      style={{ borderLeft: `2px solid ${color}` }}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onClick={isGroup ? toggleOpen : scrollToRange}
-      title={isGroup ? "Click to see all matches" : "Click to scroll to this match"}
-    >
       <div
-        className={"SidebarMatch__header"}
+        className={`SidebarMatch__container ${
+          selectedMatch === match.matchId
+            ? "SidebarMatch__container--is-selected"
+            : ""
+        }`}
+        style={{ borderLeft: `2px solid ${color}` }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onClick={isGroup ? toggleOpen : scrollToRange}
+        title={getTitleText()}
       >
-        <div className="SidebarMatch__header-label">
-          <div>
-            <div className="SidebarMatch__header-match-text">
-              {isSubset ? "" : match.matchedText}
+        <div className={"SidebarMatch__header"}>
+          <div className="SidebarMatch__header-label">
+            <div>
+              <div className="SidebarMatch__header-match-text">
+                {isSubset ? "" : match.matchedText}
+              </div>
+              <div
+                className="SidebarMatch__header-description"
+                dangerouslySetInnerHTML={{
+                  // __html: getHtmlFromMarkdown(match.message)
+                  __html: isSubset
+                    ? getHtmlFromMarkdown(match.matchContext)
+                    : getHtmlFromMarkdown(match.message)
+                }}
+              ></div>
             </div>
-            <div
-              className="SidebarMatch__header-description"
-              dangerouslySetInnerHTML={{
-                // __html: getHtmlFromMarkdown(match.message)
-                __html: isSubset ? getHtmlFromMarkdown(match.matchContext) : getHtmlFromMarkdown(match.message)
-              }}
-            ></div>
-          </div>
-          <div className="SidebarMatch__header-meta">
+
             {isGroup && (
-              <div className="SidebarMatch__header-toggle-status">
-                {isOpen ? "-" : "+"}
-                {/* {isOpen ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />} */}
+              <div className="SidebarMatch__header-group">
+                ({numberOfGroupedMatches && <div>{numberOfGroupedMatches}</div>}) 
+                <div>{isOpen ? <ArrowDropUp /> : <ArrowDropDown />}</div>
               </div>
             )}
           </div>
         </div>
       </div>
-      
-    </div>
-    {isOpen && (
-      <div className="SidebarMatch__content">
-        {(isGroup && showAllMatches) && showAllMatches()}
-      </div>
-    )}
+      {isOpen && (
+        <div className="SidebarMatch__content">
+          {isGroup && showAllMatches && showAllMatches()}
+        </div>
+      )}
     </>
   );
 };

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -1,29 +1,21 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
+
 import { IMatch } from "../interfaces/IMatch";
-import {
-  IMatchTypeToColourMap,
-  getColourForMatch,
-  maybeGetDecorationElement
-} from "../utils/decoration";
-import { ApplySuggestionOptions } from "../commands";
+import { IMatchTypeToColourMap, getColourForMatch } from "../utils/decoration";
 import { getHtmlFromMarkdown } from "../utils/dom";
 import TelemetryContext from "../contexts/TelemetryContext";
-import { ArrowDropDown, ArrowDropUp } from "@material-ui/icons";
+import SidebarMatchContainer from "./SidebarMatchContainer";
+import { createScrollToRangeHandler } from "../utils/component";
 
 interface IProps {
   match: IMatch;
   matchColours?: IMatchTypeToColourMap;
-  applySuggestions: (suggestions: ApplySuggestionOptions) => void;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;
   stopHighlight: () => void;
   selectedMatch: string | undefined;
   editorScrollElement: Element;
   getScrollOffset: () => number;
-  isGroup: boolean;
-  isSubset: boolean;
-  showAllMatches?: () => JSX.Element;
-  numberOfGroupedMatches?: number;
 }
 
 /**
@@ -37,14 +29,8 @@ const SidebarMatch = ({
   stopHighlight,
   selectedMatch,
   editorScrollElement,
-  getScrollOffset,
-  isGroup,
-  isSubset,
-  children,
-  numberOfGroupedMatches
+  getScrollOffset
 }: React.PropsWithChildren<IProps>) => {
-
-  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const { telemetryAdapter } = useContext(TelemetryContext);
 
@@ -52,29 +38,12 @@ const SidebarMatch = ({
     ? getColourForMatch(match, matchColours, false).borderColour
     : undefined;
 
-  const toggleOpen = () => {
-    setIsOpen(!isOpen);
-  };
-  const scrollToRange = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    telemetryAdapter?.sidebarMatchClicked(match, document.URL);
-
-    if (!editorScrollElement) {
-      return;
-    }
-
-    const decorationElement = maybeGetDecorationElement(match.matchId);
-
-    if (decorationElement) {
-      const scrollToYCoord = decorationElement.offsetTop - getScrollOffset();
-      editorScrollElement.scrollTo({
-        top: scrollToYCoord,
-        behavior: "smooth"
-      });
-    }
-  };
+  const scrollToRange = createScrollToRangeHandler(
+    match,
+    getScrollOffset,
+    editorScrollElement,
+    telemetryAdapter
+  );
 
   const handleMouseEnter = () => {
     indicateHighlight(match.matchId);
@@ -84,80 +53,33 @@ const SidebarMatch = ({
     stopHighlight();
   };
 
-  const getTitleText = (): string => {
-    if (isGroup) {
-      if (isOpen) {
-        return "Click to hide all matches for this rule";
-      } else {
-        return "Click to show all matches for this rule";
-      }
-    } else {
-      return "Click to scroll to this match";
-    }
-  };
-
-  const emboldenMatchInMatchContext = (text: string): string => {
-    return text.replace("[[", "<strong>").replace("]]", "</strong>");
-  };
-
-  const getDescription = () => {
-    return isSubset ? (
-      <div
-        className="SidebarMatch__header-description"
-        dangerouslySetInnerHTML={{
-          __html: emboldenMatchInMatchContext(match.matchContext)
-        }}
-      ></div>
-    ) : (
-      <div
-        className="SidebarMatch__header-description"
-        dangerouslySetInnerHTML={{
-          __html: getHtmlFromMarkdown(match.message)
-        }}
-      ></div>
-    );
-  };
-
   return (
-    <>
-      <div
-        className={`SidebarMatch__container ${
-          selectedMatch === match.matchId
-            ? "SidebarMatch__container--is-selected"
-            : ""
-        } ${
-          isGroup && !isSubset && "SidebarMatch__group-container"
-        }`}
+    <li className="Sidebar__list-item">
+      <SidebarMatchContainer
         style={{ borderLeft: `2px solid ${color}` }}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={isGroup ? toggleOpen : scrollToRange}
-        title={getTitleText()}
+        onClick={scrollToRange}
+        title="Click to scroll to this match"
+        isSelected={selectedMatch === match.matchId}
       >
         <div className={"SidebarMatch__header"}>
           <div className="SidebarMatch__header-label">
             <div>
               <div className="SidebarMatch__header-match-text">
-                {isSubset ? "" : match.matchedText}
+                {match.matchedText}
               </div>
-              {getDescription()}
+              <div
+                className="SidebarMatch__header-description"
+                dangerouslySetInnerHTML={{
+                  __html: getHtmlFromMarkdown(match.message)
+                }}
+              ></div>
             </div>
-
-            {isGroup && (
-              <div className="SidebarMatch__header-group">
-                ({numberOfGroupedMatches && <div>{numberOfGroupedMatches}</div>}
-                )<div>{isOpen ? <ArrowDropUp /> : <ArrowDropDown />}</div>
-              </div>
-            )}
           </div>
         </div>
-      </div>
-      {isOpen && isGroup && (
-        <div className="SidebarMatch__content">
-          {children}
-        </div>
-      )}
-    </>
+      </SidebarMatchContainer>
+    </li>
   );
 };
 

--- a/src/ts/components/SidebarMatchContainer.tsx
+++ b/src/ts/components/SidebarMatchContainer.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface IProps {
+  isSelected?: boolean;
+  className?: string;
+}
+
+const SidebarMatchContainer = ({
+  isSelected,
+  className,
+  children,
+  ...rest
+}: IProps & React.HTMLProps<HTMLDivElement>) => (
+  <div
+    className={`SidebarMatch__container ${className || ""} ${
+      isSelected ? "SidebarMatch__container--is-selected" : ""
+    }`}
+    {...rest}
+  >
+    {children}
+  </div>
+);
+
+export default SidebarMatchContainer;

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -33,9 +33,9 @@ const SidebarMatchGroup = ({
 }: IProps) => {
   
   const showGroupMatchSubset = () => (
-    <ul>
+    <ul className="Sidebar__list">
       {matchGroup.map(match => (
-        <li className="Sidebar__list-item" key={match.matchId}>
+        <li className="SidebarMatch__subset-list" key={`${match.ruleId}_${match.matchId}`}>
           <SidebarMatch
             matchColours={matchColours}
             match={match}
@@ -90,7 +90,7 @@ const SidebarMatchGroup = ({
               isGroup
               isSubset={false}
               showAllMatches={showGroupMatchSubset}
-              // numberOfGroupedMatches={matchGroup.length}
+              numberOfGroupedMatches={matchGroup.length}
             />
           </li>
         

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -99,6 +99,7 @@ const SidebarMatchGroup = ({
               stopHighlight={stopHighlight}
               getScrollOffset={getScrollOffset}
               editorScrollElement={editorScrollElement}
+              key={match.matchId}
             />
           ))}
         </ul>

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -59,53 +59,51 @@ const SidebarMatchGroup = ({
   };
 
   return (
-    <>
-      <li className="Sidebar__list-item">
-        <SidebarMatchContainer
-          className="SidebarMatch__group-container"
-          style={{ borderLeft: `2px solid ${color}` }}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          onClick={toggleOpen}
-          title={getTitleText()}
-          isSelected={selectedMatch === firstMatch.matchId}
-        >
-          <div className={"SidebarMatch__header"}>
-            <div className="SidebarMatch__header-label">
-              <div>
-                <div className="SidebarMatch__header-match-text">
-                  {firstMatch.matchedText}
-                </div>
-                <div
-                  className="SidebarMatch__header-description"
-                  dangerouslySetInnerHTML={{
-                    __html: getHtmlFromMarkdown(firstMatch.message)
-                  }}
-                ></div>
+    <li className="Sidebar__list-item">
+      <SidebarMatchContainer
+        className="SidebarMatch__group-container"
+        style={{ borderLeft: `2px solid ${color}` }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onClick={toggleOpen}
+        title={getTitleText()}
+        isSelected={selectedMatch === firstMatch.matchId}
+      >
+        <div className={"SidebarMatch__header"}>
+          <div className="SidebarMatch__header-label">
+            <div>
+              <div className="SidebarMatch__header-match-text">
+                {firstMatch.matchedText}
               </div>
-              <div className="SidebarMatch__header-group">
-                <div>({matchGroup.length})</div>
-                <div>{isOpen ? <ArrowDropUp /> : <ArrowDropDown />}</div>
-              </div>
+              <div
+                className="SidebarMatch__header-description"
+                dangerouslySetInnerHTML={{
+                  __html: getHtmlFromMarkdown(firstMatch.message)
+                }}
+              ></div>
+            </div>
+            <div className="SidebarMatch__header-group">
+              <div>({matchGroup.length})</div>
+              <div>{isOpen ? <ArrowDropUp /> : <ArrowDropDown />}</div>
             </div>
           </div>
-        </SidebarMatchContainer>
-        {isOpen && (
-          <ul className="Sidebar__list">
-            {matchGroup.map(match => (
-              <MatchSnippet
-                match={match}
-                matchColours={matchColours}
-                indicateHighlight={indicateHighlight}
-                stopHighlight={stopHighlight}
-                getScrollOffset={getScrollOffset}
-                editorScrollElement={editorScrollElement}
-              />
-            ))}
-          </ul>
-        )}
-      </li>
-    </>
+        </div>
+      </SidebarMatchContainer>
+      {isOpen && (
+        <ul className="Sidebar__list">
+          {matchGroup.map(match => (
+            <MatchSnippet
+              match={match}
+              matchColours={matchColours}
+              indicateHighlight={indicateHighlight}
+              stopHighlight={stopHighlight}
+              getScrollOffset={getScrollOffset}
+              editorScrollElement={editorScrollElement}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
   );
 };
 

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -31,29 +31,6 @@ const SidebarMatchGroup = ({
   getScrollOffset,
   selectMatch
 }: IProps) => {
-  
-  const showGroupMatchSubset = () => (
-    <ul className="Sidebar__list">
-      {matchGroup.map(match => (
-        <li className="SidebarMatch__subset-list Sidebar__list-item" key={`${match.ruleId}_${match.matchId}`}>
-          <SidebarMatch
-            matchColours={matchColours}
-            match={match}
-            selectedMatch={selectedMatch}
-            applySuggestions={applySuggestions}
-            selectMatch={selectMatch}
-            indicateHighlight={indicateHighlight}
-            stopHighlight={stopHighlight}
-            editorScrollElement={editorScrollElement}
-            getScrollOffset={getScrollOffset}
-            isGroup={false}
-            isSubset
-          />
-        </li>
-      ))}
-    </ul>
-  );
-
   return (
     <>
       {matchGroup.length === 1 ? (
@@ -89,11 +66,32 @@ const SidebarMatchGroup = ({
               getScrollOffset={getScrollOffset}
               isGroup
               isSubset={false}
-              showAllMatches={showGroupMatchSubset}
               numberOfGroupedMatches={matchGroup.length}
-            />
+            >
+              <ul className="Sidebar__list">
+                {matchGroup.map(match => (
+                  <li
+                    className="SidebarMatch__subset-list Sidebar__list-item"
+                    key={`${match.ruleId}_${match.matchId}`}
+                  >
+                    <SidebarMatch
+                      matchColours={matchColours}
+                      match={match}
+                      selectedMatch={selectedMatch}
+                      applySuggestions={applySuggestions}
+                      selectMatch={selectMatch}
+                      indicateHighlight={indicateHighlight}
+                      stopHighlight={stopHighlight}
+                      editorScrollElement={editorScrollElement}
+                      getScrollOffset={getScrollOffset}
+                      isGroup={false}
+                      isSubset
+                    />
+                  </li>
+                ))}
+              </ul>
+            </SidebarMatch>
           </li>
-        
         </>
       )}
     </>

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -35,7 +35,7 @@ const SidebarMatchGroup = ({
     <>
       {matchGroup.length === 1 ? (
         <>
-          <li className="Sidebar__list-item" key={matchGroup[0].matchId}>
+          <li className="Sidebar__list-item">
             <SidebarMatch
               matchColours={matchColours}
               match={matchGroup[0]}
@@ -53,7 +53,7 @@ const SidebarMatchGroup = ({
         </>
       ) : (
         <>
-          <li className="Sidebar__list-item" key={matchGroup[0].ruleId}>
+          <li className="Sidebar__list-item">
             <SidebarMatch
               matchColours={matchColours}
               match={matchGroup[0]}

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -35,7 +35,7 @@ const SidebarMatchGroup = ({
   const showGroupMatchSubset = () => (
     <ul className="Sidebar__list">
       {matchGroup.map(match => (
-        <li className="SidebarMatch__subset-list" key={`${match.ruleId}_${match.matchId}`}>
+        <li className="SidebarMatch__subset-list Sidebar__list-item" key={`${match.ruleId}_${match.matchId}`}>
           <SidebarMatch
             matchColours={matchColours}
             match={match}

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -1,12 +1,12 @@
 import { IMatch, ISuggestion } from "../interfaces/IMatch";
-import { IMatchColours } from "../utils/decoration";
+import { IMatchTypeToColourMap } from "../utils/decoration";
 import { ApplySuggestionOptions } from "../commands";
 import SidebarMatch from "./SidebarMatch";
 import React from "react";
 
 interface IProps {
   matchGroup: Array<IMatch<ISuggestion>>;
-  matchColours: IMatchColours;
+  matchColours?: IMatchTypeToColourMap;
   applySuggestions: (suggestions: ApplySuggestionOptions) => void;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -1,0 +1,103 @@
+import { IMatch, ISuggestion } from "../interfaces/IMatch";
+import { IMatchColours } from "../utils/decoration";
+import { ApplySuggestionOptions } from "../commands";
+import SidebarMatch from "./SidebarMatch";
+import React from "react";
+
+interface IProps {
+  matchGroup: Array<IMatch<ISuggestion>>;
+  matchColours: IMatchColours;
+  applySuggestions: (suggestions: ApplySuggestionOptions) => void;
+  selectMatch: (matchId: string) => void;
+  indicateHighlight: (blockId: string, _?: any) => void;
+  stopHighlight: () => void;
+  selectedMatch: string | undefined;
+  editorScrollElement: Element;
+  getScrollOffset: () => number;
+}
+
+/**
+ * Display information for a single match and a group of matches with same ruleId
+ */
+
+const SidebarMatchGroup = ({
+  matchGroup,
+  matchColours,
+  applySuggestions,
+  indicateHighlight,
+  stopHighlight,
+  selectedMatch,
+  editorScrollElement,
+  getScrollOffset,
+  selectMatch
+}: IProps) => {
+  
+  const showGroupMatchSubset = () => (
+    <ul>
+      {matchGroup.map(match => (
+        <li className="Sidebar__list-item" key={match.matchId}>
+          <SidebarMatch
+            matchColours={matchColours}
+            match={match}
+            selectedMatch={selectedMatch}
+            applySuggestions={applySuggestions}
+            selectMatch={selectMatch}
+            indicateHighlight={indicateHighlight}
+            stopHighlight={stopHighlight}
+            editorScrollElement={editorScrollElement}
+            getScrollOffset={getScrollOffset}
+            isGroup={false}
+            isSubset
+          />
+        </li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <>
+      {matchGroup.length === 1 ? (
+        <>
+          <li className="Sidebar__list-item" key={matchGroup[0].matchId}>
+            <SidebarMatch
+              matchColours={matchColours}
+              match={matchGroup[0]}
+              selectedMatch={selectedMatch}
+              applySuggestions={applySuggestions}
+              selectMatch={selectMatch}
+              indicateHighlight={indicateHighlight}
+              stopHighlight={stopHighlight}
+              editorScrollElement={editorScrollElement}
+              getScrollOffset={getScrollOffset}
+              isGroup={false}
+              isSubset={false}
+            />
+          </li>
+        </>
+      ) : (
+        <>
+          <li className="Sidebar__list-item" key={matchGroup[0].ruleId}>
+            <SidebarMatch
+              matchColours={matchColours}
+              match={matchGroup[0]}
+              selectedMatch={selectedMatch}
+              applySuggestions={applySuggestions}
+              selectMatch={selectMatch}
+              indicateHighlight={indicateHighlight}
+              stopHighlight={stopHighlight}
+              editorScrollElement={editorScrollElement}
+              getScrollOffset={getScrollOffset}
+              isGroup
+              isSubset={false}
+              showAllMatches={showGroupMatchSubset}
+              // numberOfGroupedMatches={matchGroup.length}
+            />
+          </li>
+        
+        </>
+      )}
+    </>
+  );
+};
+
+export default SidebarMatchGroup;

--- a/src/ts/components/SidebarMatches.tsx
+++ b/src/ts/components/SidebarMatches.tsx
@@ -1,0 +1,85 @@
+import { chain } from "lodash";
+import React from "react";
+import { IMatch } from "..";
+import { IMatchTypeToColourMap } from "../utils/decoration";
+import SidebarMatch from "./SidebarMatch";
+import SidebarMatchGroup from "./SidebarMatchGroup";
+
+interface IProps {
+  matches: IMatch[];
+  matchColours?: IMatchTypeToColourMap;
+  selectMatch: (matchId: string) => void;
+  indicateHighlight: (blockId: string, _?: any) => void;
+  stopHighlight: () => void;
+  selectedMatch: string | undefined;
+  editorScrollElement: Element;
+  getScrollOffset: () => number;
+  isSummaryView: boolean;
+}
+
+const SidebarMatches = ({
+  matches,
+  matchColours,
+  selectMatch,
+  indicateHighlight,
+  stopHighlight,
+  selectedMatch,
+  editorScrollElement,
+  getScrollOffset,
+  isSummaryView
+}: IProps) => {
+  const groupedCurrentMatches = chain(matches)
+    .groupBy("ruleId")
+    .map((groupedMatches, _) => groupedMatches)
+    .value();
+
+  return (
+    <ul className="Sidebar__list">
+      {isSummaryView
+        ? groupedCurrentMatches.map(group =>
+            group.length > 1 ? (
+              <SidebarMatchGroup
+                matchColours={matchColours}
+                matchGroup={group}
+                selectedMatch={selectedMatch}
+                selectMatch={selectMatch}
+                indicateHighlight={indicateHighlight}
+                stopHighlight={stopHighlight}
+                editorScrollElement={editorScrollElement}
+                getScrollOffset={getScrollOffset}
+                key={group[0].matchId}
+              />
+            ) : (
+              group[0] && (
+                <SidebarMatch
+                  matchColours={matchColours}
+                  match={group[0]}
+                  selectedMatch={selectedMatch}
+                  selectMatch={selectMatch}
+                  indicateHighlight={indicateHighlight}
+                  stopHighlight={stopHighlight}
+                  editorScrollElement={editorScrollElement}
+                  getScrollOffset={getScrollOffset}
+                  key={group[0].matchId}
+                />
+              )
+            )
+          )
+        : matches.map(match => (
+            <SidebarMatch
+              matchColours={matchColours}
+              match={match}
+              selectedMatch={selectedMatch}
+              selectMatch={selectMatch}
+              indicateHighlight={indicateHighlight}
+              stopHighlight={stopHighlight}
+              editorScrollElement={editorScrollElement}
+              getScrollOffset={getScrollOffset}
+              key={match.matchId}
+            />
+          ))}
+    </ul>
+  );
+};
+
+export default SidebarMatches;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -7,6 +7,7 @@ import TyperighterTelemetryAdapter from "./services/TyperighterTelemetryAdapter"
 import TyperighterAdapter, { convertTyperighterResponse } from "./services/adapters/TyperighterAdapter";
 import { createBoundCommands } from "./commands";
 import { getBlocksFromDocument } from './utils/prosemirror';
+import { filterByMatchState } from './utils/plugin';
 import createView from "./createView";
 import '../css/index.scss';
 
@@ -20,6 +21,7 @@ export {
   createBoundCommands,
   createView,
   createTyperighterPlugin,
+  filterByMatchState,
   IMatch,
   IBlock,
   Store

--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -62,6 +62,8 @@ export interface IMatch<TSuggestion = ISuggestion> {
   replacement?: TSuggestion;
   markAsCorrect?: boolean;
   matchContext: string;
+  precedingText: string;
+  subsequentText: string;
 }
 
 export interface IBlockResult {

--- a/src/ts/services/adapters/interfaces/ITyperighter.ts
+++ b/src/ts/services/adapters/interfaces/ITyperighter.ts
@@ -25,6 +25,8 @@ export interface ITypeRighterMatch {
   suggestions: ISuggestion[];
   markAsCorrect: boolean;
   matchContext: string;
+  precedingText: string;
+  subsequentText: string;
 }
 
 export interface ITypeRighterReplacement {

--- a/src/ts/services/test/MatcherService.spec.ts
+++ b/src/ts/services/test/MatcherService.spec.ts
@@ -40,7 +40,9 @@ const createResponse = (strs: string[]): ITypeRighterResponse => ({
     },
     suggestions: [],
     markAsCorrect: false,
-    matchContext: "whatever"
+    matchContext: "whatever",
+    precedingText: "whatever",
+    subsequentText: ""
   }))
 });
 

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -495,7 +495,9 @@ describe("Action handlers", () => {
           name: "cat",
           colour: "eeeeee"
         },
-        matchContext: "some more text"
+        matchContext: "some more text",
+        precedingText: "some more text",
+        subsequentText: ""        
       };
       const localState = {
         ...state,
@@ -530,7 +532,9 @@ describe("Action handlers", () => {
           name: "cat",
           colour: "eeeeee"
         },
-        matchContext: "bigger block of text"
+        matchContext: "bigger block of text",
+        precedingText: "bigger block of text",
+        subsequentText: ""        
       };
       const localState = {
         ...state,
@@ -571,7 +575,9 @@ describe("Action handlers", () => {
             colour: "eeeeee"
           },
           markAsCorrect: true,
-          matchContext: "bigger block of text"
+          matchContext: "bigger block of text",
+          precedingText: "bigger block of text",
+          subsequentText: ""        
         }
       ];
       const stateWithCurrentMatchesAndDecorations = {
@@ -619,7 +625,9 @@ describe("Action handlers", () => {
               colour: "eeeeee"
             },
             id: "exampleId",
-            matchContext: "bigger block of text"
+            matchContext: "bigger block of text",
+            precedingText: "bigger block of text",
+            subsequentText: ""        
           }
         ]
       };

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -149,7 +149,9 @@ describe("selectors", () => {
             colour: "eeeeee"
           },
           matchedText: "hai",
-          matchContext: "oh [hai]"
+          matchContext: "oh [[hai]]",
+          precedingText: "oh ",
+          subsequentText: ""
         }
       ];
       expect(
@@ -186,7 +188,9 @@ describe("selectors", () => {
             colour: "eeeeee"
           },
           matchedText: "hai",
-          matchContext: "Oh [hai]"
+          matchContext: "Oh [[hai]]",
+          precedingText: "oh ",
+          subsequentText: ""
         }
       ];
       expect(

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -76,7 +76,9 @@ describe("createTyperighterPlugin", () => {
             name: "Category 1",
             colour: "puce"
           },
-          matchContext: "bigger block of text"
+          matchContext: "bigger block of text",
+          precedingText: "bigger block of text",
+          subsequentText: ""
         }
       ],
       requestId: "reqId"

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -100,7 +100,9 @@ export const createMatcherResponse = (
         to: wordTo,
         matchId: createMatchId(0, wordFrom, wordTo, 0),
         suggestions,
-        matchContext: "here is a [block text] match"
+        matchContext: "here is a [[block text]] match",
+        precedingText: "here is a ",
+        subsequentText: " match"
       };
 
       return {
@@ -138,7 +140,9 @@ export const createMatch = (
   to,
   matchId: createMatchId(0, from, to, 0),
   suggestions,
-  matchContext: "here is a [block text] match"
+  matchContext: "here is a [[block text]] match",
+  precedingText: "here is a ",
+  subsequentText: " match"
 });
 
 export const exampleCategoryIds = ["example-category"];

--- a/src/ts/utils/component.ts
+++ b/src/ts/utils/component.ts
@@ -1,0 +1,23 @@
+import { IMatch, TyperighterTelemetryAdapter } from "..";
+import { maybeGetDecorationElement } from "../utils/decoration";
+
+export const createScrollToRangeHandler = (match: IMatch, getScrollOffset: () => number, editorScrollElement: Element, telemetryAdapter?: TyperighterTelemetryAdapter) => (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+e.preventDefault();
+e.stopPropagation();
+
+telemetryAdapter?.sidebarMatchClicked(match, document.URL);
+
+if (!editorScrollElement) {
+    return;
+}
+
+const decorationElement = maybeGetDecorationElement(match.matchId);
+
+if (decorationElement) {
+    const scrollToYCoord = decorationElement.offsetTop - getScrollOffset();
+    editorScrollElement.scrollTo({
+    top: scrollToYCoord,
+    behavior: "smooth"
+    });
+}
+};

--- a/src/ts/utils/component.ts
+++ b/src/ts/utils/component.ts
@@ -1,23 +1,28 @@
 import { IMatch, TyperighterTelemetryAdapter } from "..";
 import { maybeGetDecorationElement } from "../utils/decoration";
 
-export const createScrollToRangeHandler = (match: IMatch, getScrollOffset: () => number, editorScrollElement: Element, telemetryAdapter?: TyperighterTelemetryAdapter) => (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-e.preventDefault();
-e.stopPropagation();
+export const createScrollToRangeHandler = (
+  match: IMatch,
+  getScrollOffset: () => number,
+  editorScrollElement: Element,
+  telemetryAdapter?: TyperighterTelemetryAdapter
+) => (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  e.preventDefault();
+  e.stopPropagation();
 
-telemetryAdapter?.sidebarMatchClicked(match, document.URL);
+  telemetryAdapter?.sidebarMatchClicked(match, document.URL);
 
-if (!editorScrollElement) {
+  if (!editorScrollElement) {
     return;
-}
+  }
 
-const decorationElement = maybeGetDecorationElement(match.matchId);
+  const decorationElement = maybeGetDecorationElement(match.matchId);
 
-if (decorationElement) {
+  if (decorationElement) {
     const scrollToYCoord = decorationElement.offsetTop - getScrollOffset();
     editorScrollElement.scrollTo({
-    top: scrollToYCoord,
-    behavior: "smooth"
+      top: scrollToYCoord,
+      behavior: "smooth"
     });
-}
+  }
 };


### PR DESCRIPTION
## What does this change?
Before, users could only sort matches by importance (colour). Now the switch ('Summary view') has been adapted so that results are both sorted and matches with the same rule ID are grouped together under a dropdown. 'Summary view' is the default. Grouped matches are indicated by a dropdown arrow and number of matches in brackets. Once the user clicks the dropdown, they will see a short context snippet and the matched text in bold. They can then click on a match and scroll to the match in the document, as for single matches. Users can turn off summary view and the matches will all appear as single matches which are in document order. 

## How to test
Run the branch locally and experience the expected behaviour outlined above.

## How can we measure success?
Telemetry indicates that users keep summary view switched on and that they are making use of the grouped match dropdowns.

## Have we considered potential risks?
We will need to monitor the responsiveness of the UI as a result of these modifications.

## Images
![groupmatches_final](https://user-images.githubusercontent.com/15648334/95566564-a003dd00-0a19-11eb-9548-1d3593b30073.gif)



