### PR TITLE
fix: Fix loading bar always appearing at max width

### DIFF
--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -136,7 +136,7 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
               opacity: isLoading ? 1 : 0,
               // We always display a sliver of loading bar to let
               // users know that a check has started
-              width: `${100 - Math.min(percentRemaining, 0.99)}%`
+              width: `${100 - Math.min(percentRemaining, 99)}%`
             }}
           >
             <div className="LoadingBar__animated-background"></div>


### PR DESCRIPTION
## What does this change?

#153 broke the loading bar, which always appeared at full width. This PR should fix that.

## How to test

Perform a check. The loading bar should behave as expected.
