### PR TITLE
chore: Rename master branch to main

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,7 +6,7 @@ name: Node.js CI
 on:
   push:
     branches:
-      - master
+      - main
       - beta
   pull_request:
     branches:
@@ -34,7 +34,7 @@ jobs:
       with:
         branches: |
           [
-            'master',
+            'main',
             {
               name: 'beta',
               prerelease: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 branches:
   only:
-    - master
+    - main
 cache:
   yarn: true
   directories:

--- a/build/README.md
+++ b/build/README.md
@@ -1,4 +1,4 @@
-![](https://travis-ci.org/guardian/prosemirror-typerighter.svg?branch=master) [![Coverage Status](https://coveralls.io/repos/github/guardian/prosemirror-typerighter/badge.svg?branch=master)](https://coveralls.io/github/guardian/prosemirror-typerighter?branch=master)
+![](https://travis-ci.org/guardian/prosemirror-typerighter.svg?branch=main) [![Coverage Status](https://coveralls.io/repos/github/guardian/prosemirror-typerighter/badge.svg?branch=main)](https://coveralls.io/github/guardian/prosemirror-typerighter?branch=main)
 
 This Prosemirror plugin adds the ability to validate a document by sending it, or some parts of it, to an external service for validation. Once instantiated, it provides a store object that allows consumer code to subscribe to state updates for UI updates etc.
 
@@ -26,13 +26,8 @@ To update the project readme, edit the README.md in ./build and run `build:doc`.
 
 ## Commiting and publishing new versions
 
-This repository uses [semantic-release](https://github.com/semantic-release/semantic-release) to publish new versions of this package when PRs are merged to `master`, and prelease versions when code is pushed to `beta`.
+This repository uses [semantic-release](https://github.com/semantic-release/semantic-release) to publish new versions of this package when PRs are merged to `main`, and prelease versions when code is pushed to `beta`.
 
 Version numbers are determined by the commit history, and so to trigger a release you'll need to use the [commitizen](https://github.com/commitizen-tools/commitizen) format when writing commits.
 
 A pre-commit githook is installed on `npm i` to launch the commitizen tool, which will help you write a well-formed commit message. You can skip this with `ctrl-c` if necessary, but do bear in mind that commits that aren't in this format cannot trigger releases.
-
-
-
-
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 # @guardian/prosemirror-typerighter
 
-![](https://travis-ci.org/guardian/prosemirror-typerighter.svg?branch=master) [![Coverage Status](https://coveralls.io/repos/github/guardian/prosemirror-typerighter/badge.svg?branch=master)](https://coveralls.io/github/guardian/prosemirror-typerighter?branch=master)
+![](https://travis-ci.org/guardian/prosemirror-typerighter.svg?branch=main) [![Coverage Status](https://coveralls.io/repos/github/guardian/prosemirror-typerighter/badge.svg?branch=main)](https://coveralls.io/github/guardian/prosemirror-typerighter?branch=main)
 
 This Prosemirror plugin adds the ability to validate a document by sending it, or some parts of it, to an external service for validation. Once instantiated, it provides a store object that allows consumer code to subscribe to state updates for UI updates etc.
 
@@ -30,7 +30,7 @@ To update the project readme, edit the README.md in ./build and run `build:doc`.
 
 ## Commiting and publishing new versions
 
-This repository uses [semantic-release](https://github.com/semantic-release/semantic-release) to publish new versions of this package when PRs are merged to `master`, and prelease versions when code is pushed to `beta`.
+This repository uses [semantic-release](https://github.com/semantic-release/semantic-release) to publish new versions of this package when PRs are merged to `main`, and prelease versions when code is pushed to `beta`.
 
 Version numbers are determined by the commit history, and so to trigger a release you'll need to use the [commitizen](https://github.com/commitizen-tools/commitizen) format when writing commits.
 


### PR DESCRIPTION
Closes: #156 #157

## What does this change?
Changes references from 'master' branch to 'main' in config and documents, following the renaming of the base branch. Merging this PR will also serve as a test of whether the branch renaming process has worked.
