### PR TITLE
feat: Handle skip ranges on the client

### DIFF
--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -15,8 +15,12 @@ export interface IBlock {
   id: string;
   text: string;
   from: number;
-  to: number;
-  skipRanges?: IRange[]
+  to: number
+}
+
+
+export interface IBlockWithSkippedRanges extends IBlock {
+  skipRanges: IRange[]
 }
 
 export type ISuggestion = ITextSuggestion | IWikiSuggestion;

--- a/src/ts/services/test/MatcherService.spec.ts
+++ b/src/ts/services/test/MatcherService.spec.ts
@@ -159,13 +159,18 @@ describe("MatcherService", () => {
 
     it("On receipt of matches, map matches that succeed skipped ranges through those ranges to ensure they're correct", done => {
       const service = createMatcherService();
-      // const response = createResponse(['F'], 2);
-      fetchMock.post(`${endpoint}/check`, 400);
+      // We send the text "BDF", and create a match for the "F" at position 2
+      const response = createResponse(["F"], 2);
+      fetchMock.post(`${endpoint}/check`, response);
       service.requestFetchMatches();
 
       store.emit("STORE_EVENT_NEW_MATCHES", requestId, [blockWithSkipRanges]);
       setTimeout(() => {
-        // @todo
+        // We map our match (position 2) back through three skipRanges of
+        // one char each, pushing range into (5, 6).
+        const matches = commands.applyMatcherResponse.mock.calls[0][0].matches[0]
+        expect(matches.from).toBe(5);
+        expect(matches.to).toBe(6)
         done();
       });
     });

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -29,9 +29,9 @@ import {
 } from "./actions";
 import {
   IMatch,
-  IBlock,
   IRange,
-  IMatchRequestError
+  IMatchRequestError,
+  IBlockWithSkippedRanges
 } from "../interfaces/IMatch";
 import { DecorationSet, Decoration } from "prosemirror-view";
 import omit from "lodash/omit";
@@ -79,7 +79,7 @@ import { TFilterMatches } from "../utils/plugin";
 export interface IBlockInFlight {
   // The categories that haven't yet reported for this block.
   pendingCategoryIds: string[];
-  block: IBlock;
+  block: IBlockWithSkippedRanges;
 }
 
 /**
@@ -509,7 +509,7 @@ const createHandleMatchesRequestForDirtyRanges = (
   { payload: { requestId, categoryIds } }: ActionRequestMatchesForDirtyRanges
 ): TPluginState => {
   const ranges = expandRanges(state.dirtiedRanges, tr.doc);
-  const blocks: IBlock[] = ranges.map(range =>
+  const blocks = ranges.map(range =>
     createBlock(tr.doc, range, tr.time, getIgnoredRanges)
   );
   return handleRequestStart(requestId, blocks, categoryIds)(tr, state);
@@ -537,7 +537,7 @@ const createHandleMatchesRequestForDocument = (
  */
 const handleRequestStart = (
   requestId: string,
-  blocks: IBlock[],
+  blocks: IBlockWithSkippedRanges[],
   categoryIds: string[]
 ) => <TPluginState extends IPluginState>(
   tr: Transaction,

--- a/src/ts/state/store.ts
+++ b/src/ts/state/store.ts
@@ -1,6 +1,6 @@
 import { IPluginState } from "./reducer";
 import { ArgumentTypes } from "../utils/types";
-import { IBlock } from "../interfaces/IMatch";
+import { IBlockWithSkippedRanges } from "../interfaces/IMatch";
 
 export const STORE_EVENT_NEW_MATCHES = "STORE_EVENT_NEW_MATCHES";
 export const STORE_EVENT_NEW_STATE = "STORE_EVENT_NEW_STATE";
@@ -13,7 +13,7 @@ type STORE_EVENT_NEW_DIRTIED_RANGES = typeof STORE_EVENT_NEW_DIRTIED_RANGES;
 export interface IStoreEvents<TPluginState extends IPluginState> {
   [STORE_EVENT_NEW_MATCHES]: (
     requestId: string,
-    blocks: IBlock[]
+    blocks: IBlockWithSkippedRanges[]
   ) => void;
   [STORE_EVENT_NEW_STATE]: (state: TPluginState) => void;
   [STORE_EVENT_NEW_DIRTIED_RANGES]: () => void;

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -68,7 +68,8 @@ describe("Action handlers", () => {
             from: 1,
             text: "Example text to check",
             to: 23,
-            id: "0-from:1-to:23"
+            id: "0-from:1-to:23",
+            skipRanges: []
           }
         ])
       });
@@ -104,7 +105,8 @@ describe("Action handlers", () => {
             text: "Example text to check",
             from: 1,
             to: 22,
-            id: "0-from:1-to:22"
+            id: "0-from:1-to:22",
+            skipRanges: []
           }
         ])
       });
