### PR TITLE
fix: Remove matches when range edge touched

### DIFF
--- a/build/rollup.config.build.js
+++ b/build/rollup.config.build.js
@@ -19,7 +19,7 @@ export default [
       format: "cjs"
     },
     plugins,
-    external: ["snarkdown"]
+    external: ["snarkdown", "prosemirror-changeset"]
   },
   {
     input: "src/ts/index.ts",
@@ -28,6 +28,6 @@ export default [
       format: "es"
     },
     plugins,
-    external: ["snarkdown"]
+    external: ["snarkdown", "prosemirror-changeset"]
   }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8842,6 +8842,14 @@
         "react-is": "^16.8.1"
       }
     },
+    "prosemirror-changeset": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.1.2.tgz",
+      "integrity": "sha512-/eeAM2XeOFmtiPsFVfVkM3Iq4xfNlFuDB6MlC8Hqch/ibq3YlH3YxDi8fqg78fT8fkrfvN6zRu9EE0HkSmH8PA==",
+      "requires": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
     "prosemirror-commands": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@popperjs/core": "^2.4.4",
     "diff": "^4.0.2",
     "lodash": "^4.17.11",
+    "prosemirror-changeset": "^2.1.2",
     "prosemirror-tables": "^0.7.8",
     "prosemirror-utils": "^0.6.7",
     "react": "^16.13.1",

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,12 +1,182 @@
 declare module "prosemirror-test-builder";
 declare module "prosemirror-example-setup";
