### PR TITLE
fix: new DecorationSet() -> DecorationSet.empty

### DIFF
--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -20,7 +20,7 @@ export const addMatchesToState = <TPluginState extends IPluginState>(
   const matchesToApply = matches.filter(match => !ignoreMatch(match));
   const decorations = matchesToApply.reduce(
     (set, output) => set.add(doc, createDecorationsForMatch(output)),
-    new DecorationSet()
+    DecorationSet.empty
   );
   return {
     ...state,

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -82,7 +82,7 @@ describe("State helpers", () => {
         filterByMatchState
       );
       expect(filteredMatches).toEqual([]);
-      expect(decorations).toEqual(new DecorationSet());
+      expect(decorations).toEqual(DecorationSet.empty);
     });
     it("should handle a no-op filter state, adding matches to the filtered state", () => {
       const matches = [createMatch(1, 4), createMatch(4, 7)];
@@ -98,7 +98,7 @@ describe("State helpers", () => {
       );
       expect(filteredMatches).toEqual(currentMatches);
       expect(decorations).toEqual(
-        getNewDecorationsForCurrentMatches(matches, new DecorationSet(), tr.doc)
+        getNewDecorationsForCurrentMatches(matches, DecorationSet.empty, tr.doc)
       );
     });
     it("should remove matches when they don't pass the filter", () => {
@@ -116,7 +116,7 @@ describe("State helpers", () => {
 
       expect(currentMatches).toEqual(matches);
       expect(filteredMatches).toEqual([]);
-      expect(decorations).toEqual(new DecorationSet());
+      expect(decorations).toEqual(DecorationSet.empty);
     });
   });
 });

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -96,7 +96,7 @@ describe("Action handlers", () => {
           debug: true
         },
         dirtiedRanges: [],
-        decorations: new DecorationSet().add(tr.doc, [
+        decorations: DecorationSet.empty.add(tr.doc, [
           createDebugDecorationFromRange({ from: 1, to: 22 }, false)
         ]),
         requestPending: false,
@@ -119,7 +119,7 @@ describe("Action handlers", () => {
           ...state,
           config: { ...state.config, debug: true },
           dirtiedRanges: [{ from: 5, to: 10 }],
-          decorations: new DecorationSet().add(tr.doc, [
+          decorations: DecorationSet.empty.add(tr.doc, [
             createDebugDecorationFromRange({ from: 1, to: 3 })
           ]),
           requestPending: true
@@ -127,7 +127,7 @@ describe("Action handlers", () => {
         requestMatchesForDirtyRanges("id", exampleCategoryIds)
       );
       expect(newState.decorations).toEqual(
-        new DecorationSet().add(tr.doc, [
+        DecorationSet.empty.add(tr.doc, [
           createDebugDecorationFromRange({ from: 1, to: 22 }, false)
         ])
       );
@@ -147,7 +147,7 @@ describe("Action handlers", () => {
             { from: 5, to: 10 },
             { from: 28, to: 35 }
           ],
-          decorations: new DecorationSet(),
+          decorations: DecorationSet.empty,
           requestPending: true
         },
         requestMatchesForDirtyRanges("id", exampleCategoryIds)
@@ -219,7 +219,7 @@ describe("Action handlers", () => {
         requestMatchesSuccess(createMatcherResponse([{ from: 5, to: 10 }]))
       );
       const newMatch = newState.currentMatches[0];
-      const newDecorations = new DecorationSet().add(
+      const newDecorations = DecorationSet.empty.add(
         tr.doc,
         createDecorationsForMatch(newMatch)
       );
@@ -278,7 +278,7 @@ describe("Action handlers", () => {
         );
 
         expect(newState.decorations).toEqual(
-          new DecorationSet().add(tr.doc, [
+          DecorationSet.empty.add(tr.doc, [
             ...createDecorationsForMatch(matcherResponse2.matches[0]),
             ...createDecorationsForMatch(matcherResponse3.matches[0])
           ])
@@ -384,7 +384,7 @@ describe("Action handlers", () => {
       const currentMatches = matches.slice(0, 1);
       const decorations = getNewDecorationsForCurrentMatches(
         currentMatches,
-        new DecorationSet(),
+        DecorationSet.empty,
         defaultDoc
       );
 
@@ -425,7 +425,7 @@ describe("Action handlers", () => {
             to: 25
           }
         ],
-        decorations: new DecorationSet(),
+        decorations: DecorationSet.empty,
         requestErrors: [
           {
             requestId: exampleRequestId,
@@ -507,14 +507,14 @@ describe("Action handlers", () => {
       const localState = {
         ...state,
         currentMatches: [output],
-        decorations: new DecorationSet().add(
+        decorations: DecorationSet.empty.add(
           tr.doc,
           createDecorationsForMatch(output, defaultMatchColours, false)
         )
       };
       expect(reducer(tr, localState, newHoverIdReceived("match-id", 1))).toEqual({
         ...localState,
-        decorations: new DecorationSet().add(
+        decorations: DecorationSet.empty.add(
           tr.doc,
           createDecorationsForMatch(output, defaultMatchColours, true)
         ),
@@ -544,7 +544,7 @@ describe("Action handlers", () => {
       };
       const localState = {
         ...state,
-        decorations: new DecorationSet().add(tr.doc, [
+        decorations: DecorationSet.empty.add(tr.doc, [
           ...createDecorationsForMatch(output, defaultMatchColours, true)
         ]),
         currentMatches: [output],
@@ -555,7 +555,7 @@ describe("Action handlers", () => {
         reducer(tr, localState, newHoverIdReceived(undefined, undefined))
       ).toEqual({
         ...localState,
-        decorations: new DecorationSet().add(tr.doc, [
+        decorations: DecorationSet.empty.add(tr.doc, [
           ...createDecorationsForMatch(output, defaultMatchColours, false)
         ]),
         hoverId: undefined,

--- a/src/ts/test/helpers/prosemirror.ts
+++ b/src/ts/test/helpers/prosemirror.ts
@@ -35,7 +35,7 @@ export const getDecorationSpecsFromDoc = (
   getDecorationSpecsFromSet(view.someProp("decorations", f => f(view.state)));
 
 export const getDecorationSpecsFromMatches = (matches: IMatch[], doc: Node) => {
-  const decorationSet = getNewDecorationsForCurrentMatches(matches, new DecorationSet(), doc)
+  const decorationSet = getNewDecorationsForCurrentMatches(matches, DecorationSet.empty, doc)
   return getDecorationSpecsFromSet(decorationSet);
 }
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Changes new DecorationSet() -> DecorationSet.empty, for two reasons:
- new DecorationSet, although it works, isn't documented.
- we think object identity shenanigans may be causing a bug.

## How to test

This is no-op – everything should work as expected.