@@ -301,7 +303,8 @@ describe("Action handlers", () => {
               from: 0,
               id: firstBlock.id,
               text: "Example text to check",
-              to: 15
+              to: 15,
+              skipRanges: []
             },
             pendingCategoryIds: ["this-category-should-remain"]
           },
@@ -310,7 +313,8 @@ describe("Action handlers", () => {
               from: 16,
               id: secondBlock.id,
               text: "Another block of text",
-              to: 37
+              to: 37,
+              skipRanges: []
             },
             pendingCategoryIds: ["1", "this-category-should-remain"]
           }
@@ -498,7 +502,7 @@ describe("Action handlers", () => {
         },
         matchContext: "some more text",
         precedingText: "some more text",
-        subsequentText: ""        
+        subsequentText: ""
       };
       const localState = {
         ...state,
@@ -536,7 +540,7 @@ describe("Action handlers", () => {
         },
         matchContext: "bigger block of text",
         precedingText: "bigger block of text",
-        subsequentText: ""        
+        subsequentText: ""
       };
       const localState = {
         ...state,
@@ -580,7 +584,7 @@ describe("Action handlers", () => {
           markAsCorrect: true,
           matchContext: "bigger block of text",
           precedingText: "bigger block of text",
-          subsequentText: ""        
+          subsequentText: ""
         }
       ];
       const stateWithCurrentMatchesAndDecorations = {
@@ -630,7 +634,7 @@ describe("Action handlers", () => {
             id: "exampleId",
             matchContext: "bigger block of text",
             precedingText: "bigger block of text",
-            subsequentText: ""        
+            subsequentText: ""
           }
         ]
       };

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -92,13 +92,15 @@ describe("createTyperighterPlugin", () => {
           from: 1,
           id: "1337-from:1-to:23",
           text: "Example text to check",
-          to: 23
+          to: 23,
+          skipRanges: []
         },
         {
           from: 24,
           id: "1337-from:24-to:43",
           text: "More text to check",
-          to: 43
+          to: 43,
+          skipRanges: []
         }
       ]
     ]);

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -4,7 +4,9 @@ import {
   ISuggestion,
   IBlock,
   IMatcherResponse,
-  ICategory
+  ICategory,
+  IBlockWithSkippedRanges,
+  IRange
 } from "../../interfaces/IMatch";
 import { createBlockId, createMatchId } from "../../utils/block";
 import { IPluginState, IBlocksInFlightState, createReducer } from "../../state/reducer";
