### PR TITLE
Add telemetry for filter toggles

### DIFF
--- a/src/ts/components/FilterResults.tsx
+++ b/src/ts/components/FilterResults.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import { IMatch } from "..";
+import TelemetryContext from "../contexts/TelemetryContext";
 import {
   getColourForMatchType,
   getMatchType,
@@ -26,42 +27,47 @@ const FilterResults = ({
   applyFilterState,
   matches,
   matchColours
-}: IProps) => (
-  <>
-    {filterOrder.map(matchType => {
-      const isDisabled = filterState.includes(matchType);
-      const cannotAddFilter = filterState.length >= 2;
-      const { borderColour } = getColourForMatchType(matchType, matchColours);
+}: IProps) => {
+  const { telemetryAdapter } = useContext(TelemetryContext);
+  return (
+    <>
+      {filterOrder.map(matchType => {
+        const isDisabled = filterState.includes(matchType);
+        const cannotAddFilter = filterState.length >= 2;
+        const { borderColour } = getColourForMatchType(matchType, matchColours);
 
-      const noMatchesOfThisType = matches.filter(
-        match => getMatchType(match) === matchType
-      ).length;
+        const noMatchesOfThisType = matches.filter(
+          match => getMatchType(match) === matchType
+        ).length;
 
-      const toggleFilterValue = () =>
-        applyFilterState(
-          isDisabled
-            ? filterState.filter(currentType => currentType !== matchType)
-            : [...filterState, matchType]
+        const toggleFilterValue = () => {
+          telemetryAdapter?.filterStateToggled(matchType, !!isDisabled)
+          applyFilterState(
+            isDisabled
+              ? filterState.filter(currentType => currentType !== matchType)
+              : [...filterState, matchType]
+          );
+        }
+
+        return (
+          <button
+            key={matchType}
+            className="Sidebar__filter-toggle"
+            title="Show/hide matches of this colour"
+            disabled={cannotAddFilter && !isDisabled}
+            style={{
+              backgroundColor: isDisabled ? "transparent" : borderColour,
+              border: `2px solid ${borderColour}`,
+              color: isDisabled ? borderColour : "white"
+            }}
+            onClick={toggleFilterValue}
+          >
+            {noMatchesOfThisType}
+          </button>
         );
-
-      return (
-        <button
-          key={matchType}
-          className="Sidebar__filter-toggle"
-          title="Show/hide matches of this colour"
-          disabled={cannotAddFilter && !isDisabled}
-          style={{
-            backgroundColor: isDisabled ? "transparent" : borderColour,
-            border: `2px solid ${borderColour}`,
-            color: isDisabled ? borderColour : "white"
-          }}
-          onClick={toggleFilterValue}
-        >
-          {noMatchesOfThisType}
-        </button>
-      );
-    })}
-  </>
-);
+      })}
+    </>
+  );
+};
 
 export default FilterResults;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -3,6 +3,7 @@ import Store from './state/store';
 import createTyperighterPlugin from "./createTyperighterPlugin";
 import MatcherService from "./services/MatcherService";
 import TelemetryService from "./services/TelemetryService";
+import { ITelemetryEvent } from './interfaces/ITelemetryData';
 import TyperighterTelemetryAdapter from "./services/TyperighterTelemetryAdapter";
 import TyperighterAdapter, { convertTyperighterResponse } from "./services/adapters/TyperighterAdapter";
 import { createBoundCommands } from "./commands";