-declare module "prosemirror-changeset";
+
+// Taken from: https://gist.github.com/colelawrence/8e7051417b7e87dbf014ee4bb8bdd020
+declare module "prosemirror-changeset" {
+  type StepMap = import("prosemirror-transform").StepMap;
+  type Node = import("prosemirror-model").Node;
+
+  /**
+   * :: ([Change], Node) → [Change]
+   *
+   * Simplifies a set of changes for presentation. This makes the
+   * assumption that having both insertions and deletions within a word
+   * is confusing, and, when such changes occur without a word boundary
+   * between them, they should be expanded to cover the entire set of
+   * words (in the new document) they touch. An exception is made for
+   * single-character replacements.
+   *
+   * [simplify.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/simplify.js#L51-L67)
+   */
+  function simplifyChanges(changes: Change[], doc: Node): unknown[];
+
+  /**
+   * Stores metadata for a part of a change.
+   * [change.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/change.js#L2)
+   */
+  class Span {
+    length: number;
+    data: any;
+    constructor(length: number, data: any);
+
+    cut(length: number): Span;
+
+    static slice(spans: Span[], from: number, to: number): Span[];
+
+    static join(
+      a: Span[],
+      b: Span[],
+      combine: (dataA: any, dataB: any) => any
+    ): Span[];
+
+    /** Sum the length of each span .length */
+    static len(spans: Span[]): number;
+
+    static none: [];
+  }
+
+  /**
+   * A replaced range with metadata associated with it.
+   * [change.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/change.js#L48)
+   */
+  class Change {
+    /** The start of the range deleted/replaced in the old document. */
+    fromA: number;
+    /** The end of the range in the old document. */
+    toA: number;
+    /** The start of the range inserted in the new document. */
+    fromB: number;
+    /** The end of the range in the new document. */
+    toB: number;
+    /** Data associated with the deleted content. The length of these spans adds up to `this.toA - this.fromA`. */
+    deleted: Span[];
+    /** Data associated with the inserted content. Length adds up to `this.toB - this.toA`. */
+    inserted: Span[];
+
+    constructor(
+      fromA: number,
+      toA: number,
+      fromB: number,
+      toB: number,
+      deleted: Span[],
+      inserted: Span[]
+    );
+
+    get lenA(): number;
+    get lenB(): number;
+
+    slice(startA: number, endA: number, startB: number, endB: number): Change;
+
+    /** : ([Change], [Change], (any, any) → any) → [Change]
+     *
+     * This merges two changesets (the end document of x should be the
+     * start document of y) into a single one spanning the start of x to
+     * the end of y.
+     */
+    static merge(
+      x: Change[],
+      y: Change[],
+      combine: (dataA: any, dataB: any) => any
+    ): Change[];
+  }
+
+  type ChangeSetConfig = {
+    doc: Node;
+    combine: <T>(a: T, b: T) => T;
+  };
+
+  /**
+   * ::- A change set tracks the changes to a document from a given
+   * point in the past. It condenses a number of step maps down to a
+   * flat sequence of replacements, and simplifies replacments that
+   * partially undo themselves by comparing their content.
+   *
+   * [changeset.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/changeset.js#L6-L10)
+   */
+  class ChangeSet {
+    config: ChangeSetConfig;
+    /** Replaced regions. */
+    changes: Change[];
+
+    constructor(config: ChangeSetConfig, changes: Change[]);
+
+    /**
+     * :: (Node, [StepMap], union<[any], any>) → ChangeSet
+     *
+     * Computes a new changeset by adding the given step maps and
+     * metadata (either as an array, per-map, or as a single value to be
+     * associated with all maps) to the current set. Will not mutate the
+     * old set.
+     *
+     * Note that due to simplification that happens after each add,
+     * incrementally adding steps might create a different final set
+     * than adding all those changes at once, since different document
+     * tokens might be matched during simplification depending on the
+     * boundaries of the current changed ranges.
+     *
+     * [changeset.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/changeset.js#L17-L28)
+     */
+    addSteps(newDoc: Node, maps: StepMap[], data: any | any[]): ChangeSet;
+
+    /** The starting document of the change set. */
+    get startDoc(): Node;
+
+    /**
+     * :: (f: (range: Change) → any) → ChangeSet
+     *
+     * Map the span's data values in the given set through a function
+     * and construct a new set with the resulting data.
+     *
+     * [changeset.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/changeset.js#L92)
+     */
+    map(f: (range: Change) => any): ChangeSet;
+
+    /**
+     * :: (ChangeSet, ?[StepMap]) → ?{from: number, to: number}
+     *
+     * Compare two changesets and return the range in which they are
+     * changed, if any. If the document changed between the maps, pass
+     * the maps for the steps that changed it as second argument, and
+     * make sure the method is called on the old set and passed the new
+     * set. The returned positions will be in new document coordinates.
+     *
+     * [changeset.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/changeset.js#L100-L106)
+     */
+    changedRange(
+      b: ChangeSet,
+      maps?: StepMap[]
+    ): null | { from: number; to: number };
+
+    /**
+     * :: (Node, ?(a: any, b: any) → any) → ChangeSet
+     *
+     * Create a changeset with the given base object and configuration.
+     * The `combine` function is used to compare and combine metadata—it
+     * should return null when metadata isn't compatible, and a combined
+     * version for a merged range when it is.
+     *
+     * [changeset.js source](https://github.com/ProseMirror/prosemirror-changeset/blob/11cb7b1fc05357c0bac5c444eab48748e4c8aa3b/src/changeset.js#L130-L137)
+     */
+    static create(doc: Node, combine?: <T>(a: T, b: T) => T | null): ChangeSet;
+  }
+}
+
 // Taken from https://github.com/developit/snarkdown/blob/master/snarkdown.d.ts –
 // at time of writing the typescript definition file is not yet in the npm release.
 declare module "snarkdown" {
   interface Links {
     [index: string]: string;
   }
-  export default function (urlStr: string, prevLinks?: Links): string;
+  export default function(urlStr: string, prevLinks?: Links): string;
 }
 declare module "*.scss";

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,5 +1,6 @@
 declare module "prosemirror-test-builder";
 declare module "prosemirror-example-setup";