@@ -45,12 +47,14 @@ export const matchLibrary: IMatchLibrary = [
 export const createBlock = (
   from: number,
   to: number,
-  text = "str"
-): IBlock => ({
+  text = "str",
+  skipRanges: IRange[] = []
+): IBlockWithSkippedRanges => ({
   text,
   from,
   to,
-  id: `0-from:${from}-to:${to}`
+  id: `0-from:${from}-to:${to}`,
+  skipRanges
 });
 
 export interface ICreateMatcherResponseSpec {
@@ -150,7 +154,7 @@ export const exampleCategoryIds = ["example-category"];
 export const exampleRequestId = "set-id";
 
 export const createBlockQueriesInFlight = (
-  blockQueries: IBlock[],
+  blockQueries: IBlockWithSkippedRanges[],
   setId = exampleRequestId,
   categoryIds: string[] = exampleCategoryIds,
   pendingCategoryIds: string[] = categoryIds,
@@ -160,8 +164,8 @@ export const createBlockQueriesInFlight = (
     totalBlocks: total || blockQueries.length,
     mapping: new Mapping(),
     categoryIds,
-    pendingBlocks: blockQueries.map(input => ({
-      block: input,
+    pendingBlocks: blockQueries.map(block => ({
+      block,
       pendingCategoryIds
     }))
   }

--- a/src/ts/utils/block.ts
+++ b/src/ts/utils/block.ts
@@ -41,7 +41,23 @@ export const createMatchId = (
 ) => `${createBlockId(time, from, to)}--match-${index}`;
 
 /**
- * Remove the given ranges from the block text, adjusting the block range accordingly.
+ * For a block, remove the text covered by the given ranges, adjusting
+ * the block range accordingly.
+ *
+ * For example, with the block ```{
+ *  from: 0,
+ *  to: 2
+ *  text: `ABC`,
+ *  skipRanges: `[{ from: 1, to: 1 }]`
+ * }```
+ *
+ * We produce a new block with `B` removed and the range reduced by 1:
+ *
+ * ```{
+ *  from: 0,
+ *  to: 1
+ *  text: `AC`,
+ * }```
  */
 export const removeSkippedRanges = (block: IBlockWithSkippedRanges): IBlock => {
   const skipRanges = block.skipRanges || [];

--- a/src/ts/utils/block.ts
+++ b/src/ts/utils/block.ts
@@ -42,14 +42,12 @@ export const createMatchId = (
 /**
  * Remove the given ranges from the block text, adjusting the block range accordingly.
  */
-export const removeSkippedRanges = (
-  block: IBlock,
-  rangesToSkip: IRange[]
-): IBlock => {
-  if (rangesToSkip.length === 0) {
+export const removeSkippedRanges = (block: IBlock): IBlock => {
+  const skipRanges = block.skipRanges || [];
+  if (skipRanges.length === 0) {
     return block;
   }
-  const [newBlock] = rangesToSkip.reduce(
+  const [newBlock] = skipRanges.reduce(
     ([accBlock, rangesAlreadyApplied], range) => {
       const mappedRange = rangesAlreadyApplied.reduce(
         (acc, incomingRange) => mapRemovedRange(incomingRange, acc),

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -1,0 +1,52 @@
+import { IMatch } from "..";
+import { IBlock, IRange } from "../interfaces/IMatch";
+import { mapAddedRange } from "./range";
+
+/**
+ * Map the range this match applies to through the given ranges, adjusting its range accordingly.
+ */
+export const mapThroughSkippedRanges = <TMatch extends IMatch>(
+  match: TMatch,
+  skipRanges: IRange[]
+): TMatch => {
+  if (!skipRanges.length) {
+    return match;
+  }
+
+  const [newMatch] = skipRanges.reduce(
+    ([accMatch, rangesAlreadyApplied], range) => {
+      const initialRange = {
+        from: accMatch.from,
+        to: accMatch.to
+      };
+      const newMatchRange = mapAddedRange(initialRange, range);
+      const newRuleMatch = {
+        ...accMatch,
+        from: newMatchRange.from,
+        to: newMatchRange.to
+      };
+
+      return [newRuleMatch, rangesAlreadyApplied];
+    },
+    [match, [] as Range[]]
+  );
+
+  return newMatch;
+};
+
+/**
+ * Map this match through the given blocks' skipped ranges.
+ */
+export const mapMatchThroughBlocks = <TMatch extends IMatch>(
+  match: TMatch,
+  blocks: IBlock[]
+): TMatch => {
+  const maybeBlockForThisMatch = blocks.find(
+    block => match.from >= block.from && match.to <= block.to
+  );
+  if (!maybeBlockForThisMatch) {
+    return match;
+  }
+  const skipRangesForThisBlock = skipRanges(maybeBlockForThisMatch);
+  return mapThroughSkippedRanges(match, skipRangesForThisBlock);
+};

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -1,5 +1,4 @@
-import { IMatch } from "..";
-import { IBlockWithSkippedRanges, IRange } from "../interfaces/IMatch";
+import { IBlockWithSkippedRanges, IMatch, IRange } from "../interfaces/IMatch";
 import { mapAddedRange } from "./range";
 
 /**

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -1,6 +1,5 @@
 import { IMatch } from "..";
-import { IBlock, IRange } from "../interfaces/IMatch";
-import { removeSkippedRanges } from "./block";
+import { IBlockWithSkippedRanges, IRange } from "../interfaces/IMatch";
 import { mapAddedRange } from "./range";
 
 /**
@@ -40,7 +39,7 @@ export const mapThroughSkippedRanges = <TMatch extends IMatch>(
  */
 export const mapMatchThroughBlocks = <TMatch extends IMatch>(
   match: TMatch,
-  blocks: IBlock[]
+  blocks: IBlockWithSkippedRanges[]
 ): TMatch => {
   const maybeBlockForThisMatch = blocks.find(
     block => match.from >= block.from && match.to <= block.to

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -46,6 +46,5 @@ export const mapMatchThroughBlocks = <TMatch extends IMatch>(
   if (!maybeBlockForThisMatch) {
     return match;
   }
-  const skipRangesForThisBlock = maybeBlockForThisMatch.skipRanges || []
-  return mapThroughSkippedRanges(match, skipRangesForThisBlock);
+  return mapThroughSkippedRanges(match, maybeBlockForThisMatch.skipRanges);
 };

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -1,5 +1,6 @@
 import { IMatch } from "..";
 import { IBlock, IRange } from "../interfaces/IMatch";
+import { removeSkippedRanges } from "./block";
 import { mapAddedRange } from "./range";
 
 /**
@@ -47,6 +48,6 @@ export const mapMatchThroughBlocks = <TMatch extends IMatch>(
   if (!maybeBlockForThisMatch) {
     return match;
   }
-  const skipRangesForThisBlock = skipRanges(maybeBlockForThisMatch);
+  const skipRangesForThisBlock = maybeBlockForThisMatch.skipRanges || []
   return mapThroughSkippedRanges(match, skipRangesForThisBlock);
 };

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -3,7 +3,7 @@ import { Transaction } from "prosemirror-state";
 import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
 import * as jsDiff from "diff";
 
-import { IBlock, IRange } from "../interfaces/IMatch";
+import { IBlockWithSkippedRanges, IRange } from "../interfaces/IMatch";
 import { createBlock, doNotSkipRanges, TGetSkippedRanges } from "./block";
 
 export const MarkTypes = {
@@ -44,8 +44,8 @@ export const getBlocksFromDocument = (
   doc: Node,
   time = 0,
   getIgnoredRanges: TGetSkippedRanges = doNotSkipRanges
-): IBlock[] => {
-  const ranges = [] as IBlock[];
+): IBlockWithSkippedRanges[] => {
+  const ranges = [] as IBlockWithSkippedRanges[];
   doc.descendants((descNode, pos) => {
     if (!findChildren(descNode, _ => _.type.isBlock, false).length) {
       ranges.push(
@@ -97,7 +97,7 @@ interface IBaseSuggestionPatch {
 }
 
 interface ISuggestionPatchDelete extends IBaseSuggestionPatch {
-  type: "DELETE"
+  type: "DELETE";
 }
 
 interface ISuggestionPatchInsert extends IBaseSuggestionPatch {
@@ -110,7 +110,7 @@ interface ISuggestionPatchInsert extends IBaseSuggestionPatch {
   getMarks: (tr: Transaction) => Array<Mark<any>>;
 }
 
-type ISuggestionPatch = ISuggestionPatchInsert | ISuggestionPatchDelete
+type ISuggestionPatch = ISuggestionPatchInsert | ISuggestionPatchDelete;
 
 /**
  * Generates a minimal array of replacement nodes and ranges from two pieces of text.
@@ -168,7 +168,8 @@ export const getPatchesFromReplacementText = (
       }
 
       const prevFragment = currentFragments[currentFragments.length - 1];
-      const isInsertionThatFollowsUnalteredRange = !!prevFragment && (prevFragment.to || 0) < newFrom;
+      const isInsertionThatFollowsUnalteredRange =
+        !!prevFragment && (prevFragment.to || 0) < newFrom;
 
       let getMarks;
       if (isInsertionThatFollowsUnalteredRange) {
@@ -176,7 +177,7 @@ export const getPatchesFromReplacementText = (
         // from the character that precedes this patch. This ensures that text that expands
         // upon an existing range shares the existing range's style.
         getMarks = (localTr: Transaction) => {
-          const $newFrom = localTr.doc.resolve(newFrom)
+          const $newFrom = localTr.doc.resolve(newFrom);
           const $lastCharFrom = localTr.doc.resolve(newFrom - 1);
           return $lastCharFrom.marksAcross($newFrom) || Mark.none;
         };
@@ -184,9 +185,9 @@ export const getPatchesFromReplacementText = (
         // If this patch is a replacement, find all of the marks
         // that span the text we're replacing, and copy them across.
         getMarks = (localTr: Transaction) => {
-          const $newTo = localTr.doc.resolve(newTo)
+          const $newTo = localTr.doc.resolve(newTo);
           return localTr.doc.resolve(newFrom).marksAcross($newTo) || Mark.none;
-        }
+        };
       }
 
       const newFragment: ISuggestionPatchInsert = {

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -192,9 +192,11 @@ const getCharsRemovedBeforeFrom = (
     removedRange
   );
   if (intersection) {
+    // The number of chars covered by the intersection is one larger than its length,
+    // so for example (1, 2) will cover chars 1 and 2 – hence we add one to `from`.
     return intersection.to - intersection.from + 1;
   }
-  return 1; // If there's no intersection, this is range from (n,n)
+  return 1; // If there's no intersection, this is a range from (n, n), which is one char long
 };
 
 /**

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -176,16 +176,16 @@ export const expandRangesToParentBlockNode = (ranges: IRange[], doc: Node) =>
   getRangesOfParentBlockNodes(ranges, doc);
 
 const getCharsRemovedBeforeFrom = (
-  incomingRange: IRange,
+  currentRange: IRange,
   removedRange: IRange
 ) => {
-  if (removedRange.from >= incomingRange.from) {
+  if (removedRange.from >= currentRange.from) {
     return 0;
   }
 
   const rangeBetweenRemovedStartAndIncomingStart = {
     from: removedRange.from,
-    to: incomingRange.from
+    to: currentRange.from
   };
   const intersection = getIntersection(
     rangeBetweenRemovedStartAndIncomingStart,
@@ -203,21 +203,21 @@ const getCharsRemovedBeforeFrom = (
  * Map a from and to position through the given removed range.
  */
 export const mapRemovedRange = (
-  incomingRange: IRange,
+  currentRange: IRange,
   removedRange: IRange
 ): IRange => {
   const charsRemovedBeforeFrom = getCharsRemovedBeforeFrom(
-    incomingRange,
+    currentRange,
     removedRange
   );
 
-  const intersection = getIntersection(incomingRange, removedRange);
+  const intersection = getIntersection(currentRange, removedRange);
   const charsRemovedBeforeTo = intersection
     ? charsRemovedBeforeFrom + (intersection.to - intersection.from)
     : charsRemovedBeforeFrom;
 
-  const from = incomingRange.from - charsRemovedBeforeFrom;
-  const to = incomingRange.to - charsRemovedBeforeTo;
+  const from = currentRange.from - charsRemovedBeforeFrom;
+  const to = currentRange.to - charsRemovedBeforeTo;
 
   return { from, to };
 };
@@ -226,21 +226,21 @@ export const mapRemovedRange = (
  * Map a from and to position through the given added range.
  */
 export const mapAddedRange = (
-  incomingRange: IRange,
+  currentRange: IRange,
   addedRange: IRange
 ): IRange => {
   // We add one to our lengths here to ensure the to value
   // is placed beyond the last position the range occupies.
   const lengthOfAddedRange = addedRange.to - addedRange.from;
   const charsAddedBeforeFrom =
-    addedRange.from <= incomingRange.from ? lengthOfAddedRange + 1 : 0;
-  const intersection = getIntersection(incomingRange, addedRange);
+    addedRange.from <= currentRange.from ? lengthOfAddedRange + 1 : 0;
+  const intersection = getIntersection(currentRange, addedRange);
   const charsAddedBeforeTo = intersection
     ? lengthOfAddedRange + 1
     : charsAddedBeforeFrom;
 
-  const from = incomingRange.from + charsAddedBeforeFrom;
-  const to = incomingRange.to + charsAddedBeforeTo;
+  const from = currentRange.from + charsAddedBeforeFrom;
+  const to = currentRange.to + charsAddedBeforeTo;
 
   return { from, to };
 };

--- a/src/ts/utils/test/block.spec.ts
+++ b/src/ts/utils/test/block.spec.ts
@@ -91,5 +91,54 @@ describe("Block utils", () => {
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(22);
     });
+    it("should yield the same result if the skipped ranges overlap", () => {
+      const skipRanges = [
+        { from: 24, to: 31 },
+        { from: 18, to: 26 }
+      ];
+      const block = {
+        id: "id",
+        text: "Example [noted][noted ]text",
+        from: 10,
+        to: 37,
+        skipRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+      expect(newBlock.text).toBe("Example text");
+      expect(newBlock.from).toBe(10);
+      expect(newBlock.to).toBe(22);
+    });
+    it("should trim to the end of the text if the skipped ranges go beyond the block", () => {
+      const skipRanges = [
+        { from: 17, to: 1000 }
+      ];
+      const block = {
+        id: "id",
+        text: "Example[ text",
+        from: 10,
+        to: 23,
+        skipRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+      expect(newBlock.text).toBe("Example");
+      expect(newBlock.from).toBe(10);
+      expect(newBlock.to).toBe(17);
+    });
+    it("should trim to the beginning of the text if the skipped ranges precede the block", () => {
+      const skipRanges = [
+        { from: 0, to: 18 }
+      ];
+      const block = {
+        id: "id",
+        text: "Example] text",
+        from: 10,
+        to: 23,
+        skipRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+      expect(newBlock.text).toBe("text");
+      expect(newBlock.from).toBe(10);
+      expect(newBlock.to).toBe(14);
+    });
   });
 });

--- a/src/ts/utils/test/block.spec.ts
+++ b/src/ts/utils/test/block.spec.ts
@@ -3,13 +3,13 @@ import { removeSkippedRanges } from "../block";
 describe("Block utils", () => {
   describe("removeSkippedRanges", () => {
     it("should remove the passed skipped range from the block text", () => {
-      const skippedRanges = [{ from: 18, to: 25 }];
+      const skipRanges = [{ from: 18, to: 25 }];
       const block = {
         id: "id",
         text: "Example [noted ]text",
         from: 10,
         to: 28,
-        skippedRanges
+        skipRanges
       };
       const newBlock = removeSkippedRanges(block);
       expect(newBlock.text).toBe("Example text");
@@ -18,7 +18,7 @@ describe("Block utils", () => {
     });
 
     it("should remove multiple adjacent skipped ranges from the block text", () => {
-      const skippedRanges = [
+      const skipRanges = [
         { from: 18, to: 25 },
         { from: 26, to: 32 }
       ];
@@ -27,7 +27,7 @@ describe("Block utils", () => {
         text: "Example [noted][noted ]text",
         from: 10,
         to: 37,
-        skippedRanges
+        skipRanges
       };
       const newBlock = removeSkippedRanges(block);
 
@@ -37,7 +37,7 @@ describe("Block utils", () => {
     });
 
     it("should remove multiple non-adjacent skipped ranges from the block text - 1", () => {
-      const skippedRanges = [
+      const skipRanges = [
         { from: 18, to: 25 },
         { from: 41, to: 48 }
       ];
@@ -46,7 +46,7 @@ describe("Block utils", () => {
         text: "Example [noted ]text with more [noted ]text",
         from: 10,
         to: 52,
-        skippedRanges
+        skipRanges
       };
       const newBlock = removeSkippedRanges(block);
       expect(newBlock.text).toBe("Example text with more text");
@@ -55,7 +55,7 @@ describe("Block utils", () => {
     });
 
     it("should remove multiple non-adjacent skipped ranges from the block text - 2", () => {
-      const skippedRanges = [
+      const skipRanges = [
         { from: 40, to: 42 },
         { from: 44, to: 45 },
         { from: 47, to: 48 }
@@ -65,7 +65,7 @@ describe("Block utils", () => {
         text: "ABCDEFGHIJ",
         from: 40,
         to: 47,
-        skippedRanges
+        skipRanges
       };
       const newBlock = removeSkippedRanges(block);
 
@@ -75,7 +75,7 @@ describe("Block utils", () => {
     });
 
     it("should not care about order", () => {
-      const skippedRanges = [
+      const skipRanges = [
         { from: 24, to: 31 },
         { from: 18, to: 24 }
       ];
@@ -84,7 +84,7 @@ describe("Block utils", () => {
         text: "Example [noted][noted ]text",
         from: 10,
         to: 37,
-        skippedRanges
+        skipRanges
       };
       const newBlock = removeSkippedRanges(block);
       expect(newBlock.text).toBe("Example text");

--- a/src/ts/utils/test/block.spec.ts
+++ b/src/ts/utils/test/block.spec.ts
@@ -1,0 +1,95 @@
+import { removeSkippedRanges } from "../block";
+
+describe("Block utils", () => {
+  describe("removeSkippedRanges", () => {
+    it("should remove the passed skipped range from the block text", () => {
+      const skippedRanges = [{ from: 18, to: 25 }];
+      const block = {
+        id: "id",
+        text: "Example [noted ]text",
+        from: 10,
+        to: 28,
+        skippedRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+      expect(newBlock.text).toBe("Example text");
+      expect(newBlock.from).toBe(10);
+      expect(newBlock.to).toBe(22);
+    });
+
+    it("should remove multiple adjacent skipped ranges from the block text", () => {
+      const skippedRanges = [
+        { from: 18, to: 25 },
+        { from: 26, to: 32 }
+      ];
+      const block = {
+        id: "id",
+        text: "Example [noted][noted ]text",
+        from: 10,
+        to: 37,
+        skippedRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+
+      expect(newBlock.text).toBe("Example text");
+      expect(newBlock.from).toBe(10);
+      expect(newBlock.to).toBe(22);
+    });
+
+    it("should remove multiple non-adjacent skipped ranges from the block text - 1", () => {
+      const skippedRanges = [
+        { from: 18, to: 25 },
+        { from: 41, to: 48 }
+      ];
+      const block = {
+        id: "id",
+        text: "Example [noted ]text with more [noted ]text",
+        from: 10,
+        to: 52,
+        skippedRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+      expect(newBlock.text).toBe("Example text with more text");
+      expect(newBlock.from).toBe(10);
+      expect(newBlock.to).toBe(37);
+    });
+
+    it("should remove multiple non-adjacent skipped ranges from the block text - 2", () => {
+      const skippedRanges = [
+        { from: 40, to: 42 },
+        { from: 44, to: 45 },
+        { from: 47, to: 48 }
+      ];
+      const block = {
+        id: "1602586488022-from:40-to:214",
+        text: "ABCDEFGHIJ",
+        from: 40,
+        to: 47,
+        skippedRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+
+      expect(newBlock.text).toBe("DGJ");
+      expect(newBlock.from).toBe(40);
+      expect(newBlock.to).toBe(43);
+    });
+
+    it("should not care about order", () => {
+      const skippedRanges = [
+        { from: 24, to: 31 },
+        { from: 18, to: 24 }
+      ];
+      const block = {
+        id: "id",
+        text: "Example [noted][noted ]text",
+        from: 10,
+        to: 37,
+        skippedRanges
+      };
+      const newBlock = removeSkippedRanges(block);
+      expect(newBlock.text).toBe("Example text");
+      expect(newBlock.from).toBe(10);
+      expect(newBlock.to).toBe(22);
+    });
+  });
+});

--- a/src/ts/utils/test/match.spec.ts
+++ b/src/ts/utils/test/match.spec.ts
@@ -1,0 +1,72 @@
+import { IMatch } from "../..";
+import { mapThroughSkippedRanges } from "../match";
+
+describe("Match helpers", () => {
+  const getRuleMatch = (from: number, to: number): IMatch => ({
+    ruleId: "rule-id",
+    category: { id: "category-id", name: "Category", colour: "puce" },
+    from,
+    to,
+    matchId: "match-id",
+    precedingText: "",
+    subsequentText: "",
+    matchedText: "placeholder text",
+    message: "placeholder message",
+    matchContext: "[placeholder text]",
+    matcherType: "regex"
+  });
+
+  describe("mapMatchThroughSkippedRanges", () => {
+    it("should account for a range skipped before the given range", () => {
+      const ruleMatch = getRuleMatch(10, 15);
+      const skippedRange = [{ from: 0, to: 5 }];
+      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      expect(mappedMatch.from).toBe(16);
+      expect(mappedMatch.to).toBe(21);
+    });
+
+    it("should account for a range skipped within the given range", () => {
+      const ruleMatch = getRuleMatch(10, 15);
+      const skippedRange = [{ from: 10, to: 15 }];
+      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      expect(mappedMatch.from).toBe(16);
+      expect(mappedMatch.to).toBe(21);
+    });
+
+    it("should account for a range skipped within the given range, and extending beyond it", () => {
+      const ruleMatch = getRuleMatch(8, 12);
+      const skippedRange = [{ from: 8, to: 15 }];
+      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      expect(mappedMatch.from).toBe(16);
+      expect(mappedMatch.to).toBe(20);
+    });
+
+    it("should account for a range skipped partially within the given range – left hand side", () => {
+      const ruleMatch = getRuleMatch(10, 15);
+      const skippedRange = [{ from: 5, to: 12 }];
+      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      expect(mappedMatch.from).toBe(18);
+      expect(mappedMatch.to).toBe(23);
+    });
+
+    it("should account for a range skipped partially the given range – right hand side", () => {
+      const ruleMatch = getRuleMatch(10, 15);
+      const skippedRange = [{ from: 13, to: 20 }];
+      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      expect(mappedMatch.from).toBe(10);
+      expect(mappedMatch.to).toBe(23);
+    });
+
+    it("should account for multiple ranges", () => {
+      // E.g. "Example [noted ]text with more [noted ]text"
+      const ruleMatch = getRuleMatch(18, 22);
+      const skippedRange = [
+        { from: 18, to: 25 },
+        { from: 40, to: 47 }
+      ];
+      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      expect(mappedMatch.from).toBe(26);
+      expect(mappedMatch.to).toBe(30);
+    });
+  });
+});

--- a/src/ts/utils/test/prosemirror.spec.ts
+++ b/src/ts/utils/test/prosemirror.spec.ts
@@ -19,19 +19,33 @@ describe("Prosemirror utils", () => {
         p(ul(li("List item 1"), li("List item 2")))
       );
       expect(getBlocksFromDocument(node, 0, doNotSkipRanges)).toEqual([
-        { from: 1, to: 13, text: "Paragraph 1", id: "0-from:1-to:13" },
-        { from: 14, to: 26, text: "Paragraph 2", id: "0-from:14-to:26" },
+        {
+          from: 1,
+          to: 13,
+          text: "Paragraph 1",
+          id: "0-from:1-to:13",
+          skipRanges: []
+        },
+        {
+          from: 14,
+          to: 26,
+          text: "Paragraph 2",
+          id: "0-from:14-to:26",
+          skipRanges: []
+        },
         {
           from: 29,
           to: 41,
           text: "List item 1",
-          id: "0-from:29-to:41"
+          id: "0-from:29-to:41",
+          skipRanges: []
         },
         {
           from: 42,
           to: 54,
           text: "List item 2",
-          id: "0-from:42-to:54"
+          id: "0-from:42-to:54",
+          skipRanges: []
         }
       ]);
     });

--- a/src/ts/utils/test/range.spec.ts
+++ b/src/ts/utils/test/range.spec.ts
@@ -350,36 +350,36 @@ describe("Range utils", () => {
   });
   describe("mapAddedRange", () => {
     it("should account for a range added before the given range", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const addedRange = { from: 0, to: 5 };
-      expect(mapAddedRange(incomingRange, addedRange)).toEqual({
+      expect(mapAddedRange(currentRange, addedRange)).toEqual({
         from: 16,
         to: 21
       });
     });
 
     it("should account for a range added within the given range", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const addedRange = { from: 10, to: 15 };
-      expect(mapAddedRange(incomingRange, addedRange)).toEqual({
+      expect(mapAddedRange(currentRange, addedRange)).toEqual({
         from: 16,
         to: 21
       });
     });
 
     it("should account for a range added partially within the given range – left hand side", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const addedRange = { from: 5, to: 12 };
-      expect(mapAddedRange(incomingRange, addedRange)).toEqual({
+      expect(mapAddedRange(currentRange, addedRange)).toEqual({
         from: 18,
         to: 23
       });
     });
 
     it("should account for a range added partially the given range – right hand side", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const addedRange = { from: 13, to: 20 };
-      expect(mapAddedRange(incomingRange, addedRange)).toEqual({
+      expect(mapAddedRange(currentRange, addedRange)).toEqual({
         from: 10,
         to: 23
       });
@@ -387,35 +387,35 @@ describe("Range utils", () => {
   });
   describe("mapRemovedRange", () => {
     it("should account for a range removed before the given range", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const removedRange = { from: 0, to: 5 };
-      expect(mapRemovedRange(incomingRange, removedRange)).toEqual({
+      expect(mapRemovedRange(currentRange, removedRange)).toEqual({
         from: 4,
         to: 9
       });
     });
 
     it("should account for a range completely removed within the given range", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const removedRange = { from: 10, to: 15 };
-      expect(mapRemovedRange(incomingRange, removedRange)).toEqual({
+      expect(mapRemovedRange(currentRange, removedRange)).toEqual({
         from: 10,
         to: 10
       });
     });
     it("should account for a range partially removed within the given range – left hand side", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const removedRange = { from: 5, to: 12 };
-      expect(mapRemovedRange(incomingRange, removedRange)).toEqual({
+      expect(mapRemovedRange(currentRange, removedRange)).toEqual({
         from: 4,
         to: 7
       });
     });
 
     it("should account for a range partially within the given range – right hand side", () => {
-      const incomingRange = { from: 10, to: 15 };
+      const currentRange = { from: 10, to: 15 };
       const removedRange = { from: 13, to: 20 };
-      expect(mapRemovedRange(incomingRange, removedRange)).toEqual({
+      expect(mapRemovedRange(currentRange, removedRange)).toEqual({
         from: 10,
         to: 13
       });


### PR DESCRIPTION
## What's changed?

This PR adds logic to remove skipped ranges from blocks we send to our matcher service, and map returned matches through those ranges.

This was originally [implemented on the server](https://github.com/guardian/typerighter/pull/85), and in the accompanying PR there were a few notes as to why we'd made that choice. This PR effectively moves this logic to the client. 

This is because it's very difficult to debug problems with `skipRanges` logic that spans client and server. At the moment, we produce skipped ranges on the client, pass the block in its entirety to the server with the skippedRanges included, and rely on the server to do the right thing. But, if the server does the _wrong_ thing, it's difficult to understand where the problem lies –
- are the skippedRanges incorrectly placed?
- have the skippedRanges been incorrectly applied to the text?
- have the skippedRanges been incorrectly applied to the match?
- is the match incorrect?

Keeping all of the skipRanges logic on the client reduces the surface area of an investigation, by ensuring that the server only sees text. cc @sihil @aug24 

More detail about the problem below.

## Problem 

At the moment, when a match touches e.g. noted text, it's discarded when we try to add it to the document.

But we still check against noted text on the server. This can cause problems. E.g. for a rule that checks to see if the start of a sentence is capped up, where square brackets denote a noted range:

`... end of an example sentence[.] or is it?`

Typerighter will see

`... end of an example sentence. or is it?`

and we'll get a match suggesting `or -> Or` – but we want Typerighter to see

`... end of an example sentence or is it?`

## What's changed?

This PR removes the ranges returned by `getSkippedRanges` from blocks before they're sent to the matcher service, and maps matches returned from this service through those ranges to ensure they're placed correctly.

For example, given the phrase 
```
Example [noted ]text
|       |      |   |
0       8      15  19
```
 and a match for `text`:
- we remove the skipped ranges from the block text, so the snippet `[noted ]` is removed for the range `(8, 15)`
- the matcher service sees `Example text` where `text` covers the range `(8, 12)`
- the matcher service returns a match covering range `(8, 12)`
- the final match is mapped back through the skipped range on it to the correct position, `(16, 19)`

## How to test

The automated tests should be thorough and pass as expected.

Follow the instructions in [prosemirror-typerighter PR that introduced the `getSkippedRanges` function] (https://github.com/guardian/prosemirror-typerighter/pull/151) for an easy way to test manually.

## Definition of Success

Skipped ranges aren't seen by checkers, and their presence doesn't disturb the position of matches in the document.