### PR TITLE
chore: Update semantic-PRs.yml

### DIFF
--- a/.github/workflows/semantic-PRs.yml
+++ b/.github/workflows/semantic-PRs.yml
@@ -1,6 +1,6 @@
 name: 'Lint PR'
 on:
-    pull_request_target:
+    pull_request:
         types:
             - opened
             - edited


### PR DESCRIPTION
## What does this change?

Trigger our pull request linter on the `pull-request` event, not `pull-request-target`, b/c:

<img width="549" alt="Screenshot 2021-02-03 at 09 11 27" src="https://user-images.githubusercontent.com/7767575/106724188-d1736a80-65ff-11eb-9629-ee31a03c80cc.png">

... meaning it might possible to open a PR via a fork that ran code to e.g. pull out secrets. I haven't confirmed, but this tighter scope makes sense regardless.

Thanks @akash1810 for spotting!

## How to test

This is a no-op – our actions should continue to work as expected.

## How can we measure success?

Fewer vulns in our build process.