### PR TITLE
fix: Fixes the scroll to match issue

### DIFF
--- a/src/ts/utils/component.ts
+++ b/src/ts/utils/component.ts
@@ -16,7 +16,7 @@ export const createScrollToRangeHandler = (
     return;
   }
 
-  const scrollToYCoord = getMatchOffset(match.matchId) - getScrollOffset();
+  const scrollToYCoord = getMatchOffset(match.matchId, editorScrollElement) - getScrollOffset();
   editorScrollElement.scrollTo({
     top: scrollToYCoord,
     behavior: "smooth"

--- a/src/ts/utils/component.ts
+++ b/src/ts/utils/component.ts
@@ -1,5 +1,5 @@
 import { IMatch, TyperighterTelemetryAdapter } from "..";
-import { maybeGetDecorationElement } from "../utils/decoration";
+import { getMatchOffset } from "../utils/decoration";
 
 export const createScrollToRangeHandler = (
   match: IMatch,
@@ -16,13 +16,10 @@ export const createScrollToRangeHandler = (
     return;
   }
 
-  const decorationElement = maybeGetDecorationElement(match.matchId);
+  const scrollToYCoord = getMatchOffset(match.matchId) - getScrollOffset();
+  editorScrollElement.scrollTo({
+    top: scrollToYCoord,
+    behavior: "smooth"
+  });
 
-  if (decorationElement) {
-    const scrollToYCoord = decorationElement.offsetTop - getScrollOffset();
-    editorScrollElement.scrollTo({
-      top: scrollToYCoord,
-      behavior: "smooth"
-    });
-  }
 };

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -211,19 +211,20 @@ export const maybeGetDecorationElement = (
 ): HTMLElement | null =>
   document.querySelector(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);
 
-const getProseMirrorOffsetValue = (element: HTMLElement): number => {
+const getProseMirrorOffsetValue = (element: HTMLElement, scrollElement: Element): number => {
   var offset = element.offsetTop;
 
-  if(element.offsetParent && !element.offsetParent.className.includes("ProseMirror")){
-    return offset += getProseMirrorOffsetValue(element.offsetParent as HTMLElement);
+  if(element.offsetParent && !element.isEqualNode(scrollElement)){
+    return offset += getProseMirrorOffsetValue(element.offsetParent as HTMLElement, scrollElement);
   }
 
   return offset;
 }
 
 export const getMatchOffset = (
-  matchId: string
+  matchId: string,
+  scrollElement: Element
 ): number => {
   const element = document.querySelector<HTMLElement>(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);
-  return element ? getProseMirrorOffsetValue(element) : 0;
+  return element ? getProseMirrorOffsetValue(element, scrollElement) : 0;
 }

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -210,3 +210,20 @@ export const maybeGetDecorationElement = (
   matchId: string
 ): HTMLElement | null =>
   document.querySelector(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);
+
+const getProseMirrorOffsetValue = (element: HTMLElement): number => {
+  var offset = element.offsetTop;
+
+  if(element.offsetParent && !element.offsetParent.className.includes("ProseMirror")){
+    return offset += getProseMirrorOffsetValue(element.offsetParent as HTMLElement);
+  }
+
+  return offset;
+}
+
+export const getMatchOffset = (
+  matchId: string
+): number => {
+  const element = document.querySelector<HTMLElement>(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);
+  return element ? getProseMirrorOffsetValue(element) : 0;
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR aims to fix the scroll-to match issue by tallying up the top offset value until the desired element is found. 

The bug was a result of using `offsetTop` regardless of where the match was found. If for example the match was within a list, the offset would only relative to the top of the list. This would result in the pane scrolling to the top regardless of where the match was located in the document.

There may be a better way of determining the element we want to calculate the offset relative to, using the `ProseMirror` class name seems fraught.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Check a document with various matches, turn a set of matches into a list (or nested list), navigate to those match by using the sidebar. The panel should scroll to the correct location.
