### PR TITLE
fix: popover placement issue

### DIFF
--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -82,7 +82,7 @@ export const requestMatchesForDirtyRangesCommand = (
 /**
  * Indicate the user is hovering over a match.
  */
-export const startHoverCommand = (matchId: string): Command => (
+export const startHoverCommand = (matchId: string, rectIndex: number | undefined): Command => (
   state,
   dispatch
 ) => {
@@ -90,7 +90,7 @@ export const startHoverCommand = (matchId: string): Command => (
     dispatch(
       state.tr.setMeta(
         PROSEMIRROR_TYPERIGHTER_ACTION,
-        newHoverIdReceived(matchId)
+        newHoverIdReceived(matchId, rectIndex)
       )
     );
   }
@@ -105,7 +105,7 @@ export const stopHoverCommand = (): Command => (state, dispatch) => {
     dispatch(
       state.tr.setMeta(
         PROSEMIRROR_TYPERIGHTER_ACTION,
-        newHoverIdReceived(undefined)
+        newHoverIdReceived(undefined, undefined)
       )
     );
   }

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -87,16 +87,18 @@ const matchOverlay = <TPluginState extends IPluginState>({
     if (referenceElement && currentRectIndex !== undefined && (isTop || isBottom)) {
       const rects = referenceElement?.getClientRects();
       const hoverRect = rects[currentRectIndex];
-      const lastRect = rects[rects.length - 1]
+      const lastRect = rects[rects.length - 1];
       //Determine the X offset as the difference between the last rect (bottom left) and the current rect.
-      const x = hoverRect.left - lastRect.left
+      //This will only work if the placement is set to the "bottom-start". If we wanted to change this we
+      //would need to build more flexibility into how this is calculated. 
+      const x = hoverRect.left - lastRect.left;
       //Determine the Y offset by taking the rect height and multiplying by the number of rects (lines)
       //This adjustment depends on if the popup is displayed above or below the content.
       const heightMultiplier = isBottom ? Math.max(0, rects.length - 1 - currentRectIndex) : currentRectIndex;
       const y = -hoverRect.height * heightMultiplier;
-      return [x, y + yOffset]
+      return [x, y + yOffset];
     }
-    return [0, yOffset]
+    return [0, yOffset];
   }, [referenceElement, currentRectIndex])
 
   const { styles, attributes } = usePopper(referenceElement, popperElement, {

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -78,7 +78,7 @@ const matchOverlay = <TPluginState extends IPluginState>({
   const getOffsets = React.useMemo(() => ({ placement }: {placement: Placement}): [number | null | undefined, number | null | undefined] => {
     const isTop = placement.indexOf("top") >= 0;
     const isBottom = placement.indexOf("bottom") >= 0
-    if(referenceElement && currentRectIndex != undefined && (isTop || isBottom)){
+    if(referenceElement && currentRectIndex !== undefined && (isTop || isBottom)){
       const rects = referenceElement?.getClientRects();
       const hoverRect = rects[currentRectIndex];
       const lastRect = rects[rects.length-1]

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -27,6 +27,7 @@ import { doNotSkipRanges, TGetSkippedRanges } from "./utils/block";
 import { startHoverCommand, stopHoverCommand } from "./commands";
 import { TFilterMatches, maybeResetHoverStates } from "./utils/plugin";
 import { pluginKey } from "./utils/plugin";
+import { getClientRectIndex } from "./utils/clientRect";
 
 export type ExpandRanges = (ranges: IRange[], doc: Node<any>) => IRange[];
 
@@ -217,7 +218,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
           }
 
           if (newMatchId) {
-            startHoverCommand(newMatchId)(view.state, view.dispatch);
+            startHoverCommand(newMatchId, getClientRectIndex(event))(view.state, view.dispatch);
           } else {
             stopHoverCommand()(view.state, view.dispatch);
           }

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -75,9 +75,9 @@ export const requestMatchesComplete = (requestId: string) => ({
 });
 export type ActionRequestComplete = ReturnType<typeof requestMatchesComplete>;
 
-export const newHoverIdReceived = (matchId: string | undefined) => ({
+export const newHoverIdReceived = (matchId: string | undefined, rectIndex: number | undefined) => ({
   type: NEW_HOVER_ID,
-  payload: { matchId }
+  payload: { matchId, rectIndex }
 });
 export type ActionNewHoverIdReceived = ReturnType<typeof newHoverIdReceived>;
 

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -446,7 +446,7 @@ const createHandleNewFocusState = <TPluginState extends IPluginState>(
     );
   }, decorations);
 
-  var hoverRectIndex = undefined;
+  var hoverRectIndex = state.hoverRectIndex;
 
   if(action.type == "NEW_HOVER_ID"){
     hoverRectIndex = action.payload.rectIndex

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -135,7 +135,6 @@ export interface IPluginState<
   // By indicating which clientRect we're closest to, we can position our match
   // popup next to the correct section of the span.
   // See https://developer.mozilla.org/en-US/docs/Web/API/Element/getClientRects.
-  //This index used to know where to display a match popup
   hoverRectIndex: number | undefined;
   // The id of the match the user is currently highlighting –
   // triggers a focus state on the match decoration.

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -130,7 +130,8 @@ export interface IPluginState<
   // The id of the match the user is currently hovering over –
   // e.g. to display a tooltip.
   hoverId: string | undefined;
-  //The clientRectIndex of the hover mouseover event.
+  //The clientRectIndex of the hover mouseover event. 
+  //This index used to know where to display a match popup
   hoverRectIndex: number | undefined;
   // The id of the match the user is currently highlighting –
   // triggers a focus state on the match decoration.

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -130,7 +130,7 @@ export interface IPluginState<
   // The id of the match the user is currently hovering over –
   // e.g. to display a tooltip.
   hoverId: string | undefined;
-  // The index of the clientRect closest to hover mouseover event.
+  // The index of the clientRect closest to the hover mouseover event.
   // Spans can contain multiple clientRects when they're broken across lines.
   // By indicating which clientRect we're closest to, we can position our match
   // popup next to the correct section of the span.

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -130,7 +130,11 @@ export interface IPluginState<
   // The id of the match the user is currently hovering over –
   // e.g. to display a tooltip.
   hoverId: string | undefined;
-  //The clientRectIndex of the hover mouseover event. 
+  // The index of the clientRect closest to hover mouseover event.
+  // Spans can contain multiple clientRects when they're broken across lines.
+  // By indicating which clientRect we're closest to, we can position our match
+  // popup next to the correct section of the span.
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Element/getClientRects.
   //This index used to know where to display a match popup
   hoverRectIndex: number | undefined;
   // The id of the match the user is currently highlighting –

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -130,6 +130,8 @@ export interface IPluginState<
   // The id of the match the user is currently hovering over –
   // e.g. to display a tooltip.
   hoverId: string | undefined;
+  //The clientRectIndex of the hover mouseover event.
+  hoverRectIndex: number | undefined;
   // The id of the match the user is currently highlighting –
   // triggers a focus state on the match decoration.
   highlightId: string | undefined;
@@ -194,6 +196,7 @@ export const createInitialState = <
     filteredMatches: [] as TMatch[],
     selectedMatch: undefined,
     hoverId: undefined,
+    hoverRectIndex: undefined,
     highlightId: undefined,
     requestsInFlight: {},
     requestPending: false,
@@ -443,9 +446,16 @@ const createHandleNewFocusState = <TPluginState extends IPluginState>(
     );
   }, decorations);
 
+  var hoverRectIndex = undefined;
+
+  if(action.type == "NEW_HOVER_ID"){
+    hoverRectIndex = action.payload.rectIndex
+  }
+
   return {
     ...state,
     decorations,
+    hoverRectIndex,
     [focusState]: action.payload.matchId
   };
 };

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -472,7 +472,7 @@ describe("Action handlers", () => {
         reducer(
           new Transaction(createDoc),
           state,
-          newHoverIdReceived("exampleHoverId")
+          newHoverIdReceived("exampleHoverId", undefined)
         )
       ).toEqual({
         ...state,
@@ -507,7 +507,7 @@ describe("Action handlers", () => {
           createDecorationsForMatch(output, defaultMatchColours, false)
         )
       };
-      expect(reducer(tr, localState, newHoverIdReceived("match-id"))).toEqual({
+      expect(reducer(tr, localState, newHoverIdReceived("match-id", undefined))).toEqual({
         ...localState,
         decorations: new DecorationSet().add(
           tr.doc,
@@ -546,7 +546,7 @@ describe("Action handlers", () => {
         hoverInfo: undefined
       };
       expect(
-        reducer(tr, localState, newHoverIdReceived(undefined))
+        reducer(tr, localState, newHoverIdReceived(undefined, undefined))
       ).toEqual({
         ...localState,
         decorations: new DecorationSet().add(tr.doc, [

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -477,6 +477,7 @@ describe("Action handlers", () => {
       ).toEqual({
         ...state,
         hoverId: "exampleHoverId",
+        hoverRectIndex: undefined,
         hoverInfo: undefined
       });
     });
@@ -507,13 +508,14 @@ describe("Action handlers", () => {
           createDecorationsForMatch(output, defaultMatchColours, false)
         )
       };
-      expect(reducer(tr, localState, newHoverIdReceived("match-id", undefined))).toEqual({
+      expect(reducer(tr, localState, newHoverIdReceived("match-id", 1))).toEqual({
         ...localState,
         decorations: new DecorationSet().add(
           tr.doc,
           createDecorationsForMatch(output, defaultMatchColours, true)
         ),
         hoverId: "match-id",
+        hoverRectIndex: 1,
         hoverInfo: undefined
       });
     });
@@ -553,6 +555,7 @@ describe("Action handlers", () => {
           ...createDecorationsForMatch(output, defaultMatchColours, false)
         ]),
         hoverId: undefined,
+        hoverRectIndex: undefined,
         hoverInfo: undefined
       });
     });

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -198,6 +198,7 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       filteredMatches: [],
       selectedMatch: undefined,
       hoverId: undefined,
+      hoverRectIndex: undefined,
       highlightId: undefined,
       hoverInfo: undefined,
       trHistory: [tr],

--- a/src/ts/utils/clientRect.ts
+++ b/src/ts/utils/clientRect.ts
@@ -1,0 +1,23 @@
+export const getClientRectIndex = (event: Event): number | undefined => {
+
+    if (!event.target || !(event.target instanceof HTMLElement) || !(event instanceof MouseEvent)) {
+        return undefined;
+    }
+
+    const rects = event.target.getClientRects();
+
+    if(rects.length < 1) {
+        return 0;
+    }
+
+    for (var i = 0; i != rects.length; i++) {
+        const {left, right, top, bottom} = rects[i];
+        const {pageX, pageY} = event;
+
+        if(pageX >= left && pageX <= right && pageY >= top && pageY <= bottom){
+            return i;
+        }
+    }
+
+    return 0;
+}

--- a/src/ts/utils/clientRect.ts
+++ b/src/ts/utils/clientRect.ts
@@ -1,6 +1,11 @@
 const topBuffer = 2;
 const leftBuffer = 2;
 
+/**
+ * A function which takes a mouseover event and determines which part of the 
+ * div was hovered over by doing some basic collision detection. 
+ * The index of the hovered over rect from the getClientRects function is returned.
+ */
 export const getClientRectIndex = (event: Event): number | undefined => {
 
     if (!event.target || !(event.target instanceof HTMLElement) || !(event instanceof MouseEvent)) {

--- a/src/ts/utils/clientRect.ts
+++ b/src/ts/utils/clientRect.ts
@@ -1,3 +1,5 @@
+const topBuffer = 2;
+
 export const getClientRectIndex = (event: Event): number | undefined => {
 
     if (!event.target || !(event.target instanceof HTMLElement) || !(event instanceof MouseEvent)) {
@@ -14,7 +16,7 @@ export const getClientRectIndex = (event: Event): number | undefined => {
         const {left, right, top, bottom} = rects[i];
         const {pageX, pageY} = event;
 
-        if(pageX >= left && pageX <= right && pageY >= top && pageY <= bottom){
+        if(pageX >= left && pageX <= right && pageY >= top - topBuffer && pageY <= bottom){
             return i;
         }
     }

--- a/src/ts/utils/clientRect.ts
+++ b/src/ts/utils/clientRect.ts
@@ -1,4 +1,5 @@
 const topBuffer = 2;
+const leftBuffer = 2;
 
 export const getClientRectIndex = (event: Event): number | undefined => {
 
@@ -16,7 +17,7 @@ export const getClientRectIndex = (event: Event): number | undefined => {
         const {left, right, top, bottom} = rects[i];
         const {pageX, pageY} = event;
 
-        if(pageX >= left && pageX <= right && pageY >= top - topBuffer && pageY <= bottom){
+        if(pageX >= left - leftBuffer && pageX <= right && pageY >= top - topBuffer && pageY <= bottom){
             return i;
         }
     }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR handles the placement of popups on matches which cross multiple lines. This is important as previously some match popups would be impossible to reach due to their placement. 

This issue is fixed through the usage of `getClientRects` which provides a set of rectangles which an element covers, importantly with a separate rect per line. When the popup event is triggered on mouseover, the rect index is saved for reference. This is then used when determining the offsets of the popup and adjusting the offset X and Y based on the rect values.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run a document through TR, find a match which spans multiple lines, observe that it's possible to access a popup regardless of where the match is hovered over.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users are always able to access a match popup and they are placed in a sensible position. 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
It may be dangerous to second guess Popper's default behaviour and their may some unexpected issues a s result.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

BEFORE
![TRPOPUPOLD](https://user-images.githubusercontent.com/4633246/98799261-ca74fb80-2406-11eb-85c3-d9cc9cef39d8.gif)

AFTER
![TRPOPUP](https://user-images.githubusercontent.com/4633246/98799253-c812a180-2406-11eb-8896-75c61da62fa2.gif)
