### PR TITLE
fix: Fixes the filter button number size

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -59,9 +59,9 @@
   border-radius: $base-border-radius;
   min-width: 30px;
   font-weight: bold;
-  height: 20px;
+  height: fit-content;
   margin-right: $gutter-width / 2;
-  font-size: 14px;
+  font-size: $font-size-base;
   cursor: pointer;
   &:focus {
     outline: none;

--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -61,6 +61,7 @@
   font-weight: bold;
   height: 20px;
   margin-right: $gutter-width / 2;
+  font-size: 14px;
   cursor: pointer;
   &:focus {
     outline: none;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes a minor issue with the filter options font size. This size is being overwritten in composer, causing it to display too large. This PR sets the size explicitly fixing the issue. 

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

before: 
![image](https://user-images.githubusercontent.com/4633246/95847857-26376080-0d45-11eb-98ef-cd41d2f07fdd.png)
![image](https://user-images.githubusercontent.com/4633246/95847893-351e1300-0d45-11eb-8c77-43ca3999d67b.png)

after:
![image](https://user-images.githubusercontent.com/4633246/95847837-1fa8e900-0d45-11eb-8206-3a351e5d0594.png)
![image](https://user-images.githubusercontent.com/4633246/95847919-3fd8a800-0d45-11eb-92f6-6bd30a2c8be9.png)