+declare module "prosemirror-changeset";
 // Taken from https://github.com/developit/snarkdown/blob/master/snarkdown.d.ts –
 // at time of writing the typescript definition file is not yet in the npm release.
 declare module "snarkdown" {

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -15,7 +15,7 @@ import {
 import { EditorView } from "prosemirror-view";
 import { Plugin, Transaction, EditorState } from "prosemirror-state";
 import { expandRangesToParentBlockNode } from "./utils/range";
-import { getReplaceStepRangesFromTransaction } from "./utils/prosemirror";
+import { getDirtiedRangesFromTransaction } from "./utils/prosemirror";
 import { IRange, IMatch } from "./interfaces/IMatch";
 import { Node } from "prosemirror-model";
 import Store, {
@@ -148,10 +148,10 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
       const oldPluginState: TPluginState = plugin.getState(oldState);
       const newPluginState: TPluginState = plugin.getState(newState);
 
-      const tr = newState.tr;
+      const newTr = newState.tr;
 
       const newDirtiedRanges = trs.reduce(
-        (acc, range) => acc.concat(getReplaceStepRangesFromTransaction(range)),
+        (acc, tr) => acc.concat(getDirtiedRangesFromTransaction(oldState.doc, tr)),
         [] as IRange[]
       );
       if (newDirtiedRanges.length) {
@@ -161,7 +161,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
           // @todo -- this is a bit of a hack, it can be done better.
           setTimeout(() => store.emit(STORE_EVENT_NEW_DIRTIED_RANGES));
         }
-        return tr.setMeta(
+        return newTr.setMeta(
           PROSEMIRROR_TYPERIGHTER_ACTION,
           applyNewDirtiedRanges(newDirtiedRanges)
         );

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -468,7 +468,7 @@ const handleNewDirtyRanges = <TPluginState extends IPluginState>(
   // and we need to ensure that the range includes the cursor position before it.
   newDecorations = removeDecorationsFromRanges(newDecorations, dirtiedRanges);
   const currentMatches = state.currentMatches.filter(
-    output => findOverlappingRangeIndex(output, dirtiedRanges, -1) !== -1
+    output => findOverlappingRangeIndex(output, dirtiedRanges, -1) === -1
   );
 
   return {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -456,7 +456,7 @@ const handleNewDirtyRanges = <TPluginState extends IPluginState>(
   { payload: { ranges: dirtiedRanges } }: ActionHandleNewDirtyRanges
 ): TPluginState => {
   // Map our dirtied ranges through the current transaction, and append any new ranges it has dirtied.
-  const newDecorations = state.config.debug
+  let newDecorations = state.config.debug
     ? state.decorations.add(
         tr.doc,
         dirtiedRanges.map(range => createDebugDecorationFromRange(range))
@@ -466,7 +466,7 @@ const handleNewDirtyRanges = <TPluginState extends IPluginState>(
   // Remove any matches and associated decorations touched by the dirtied ranges from the doc
   // We are providing a from offset of -1 as the range provides a cursor position,
   // and we need to ensure that the range includes the cursor position before it.
-
+  newDecorations = removeDecorationsFromRanges(newDecorations, dirtiedRanges);
   const currentMatches = state.currentMatches.filter(output =>
     findOverlappingRangeIndex(output, dirtiedRanges, -1)
   );

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -464,11 +464,9 @@ const handleNewDirtyRanges = <TPluginState extends IPluginState>(
     : state.decorations;
 
   // Remove any matches and associated decorations touched by the dirtied ranges from the doc
-  // We are providing a from offset of -1 as the range provides a cursor position,
-  // and we need to ensure that the range includes the cursor position before it.
   newDecorations = removeDecorationsFromRanges(newDecorations, dirtiedRanges);
   const currentMatches = state.currentMatches.filter(
-    output => findOverlappingRangeIndex(output, dirtiedRanges, -1) === -1
+    output => findOverlappingRangeIndex(output, dirtiedRanges) === -1
   );
 
   return {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -52,7 +52,8 @@ import {
   mapAndMergeRanges,
   mapRanges,
   findOverlappingRangeIndex,
-  removeOverlappingRanges
+  removeOverlappingRanges,
+  findAbuttingRangeIndex
 } from "../utils/range";
 import { ExpandRanges, IFilterOptions } from "../createTyperighterPlugin";
 import { getBlocksFromDocument } from "../utils/prosemirror";
@@ -467,7 +468,9 @@ const handleNewDirtyRanges = <TPluginState extends IPluginState>(
   // touched by the dirtied ranges from the doc
   newDecorations = removeDecorationsFromRanges(newDecorations, dirtiedRanges);
   const currentMatches = state.currentMatches.filter(
-    output => findOverlappingRangeIndex(output, dirtiedRanges) === -1
+    output =>
+      findOverlappingRangeIndex(output, dirtiedRanges) === -1 &&
+      findAbuttingRangeIndex(output, dirtiedRanges) === -1
   );
 
   return {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -467,8 +467,8 @@ const handleNewDirtyRanges = <TPluginState extends IPluginState>(
   // We are providing a from offset of -1 as the range provides a cursor position,
   // and we need to ensure that the range includes the cursor position before it.
   newDecorations = removeDecorationsFromRanges(newDecorations, dirtiedRanges);
-  const currentMatches = state.currentMatches.filter(output =>
-    findOverlappingRangeIndex(output, dirtiedRanges, -1)
+  const currentMatches = state.currentMatches.filter(
+    output => findOverlappingRangeIndex(output, dirtiedRanges, -1) !== -1
   );
 
   return {

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -12,6 +12,7 @@ import createTyperighterPlugin, {
   IPluginOptions
 } from "../createTyperighterPlugin";
 import { createMatch, createMatcherResponse } from "./helpers/fixtures";
+import { createEditor } from "./helpers/createEditor";
 import { createBoundCommands } from "../commands";
 import { IMatch, IMatcherResponse } from "../interfaces/IMatch";
 import { getBlocksFromDocument } from "../utils/prosemirror";
@@ -55,6 +56,65 @@ describe("createTyperighterPlugin", () => {
   it("should add matches passed to the plugin to the plugin state when the plugin is constructed", () => {
     const { getState, view } = createPlugin();
     expect(getState(view.state).currentMatches).toEqual(matches);
+  });
+  describe("Match persistence/removal", () => {
+    it("should add matches to the document by default", () => {
+      const { editorElement } = createEditor("123456", [createMatch(2, 4)]);
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBeTruthy()
+    });
+    it("should remove matches when the user makes an edit that overlaps them", () => {
+      const { editorElement, view } = createEditor("123456", [createMatch(2, 4)]);
+
+      const tr = view.state.tr
+      tr.delete(3, 5)
+      view.dispatch(tr);
+
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBe(null)   
+    });
+    it("should remove matches when the user makes an insert that abuts them – rhs", () => {
+      const { editorElement, view } = createEditor("123456", [createMatch(2, 4)]);
+
+      const tr = view.state.tr
+      tr.insertText("A", 4);
+      view.dispatch(tr);
+
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBe(null)
+    });
+    it("should remove matches when the user makes an insert that abuts them - lhs", () => {
+      const { editorElement, view } = createEditor("123456", [createMatch(2, 4)]);
+
+      const tr = view.state.tr
+      tr.insertText("A", 1);
+      view.dispatch(tr);
+
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBe(null);
+    });
+    it("should not remove matches when the user makes an edit that doesn't overlap or abut them", () => {
+      const { editorElement, view } = createEditor("123456", [createMatch(2, 4)]);
+
+      const tr = view.state.tr
+      tr.insertText("A", 5);
+      view.dispatch(tr);
+
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBeTruthy()
+    });
+    it("should not remove matches when the user makes a deletion to the left hand side of the match that doesn't cover its range", () => {
+      // @todo – this fails at the moment, as our change detection overestimates
+      // the range affected by delete operations.
+      const { editorElement, view } = createEditor("123456", [createMatch(3, 5)]);
+
+      const tr = view.state.tr
+      tr.delete(1, 2);
+      view.dispatch(tr);
+
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBeTruthy()
+    });
   });
   it("should trigger onMatches when matches are found in the document", () => {
     const { store, commands } = createPlugin();

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -87,7 +87,7 @@ describe("createTyperighterPlugin", () => {
       const { editorElement, view } = createEditor("123456", [createMatch(2, 4)]);
 
       const tr = view.state.tr
-      tr.insertText("A", 1);
+      tr.insertText("A", 2);
       view.dispatch(tr);
 
       const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;

--- a/src/ts/test/helpers/createEditor.ts
+++ b/src/ts/test/helpers/createEditor.ts
@@ -58,5 +58,5 @@ export const createEditor = (htmlDoc: string, matches: IMatch[] = []) => {
     new TyperighterAdapter("https://api.typerighter.local.dev-gutools.co.uk")
   );
 
-  return { editorElement, view, commands };
+  return { editorElement, view, commands, schema: mySchema };
 };

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -68,8 +68,8 @@ export const removeDecorationsFromRanges = (
   decorationSet: DecorationSet,
   ranges: IRange[],
   types = [DECORATION_MATCH, DECORATION_MATCH_HEIGHT_MARKER]
-) =>
-  ranges.reduce((acc, range) => {
+) =>{
+  return ranges.reduce((acc, range) => {
     const predicate = (spec: { [key: string]: any }) =>
       types.indexOf(spec.type) !== -1;
     const decorations = decorationSet.find(range.from, range.to, predicate);
@@ -86,6 +86,8 @@ export const removeDecorationsFromRanges = (
     );
     return acc.remove(decorationsToRemove);
   }, decorationSet);
+}
+
 
 /**
  * Given a matcher response and the current decoration set,

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -68,8 +68,8 @@ export const removeDecorationsFromRanges = (
   decorationSet: DecorationSet,
   ranges: IRange[],
   types = [DECORATION_MATCH, DECORATION_MATCH_HEIGHT_MARKER]
-) =>{
-  return ranges.reduce((acc, range) => {
+) =>
+  ranges.reduce((acc, range) => {
     const predicate = (spec: { [key: string]: any }) =>
       types.indexOf(spec.type) !== -1;
     const decorations = decorationSet.find(range.from, range.to, predicate);
@@ -86,8 +86,6 @@ export const removeDecorationsFromRanges = (
     );
     return acc.remove(decorationsToRemove);
   }, decorationSet);
-}
-
 
 /**
  * Given a matcher response and the current decoration set,
@@ -213,20 +211,28 @@ export const maybeGetDecorationElement = (
 ): HTMLElement | null =>
   document.querySelector(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);
 
-const getProseMirrorOffsetValue = (element: HTMLElement, scrollElement: Element): number => {
+const getProseMirrorOffsetValue = (
+  element: HTMLElement,
+  scrollElement: Element
+): number => {
   var offset = element.offsetTop;
 
-  if(element.offsetParent && !element.isEqualNode(scrollElement)){
-    return offset += getProseMirrorOffsetValue(element.offsetParent as HTMLElement, scrollElement);
+  if (element.offsetParent && !element.isEqualNode(scrollElement)) {
+    return (offset += getProseMirrorOffsetValue(
+      element.offsetParent as HTMLElement,
+      scrollElement
+    ));
   }
 
   return offset;
-}
+};
 
 export const getMatchOffset = (
   matchId: string,
   scrollElement: Element
 ): number => {
-  const element = document.querySelector<HTMLElement>(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);
+  const element = document.querySelector<HTMLElement>(
+    `[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`
+  );
   return element ? getProseMirrorOffsetValue(element, scrollElement) : 0;
-}
+};

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -1,7 +1,6 @@
 import { Node, Mark, Schema, MarkType } from "prosemirror-model";
 import { Transaction } from "prosemirror-state";
-import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
-import { ChangeSet } from 'prosemirror-changeset';
+import { ChangeSet } from "prosemirror-changeset";
 import * as jsDiff from "diff";
 
 import { IBlock, IRange } from "../interfaces/IMatch";
@@ -69,15 +68,16 @@ export const getBlocksFromDocument = (
 /**
  * Get all of the ranges of any replace steps in the given transaction.
  */
-export const getDirtiedRangesFromTransaction = (oldDoc: Node, tr: Transaction) => {
-
-    const changeSet = ChangeSet.create(oldDoc).addSteps(tr.doc, tr.mapping.maps);
-    console.log(changeSet.changes);
-    return {
-      from: 0,
-      to: 0
-    };
-  }
+export const getDirtiedRangesFromTransaction = (
+  oldDoc: Node,
+  tr: Transaction
+) => {
+  const changeSet = ChangeSet.create(oldDoc).addSteps(tr.doc, tr.mapping.maps);
+  return changeSet.changes.map((change: any) => ({
+    from: change.fromB,
+    to: change.toB
+  }));
+};
 
 /**
  * A patch representing part, or all, of a suggestion, to apply to the document.
@@ -92,7 +92,7 @@ interface IBaseSuggestionPatch {
 }
 
 interface ISuggestionPatchDelete extends IBaseSuggestionPatch {
-  type: "DELETE"
+  type: "DELETE";
 }
 
 interface ISuggestionPatchInsert extends IBaseSuggestionPatch {
@@ -105,7 +105,7 @@ interface ISuggestionPatchInsert extends IBaseSuggestionPatch {
   getMarks: (tr: Transaction) => Array<Mark<any>>;
 }
 
-type ISuggestionPatch = ISuggestionPatchInsert | ISuggestionPatchDelete
+type ISuggestionPatch = ISuggestionPatchInsert | ISuggestionPatchDelete;
 
 /**
  * Generates a minimal array of replacement nodes and ranges from two pieces of text.
@@ -163,7 +163,8 @@ export const getPatchesFromReplacementText = (
       }
 
       const prevFragment = currentFragments[currentFragments.length - 1];
-      const isInsertionThatFollowsUnalteredRange = !!prevFragment && (prevFragment.to || 0) < newFrom;
+      const isInsertionThatFollowsUnalteredRange =
+        !!prevFragment && (prevFragment.to || 0) < newFrom;
 
       let getMarks;
       if (isInsertionThatFollowsUnalteredRange) {
@@ -171,7 +172,7 @@ export const getPatchesFromReplacementText = (
         // from the character that precedes this patch. This ensures that text that expands
         // upon an existing range shares the existing range's style.
         getMarks = (localTr: Transaction) => {
-          const $newFrom = localTr.doc.resolve(newFrom)
+          const $newFrom = localTr.doc.resolve(newFrom);
           const $lastCharFrom = localTr.doc.resolve(newFrom - 1);
           return $lastCharFrom.marksAcross($newFrom) || Mark.none;
         };
@@ -179,9 +180,9 @@ export const getPatchesFromReplacementText = (
         // If this patch is a replacement, find all of the marks
         // that span the text we're replacing, and copy them across.
         getMarks = (localTr: Transaction) => {
-          const $newTo = localTr.doc.resolve(newTo)
+          const $newTo = localTr.doc.resolve(newTo);
           return localTr.doc.resolve(newFrom).marksAcross($newTo) || Mark.none;
-        }
+        };
       }
 
       const newFragment: ISuggestionPatchInsert = {

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -1,6 +1,6 @@
 import { Node, Mark, Schema, MarkType } from "prosemirror-model";
 import { Transaction } from "prosemirror-state";
-import { ChangeSet } from "prosemirror-changeset";
+import { Change, ChangeSet } from "prosemirror-changeset";
 import * as jsDiff from "diff";
 
 import { IBlock, IRange } from "../interfaces/IMatch";
@@ -72,8 +72,8 @@ export const getDirtiedRangesFromTransaction = (
   oldDoc: Node,
   tr: Transaction
 ) => {
-  const changeSet = ChangeSet.create(oldDoc).addSteps(tr.doc, tr.mapping.maps);
-  return changeSet.changes.map((change: any) => ({
+  const changeSet: ChangeSet = ChangeSet.create(oldDoc).addSteps(tr.doc, tr.mapping.maps, null);
+  return changeSet.changes.map((change: Change) => ({
     from: change.fromB,
     to: change.toB
   }));

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -1,6 +1,7 @@
 import { Node, Mark, Schema, MarkType } from "prosemirror-model";
 import { Transaction } from "prosemirror-state";
 import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
+import { ChangeSet } from 'prosemirror-changeset';
 import * as jsDiff from "diff";
 
 import { IBlock, IRange } from "../interfaces/IMatch";
@@ -68,21 +69,15 @@ export const getBlocksFromDocument = (
 /**
  * Get all of the ranges of any replace steps in the given transaction.
  */
-export const getReplaceStepRangesFromTransaction = (tr: Transaction) =>
-  getReplaceTransactions(tr).map((step: ReplaceStep | ReplaceAroundStep) => {
-    return {
-      from: (step as any).from,
-      to: (step as any).to
-    };
-  });
+export const getDirtiedRangesFromTransaction = (oldDoc: Node, tr: Transaction) => {
 
-/**
- * Get all of the ranges of any replace steps in the given transaction.
- */
-export const getReplaceTransactions = (tr: Transaction) =>
-  tr.steps.filter(
-    step => step instanceof ReplaceStep || step instanceof ReplaceAroundStep
-  );
+    const changeSet = ChangeSet.create(oldDoc).addSteps(tr.doc, tr.mapping.maps);
+    console.log(changeSet.changes);
+    return {
+      from: 0,
+      to: 0
+    };
+  }
 
 /**
  * A patch representing part, or all, of a suggestion, to apply to the document.

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -7,30 +7,22 @@ import { IBlock } from "../interfaces/IMatch";
 import { Mapping } from "prosemirror-transform";
 
 /**
- * Find the index of the first range in the given range array that overlaps with the given range.
+ * Find the index of the first range in the given range array that overlaps/abuts with the given range.
  */
-export const findOverlappingRangeIndex = (range: IRange, ranges: IRange[]) => {
+export const findOverlappingRangeIndex = (
+  range: IRange,
+  ranges: IRange[],
+  fromOffset: number = 0
+) => {
+  const offsetRangeFrom = range.from + fromOffset;
   return ranges.findIndex(
     localRange =>
-      // Overlaps to the left of the range
-      (localRange.from <= range.from && localRange.to >= range.from) ||
+      // Overlaps (or abuts if an offset of -1 is given) to the left of the range
+      (localRange.from <= range.from && localRange.to >= offsetRangeFrom) ||
       // Overlaps within the range
       (localRange.to >= range.to && localRange.from <= range.to) ||
       // Overlaps to the right of the range
       (localRange.from >= range.from && localRange.to <= range.to)
-  );
-};
-
-/**
- * Find the index of the first range in the given range array that abuts the left side of the given range.
- * (Abutting to the right is taken care of by findOverlappingRangeIndex.)
- */
-export const findAbuttingRangeIndex = (
-  decoratedRange: IRange,
-  dirtiedRanges: IRange[]
-) => {
-  return dirtiedRanges.findIndex(
-    dirtiedRange => dirtiedRange.to === decoratedRange.from - 1
   );
 };
 

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -12,19 +12,16 @@ import { Mapping } from "prosemirror-transform";
 export const findOverlappingRangeIndex = (
   range: IRange,
   ranges: IRange[],
-  fromOffset: number = 0
-) => {
-  const offsetRangeFrom = range.from + fromOffset;
-  return ranges.findIndex(
+) => ranges.findIndex(
     localRange =>
-      // Overlaps (or abuts if an offset of -1 is given) to the left of the range
-      (localRange.from <= range.from && localRange.to >= offsetRangeFrom) ||
+      // Overlaps or abuts to the left of the range
+      (localRange.from <= range.from && localRange.to >= range.from) ||
       // Overlaps within the range
       (localRange.to >= range.to && localRange.from <= range.to) ||
-      // Overlaps to the right of the range
+      // Overlaps or abuts to the right of the range
       (localRange.from >= range.from && localRange.to <= range.to)
   );
-};
+
 
 export const mapAndMergeRanges = <Range extends IRange>(
   ranges: Range[],

--- a/src/ts/utils/test/prosemirror.spec.ts
+++ b/src/ts/utils/test/prosemirror.spec.ts
@@ -46,7 +46,7 @@ describe("Prosemirror utils", () => {
       const tr = view.state.tr
       tr.replaceWith(1, 5, schema.text("Replacement text"));
       expect(getDirtiedRangesFromTransaction(view.state.doc, tr)).toEqual([
-        { from: 1, to: 5 }
+        { from: 1, to: 17 }
       ]);
     });
     it("should get the ranges (with a to value that's the same as the from value) from any deleted text in the transaction", () => {
@@ -60,6 +60,20 @@ describe("Prosemirror utils", () => {
       // no length in document to which they've been applied.
       expect(getDirtiedRangesFromTransaction(view.state.doc, tr)).toEqual([
         { from: 1, to: 1 }
+      ]);
+    });
+    it("should get ranges from multiple steps", () => {
+      const { view } = createEditor(
+        `<p>Paragraph 1</p>
+         <p>Paragraph 2</p>`
+       )
+      const tr = view.state.tr
+      tr.deleteRange(1, 2);
+      tr.deleteRange(5, 6);
+
+      expect(getDirtiedRangesFromTransaction(view.state.doc, tr)).toEqual([
+        { from: 1, to: 1 },
+        { from: 5, to: 5 }
       ]);
     });
   });


### PR DESCRIPTION
## What does this change?

Adds the ability for a match and its associated decorations to be removed when the user clicks immediately to the left of it (this behaviour already existing for user clicking to the immediate right of a match).

## How to test

- Locally, check the text: 'We an hope to address it.' You should get a match for 'an'.
- and a `c` to correct 'an' to 'can'. The match should disappear from the document and Typerighter panel.

## How can we measure success?
A match will disappear after the user has typed something immediately next to it, both its decoration in the document and its entry in the Typerighter panel.

## Images

### Before

![remove_abutting_before](https://user-images.githubusercontent.com/15648334/98671643-79083600-234c-11eb-82b4-19cb4c06cbf2.gif)

### After

![remove_abutting](https://user-images.githubusercontent.com/15648334/98671424-23338e00-234c-11eb-8543-ad014cf3dfa3.gif)