@@ -22,5 +23,6 @@ export {
   createTyperighterPlugin,
   IMatch,
   IBlock,
+  ITelemetryEvent,
   Store
 };

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -1,3 +1,5 @@
+import { MatchType } from "../utils/decoration";
+
 type TelemetryBool = "true" | "false";
 
 export interface ITelemetryEvent {
@@ -43,7 +45,8 @@ export enum TYPERIGHTER_TELEMETRY_TYPE {
   TYPERIGHTER_CLEAR_DOCUMENT = "TYPERIGHTER_CLEAR_DOCUMENT",
   TYPERIGHTER_OPEN_STATE_CHANGED = "TYPERIGHTER_OPEN_STATE_CHANGED",
   TYPERIGHTER_SIDEBAR_MATCH_CLICK = "TYPERIGHTER_SIDEBAR_MATCH_CLICK",
-  TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED = "TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED"
+  TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED = "TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED",
+  TYPERIGHTER_FILTER_STATE_CHANGED = "TYPERIGHTER_FILTER_STATE_CHANGED"
 }
 
 export interface ITyperighterTelemetryEvent extends ITelemetryEvent {
@@ -111,4 +114,10 @@ export interface ISidebarClickEvent extends ITyperighterTelemetryEvent {
 export interface ISummaryToggleEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED;
   value: 0 | 1;
+}
+
+export interface IFilterToggleEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_FILTER_STATE_CHANGED;
+  value: 0 | 1;
+  tags: ITyperighterTelemetryEvent["tags"] & { matchType: MatchType };
 }

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -21,12 +21,9 @@ class TyperighterTelemetryAdapter {
   ) {}
 
   public suggestionIsAccepted(match: IMatch, documentUrl: string, suggestion: string) {
-    this.telemetryService.addEvent({
-      app: this.app,
-      stage: this.stage,
+    this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUGGESTION_IS_ACCEPTED,
       value: 1,
-      eventTime: new Date().toISOString(),
       tags: {
         suggestion,
         documentUrl,
@@ -36,12 +33,9 @@ class TyperighterTelemetryAdapter {
   }
 
   public matchIsMarkedAsCorrect(match: IMatch, documentUrl: string) {
-    this.telemetryService.addEvent({
-      app: this.app,
-      stage: this.stage,
+    this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT,
       value: 1,
-      eventTime: new Date().toISOString(),
       tags: {
         documentUrl,
         ...this.getTelemetryTagsFromMatch(match)
@@ -50,56 +44,41 @@ class TyperighterTelemetryAdapter {
   }
 
   public documentIsChecked(tags: ITyperighterTelemetryEvent["tags"]) {
-    this.telemetryService.addEvent({
-      app: this.app,
-      stage: this.stage,
+    this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_CHECK_DOCUMENT,
       value: 1,
-      eventTime: new Date().toISOString(),
       tags
     } as ICheckDocumentEvent);
   }
 
   public documentIsCleared(tags: ITyperighterTelemetryEvent["tags"]) {
-    this.telemetryService.addEvent({
-      app: this.app,
-      stage: this.stage,
+    this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_CLEAR_DOCUMENT,
       value: 1,
-      eventTime: new Date().toISOString(),
       tags
     } as IClearDocumentEvent);
   }
 
   public typerighterIsOpened(tags: ITyperighterTelemetryEvent["tags"]) {
-    this.telemetryService.addEvent({
-        app: this.app,
-        stage: this.stage,
+    this.addEvent({
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
         value: 1,
-        eventTime: new Date().toISOString(),
         tags
     } as IOpenTyperighterEvent);
   }
 
   public typerighterIsClosed(tags: ITyperighterTelemetryEvent["tags"]) {
-    this.telemetryService.addEvent({
-        app: this.app,
-        stage: this.stage,
+    this.addEvent({
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
         value: 0,
-        eventTime: new Date().toISOString(),
         tags
      } as IOpenTyperighterEvent);
   }
 
   public sidebarMatchClicked(match: IMatch, documentUrl: string) {
-    this.telemetryService.addEvent({
-        app: this.app,
-        stage: this.stage,
+    this.addEvent({
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
         value: 1,
-        eventTime: new Date().toISOString(),
         tags: {
           documentUrl,
           ...this.getTelemetryTagsFromMatch(match)
@@ -108,12 +87,9 @@ class TyperighterTelemetryAdapter {
   }
 
   public matchFound(match: IMatch, documentUrl: string) {
-    this.telemetryService.addEvent({
-        app: this.app,
-        stage: this.stage,
+    this.addEvent({
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND,
         value: 1,
-        eventTime: new Date().toISOString(),
         tags: {
           documentUrl,
           ...this.getTelemetryTagsFromMatch(match)
@@ -122,14 +98,20 @@ class TyperighterTelemetryAdapter {
   }
 
   public summaryViewToggled(toggledOn: boolean, tags: ITyperighterTelemetryEvent["tags"]) {
-    this.telemetryService.addEvent({
-        app: this.app,
-        stage: this.stage,
+    this.addEvent({
         type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED,
         value: toggledOn ? 1 : 0,
-        eventTime: new Date().toISOString(),
         tags
     } as ISummaryToggleEvent);
+  }
+
+  private addEvent<TEvent extends ITyperighterTelemetryEvent>(event: Omit<TEvent, 'app' | 'stage' | 'eventTime'>) {
+    this.telemetryService.addEvent({
+      ...event,
+      app: this.app,
+      stage: this.stage,
+      eventTime: new Date().toISOString()
+    })
   }
 
   private getTelemetryTagsFromMatch = (match: IMatch) => ({

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -1,6 +1,7 @@
 import {
   ICheckDocumentEvent,
   IClearDocumentEvent,
+  IFilterToggleEvent,
   IMarkAsCorrectEvent,
   IMatchFoundEvent,
   IOpenTyperighterEvent,
@@ -8,10 +9,11 @@ import {
   ISuggestionAcceptedEvent,
   ISummaryToggleEvent,
   ITyperighterTelemetryEvent,
-  TYPERIGHTER_TELEMETRY_TYPE,
+  TYPERIGHTER_TELEMETRY_TYPE
 } from "../interfaces/ITelemetryData";
-import TelemetryService from './TelemetryService';
+import TelemetryService from "./TelemetryService";
 import { IMatch } from "..";
+import { MatchType } from "../utils/decoration";
 
 class TyperighterTelemetryAdapter {
   constructor(
@@ -20,7 +22,11 @@ class TyperighterTelemetryAdapter {
     private stage: string
   ) {}
 
-  public suggestionIsAccepted(match: IMatch, documentUrl: string, suggestion: string) {
+  public suggestionIsAccepted(
+    match: IMatch,
+    documentUrl: string,
+    suggestion: string
+  ) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUGGESTION_IS_ACCEPTED,
       value: 1,
@@ -61,57 +67,70 @@ class TyperighterTelemetryAdapter {
 
   public typerighterIsOpened(tags: ITyperighterTelemetryEvent["tags"]) {
     this.addEvent({
-        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
-        value: 1,
-        tags
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
+      value: 1,
+      tags
     } as IOpenTyperighterEvent);
   }
 
   public typerighterIsClosed(tags: ITyperighterTelemetryEvent["tags"]) {
     this.addEvent({
-        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
-        value: 0,
-        tags
-     } as IOpenTyperighterEvent);
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_OPEN_STATE_CHANGED,
+      value: 0,
+      tags
+    } as IOpenTyperighterEvent);
   }
 
   public sidebarMatchClicked(match: IMatch, documentUrl: string) {
     this.addEvent({
-        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
-        value: 1,
-        tags: {
-          documentUrl,
-          ...this.getTelemetryTagsFromMatch(match)
-        }
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
+      value: 1,
+      tags: {
+        documentUrl,
+        ...this.getTelemetryTagsFromMatch(match)
+      }
     } as ISidebarClickEvent);
   }
 
   public matchFound(match: IMatch, documentUrl: string) {
     this.addEvent({
-        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND,
-        value: 1,
-        tags: {
-          documentUrl,
-          ...this.getTelemetryTagsFromMatch(match)
-        }
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND,
+      value: 1,
+      tags: {
+        documentUrl,
+        ...this.getTelemetryTagsFromMatch(match)
+      }
     } as IMatchFoundEvent);
   }
 
-  public summaryViewToggled(toggledOn: boolean, tags: ITyperighterTelemetryEvent["tags"]) {
+  public summaryViewToggled(
+    toggledOn: boolean,
+    tags: ITyperighterTelemetryEvent["tags"]
+  ) {
     this.addEvent({
-        type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED,
-        value: toggledOn ? 1 : 0,
-        tags
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED,
+      value: toggledOn ? 1 : 0,
+      tags
     } as ISummaryToggleEvent);
   }
 
-  private addEvent<TEvent extends ITyperighterTelemetryEvent>(event: Omit<TEvent, 'app' | 'stage' | 'eventTime'>) {
+  public filterStateToggled(matchType: MatchType, toggledOn: boolean) {
+    this.addEvent({
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_FILTER_STATE_CHANGED,
+      value: toggledOn ? 1 : 0,
+      tags: { matchType }
+    } as IFilterToggleEvent);
+  }
+
+  private addEvent<TEvent extends ITyperighterTelemetryEvent>(
+    event: Omit<TEvent, "app" | "stage" | "eventTime">
+  ) {
     this.telemetryService.addEvent({
       ...event,
       app: this.app,
       stage: this.stage,
       eventTime: new Date().toISOString()
-    })
+    });
   }
 
   private getTelemetryTagsFromMatch = (match: IMatch) => ({
@@ -119,10 +138,10 @@ class TyperighterTelemetryAdapter {
     ruleId: match.ruleId,
     matchId: match.matchId,
     matchedText: match.matchedText,
-    matchHasReplacement: match.replacement ? 'true' : 'false',
-    matchIsAdvisory: 'false',
-    matchIsMarkedAsCorrect: match.markAsCorrect ? 'true' : 'false',
-  })
+    matchHasReplacement: match.replacement ? "true" : "false",
+    matchIsAdvisory: "false",
+    matchIsMarkedAsCorrect: match.markAsCorrect ? "true" : "false"
+  });
 }
 
 export default TyperighterTelemetryAdapter;


### PR DESCRIPTION
## What does this change?

Adds a telemetry event for the match filters, FILTER_STATE_CHANGED.

As a small multiplier bonus, exposes the telemetry event interface to the consumer, which I suspect will be handy elsewhere 😁 

## How to test

Toggle the match filter ... toggles. You should see events emitted by the telemetry service after the usual delay.

## How can we measure success?

We can see when users toggle the match filters in our telemetry. 

## Dev notes

Included a minor refactor to DRY up our telemetry service a bit.