### PR TITLE
feat: add telemetry on match decoration click

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -43,6 +43,12 @@ document.body.append(overlayNode);
 const isElementPartOfTyperighterUI = (element: HTMLElement) =>
   overlayNode.contains(element);
 
+const telemetryService = new TelemetryService("https://example.com");
+const typerighterTelemetryAdapter = new TyperighterTelemetryAdapter(
+  telemetryService,
+  "prosemirror-typerighter",
+  "DEV"
+);
 
 const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin({
   isElementPartOfTyperighterUI,
@@ -50,7 +56,10 @@ const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin({
     filterMatches: filterByMatchState,
     initialFilterState: [] as MatchType[]
   },
-  getSkippedRanges: (node, from, to) => findMarkPositions(node, from, to, mySchema.marks.code)
+  getSkippedRanges: (node, from, to) =>
+    findMarkPositions(node, from, to, mySchema.marks.code),
+  onMatchDecorationClicked: match =>
+    typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL)
 });
 
 if (editorElement && sidebarNode) {
@@ -75,13 +84,6 @@ if (editorElement && sidebarNode) {
     editorElement.getBoundingClientRect().height / 2 - menuHeight;
 
   const commands = createBoundCommands(view, getState);
-
-  const telemetryService = new TelemetryService("https://example.com");
-  const typerighterTelemetryAdapter = new TyperighterTelemetryAdapter(
-    telemetryService,
-    "prosemirror-typerighter",
-    "DEV"
-  );
 
   const matcherService = new MatcherService(
     store,

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -63,13 +63,14 @@ const matchOverlay = <TPluginState extends IPluginState>({
   }, []);
 
   useEffect(() => {
-    // If we've got a new match tooltip to display, get the reference to
-    // the current decoration and set the state.
     if (!currentMatchId) {
       debounceShowMatch.current.cancel();
       setShowMatch(false);
       return;
     }
+
+    // If we've got a new match tooltip to display, get the reference to
+    // the current decoration and set the state.
     const matchElement = maybeGetDecorationElement(currentMatchId);
     setReferenceElement(matchElement as any);
     debounceShowMatch.current(true)

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -80,26 +80,31 @@ export interface IPluginOptions<
   getSkippedRanges?: TGetSkippedRanges;
 
   /**
-   * The colours to use for document matches.
    * Is the given element part of the typerighter UI, but not
    * part of the Prosemirror editor? This helps us avoid resetting
    * hover or highlight states when we're hoving over e.g. tooltips
    * or other overlay nodes that are mounted outside of the editor.
    */
   isElementPartOfTyperighterUI?: (el: HTMLElement) => boolean;
+
+  /**
+   * Called when a match decoration is clicked.
+   */
+  onMatchDecorationClicked?: (match: TMatch) => void
 }
 
 /**
  * Creates the prosemirror-typerighter plugin. Responsible for issuing requests when the
  * document is changed via the supplied servier, decorating the document with matches
  * when they are are returned, and applying suggestions to the document.
- *
- * @param {IPluginOptions} options The plugin options object.
- * @returns {{plugin: Plugin, commands: ICommands}}
  */
 const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
   options: IPluginOptions<TFilterState, TMatch> = {}
-) => {
+): {
+  plugin: Plugin<IPluginState<TFilterState, TMatch>>,
+  store: Store<IPluginState<TFilterState, TMatch>>,
+  getState: (state: EditorState) => IPluginState<TFilterState, TMatch>;
+} => {
   const {
     expandRanges = expandRangesToParentBlockNode,
     getSkippedRanges = doNotSkipRanges,

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -38,6 +38,7 @@ export interface ITelemetryEvent {
 }
 
 export enum TYPERIGHTER_TELEMETRY_TYPE {
+  TYPERIGHTER_MATCH_DECORATION_CLICKED = "TYPERIGHTER_MATCH_DECORATION_CLICKED",
   TYPERIGHTER_SUGGESTION_IS_ACCEPTED = "TYPERIGHTER_SUGGESTION_IS_ACCEPTED",
   TYPERIGHTER_MARK_AS_CORRECT = "TYPERIGHTER_MARK_AS_CORRECT",
   TYPERIGHTER_MATCH_FOUND = "TYPERIGHTER_MATCH_FOUND",
@@ -86,6 +87,12 @@ export interface ISuggestionAcceptedEvent extends ITyperighterTelemetryEvent {
 
 export interface IMarkAsCorrectEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT;
+  value: 1;
+  tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
+}
+
+export interface IMatchDecorationClickedEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_DECORATION_CLICKED;
   value: 1;
   tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
 }

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -3,6 +3,7 @@ import {
   IClearDocumentEvent,
   IFilterToggleEvent,
   IMarkAsCorrectEvent,
+  IMatchDecorationClickedEvent,
   IMatchFoundEvent,
   IOpenTyperighterEvent,
   ISidebarClickEvent,
@@ -47,6 +48,17 @@ class TyperighterTelemetryAdapter {
         ...this.getTelemetryTagsFromMatch(match)
       }
     } as IMarkAsCorrectEvent);
+  }
+
+  public matchDecorationClicked(match: IMatch, documentUrl: string) {
+    this.addEvent({
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_DECORATION_CLICKED,
+      value: 1,
+      tags: {
+        documentUrl,
+        ...this.getTelemetryTagsFromMatch(match)
+      }
+    } as IMatchDecorationClickedEvent);
   }
 
   public documentIsChecked(tags: ITyperighterTelemetryEvent["tags"]) {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -450,11 +450,10 @@ const createHandleNewFocusState = <TPluginState extends IPluginState>(
     );
   }, decorations);
 
-  var hoverRectIndex = state.hoverRectIndex;
-
-  if(action.type == "NEW_HOVER_ID"){
-    hoverRectIndex = action.payload.rectIndex
-  }
+  const hoverRectIndex =
+    action.type === "NEW_HOVER_ID"
+      ? action.payload.rectIndex
+      : state.hoverRectIndex;
 
   return {
     ...state,

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -3,10 +3,10 @@ import { IMatch, ISuggestion } from "../interfaces/IMatch";
 import { getMatchType, MatchType } from "../utils/decoration";
 import { IPluginState, IBlockInFlight, IBlocksInFlightState } from "./reducer";
 
-export const selectMatchByMatchId = (
-  state: IPluginState<unknown>,
+export const selectMatchByMatchId = <TPluginState extends IPluginState>(
+  state: TPluginState,
   matchId: string
-): IMatch | undefined =>
+): TPluginState['currentMatches'][number] | undefined =>
   state.currentMatches.find(match => match.matchId === matchId);
 
 export const selectBlockQueriesInFlightForSet = (

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -211,11 +211,8 @@ export const maybeGetDecorationElement = (
 ): HTMLElement | null =>
   document.querySelector(`[${DECORATION_ATTRIBUTE_ID}="${matchId}"]`);
 
-const getProseMirrorOffsetValue = (
-  element: HTMLElement,
-  scrollElement: Element
-): number => {
-  var offset = element.offsetTop;
+const getProseMirrorOffsetValue = (element: HTMLElement, scrollElement: Element): number => {
+  let offset = element.offsetTop;
 
   if (element.offsetParent && !element.isEqualNode(scrollElement)) {
     return (offset += getProseMirrorOffsetValue(
@@ -226,6 +223,15 @@ const getProseMirrorOffsetValue = (
 
   return offset;
 };
+
+export const maybeGetDecorationMatchIdFromEvent = (event: Event): string | undefined => {
+  if (!event.target || !(event.target instanceof HTMLElement)) {
+    return undefined;
+  }
+  const target = event.target;
+  const targetAttr = target.getAttribute(DECORATION_ATTRIBUTE_ID);
+  return targetAttr ? targetAttr : undefined;
+}
 
 export const getMatchOffset = (
   matchId: string,


### PR DESCRIPTION
## What does this change?

Adds a telemetry event and a callback to enable us to post that event when the match decoration is clicked. Clicking on a match range will send that match's data to the telemetry client.

### But ... why?

We _think_, because of historical, workflow-related issues, users are selecting ranges and manually making changes, rather than using the green 'apply suggestion' button in the tooltip. This'll, I hope, help us find out.

You can of course make a cursor selection next to a word without clicking the surrounding span, but my hope is that this will pick up e.g. ~50% of the cases. When I went to select text, I found myself clicking within the span every time, using the bounding box as to orient the cursor, but others' behaviour may well be different.

Users may be annotating a broader range when they make their changes, though, and there's no defence against that.

Finally, there's also a question of whether clicks into match ranges constitute intent to edit. My assumption is that this is almost always the case.

## How to test

Run the app, scan a document, and click within a match decoration (the highlighted range covering. After the telemetry throttle threshold (10s), you should see a telemetry event signifying the click has occurred. It should include the match data.

I wrote an integration test, and in the process sadly found out that jsDOM cannot supply the necessary DOM API, so the Prosemirror top-level event handler throws. We'll need to integrate Jest with e.g. Puppeteer to run our  unit tests in proper browser environment.

## How can we measure success?

We can pick up, most of the time, users clicking on matches. 
