### PR TITLE
fix: Memoize SidebarMatch to avoid rerendering as results arrive

### DIFF
--- a/src/ts/components/Markdown.tsx
+++ b/src/ts/components/Markdown.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { getHtmlFromMarkdown } from "../utils/dom";
+
+const Markdown = ({ markdown }: { markdown: string }) => (
+  <div
+    dangerouslySetInnerHTML={{
+      __html: getHtmlFromMarkdown(markdown)
+    }}
+  />
+);
+
+export default Markdown;

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from "react";
+import React, { useContext, memo } from "react";
 
 import { IMatch } from "../interfaces/IMatch";
 import { IMatchTypeToColourMap, getColourForMatch } from "../utils/decoration";
-import { getHtmlFromMarkdown } from "../utils/dom";
 import TelemetryContext from "../contexts/TelemetryContext";
 import SidebarMatchContainer from "./SidebarMatchContainer";
 import { createScrollToRangeHandler } from "../utils/component";
+import Markdown from "./Markdown";
 
 interface IProps {
   match: IMatch;
@@ -69,12 +69,9 @@ const SidebarMatch = ({
               <div className="SidebarMatch__header-match-text">
                 {match.matchedText}
               </div>
-              <div
-                className="SidebarMatch__header-description"
-                dangerouslySetInnerHTML={{
-                  __html: getHtmlFromMarkdown(match.message)
-                }}
-              ></div>
+              <div className="SidebarMatch__header-description">
+                <Markdown markdown={match.message} />
+              </div>
             </div>
           </div>
         </div>
@@ -83,4 +80,4 @@ const SidebarMatch = ({
   );
 };
 
-export default SidebarMatch;
+export default memo(SidebarMatch);


### PR DESCRIPTION
## What does this change?

Memoizes the `SidebarMatch` component, which is continually rerendered as our state changes.

This results in a significant improvement in our JS calc times. Timings taken when rechecking an article of 4,540 (to better isolate unneeded rerenders), averaged over 5 tries:

| Before | After |
|-|-|
| 6252ms | 4234ms |

## How to test

This is a no-op for features, but the impact is noticeable when using CPU throttling in e.g. Chrome.
