### PR TITLE
fix: Remove and re-add package-lock.json to ensure react-dom@17.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,12 +48,12 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
-      "integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+      "integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.12.10"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -147,12 +147,12 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
-      "integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-module-transforms": {
@@ -179,9 +179,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
       "dev": true
     },
     "@babel/helper-regex": {
@@ -236,6 +236,12 @@
       "requires": {
         "@babel/types": "^7.7.4"
       }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.7.4",
@@ -819,13 +825,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -5260,9 +5266,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "hsl-regex": {
@@ -8717,9 +8723,9 @@
       }
     },
     "prosemirror-state": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.2.tgz",
-      "integrity": "sha512-t/JqE3aR0SV9QrzFVkAXsQwsgrQBNs/BDbcFH20RssW0xauqNNdjTXxy/J/kM7F+0zYi6+BRmz7cMMQQFU3mwQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.3.4.tgz",
+      "integrity": "sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==",
       "requires": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -8762,13 +8768,407 @@
       "integrity": "sha512-nOKcfqyfZBhsephi9HCvEcF6qof7NcbKthnWhXAHJvca5YTaKh6h5mjGSRndm91CnbvRrwlG/BCC0BTu790fDA=="
     },
     "prosemirror-view": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.13.4.tgz",
-      "integrity": "sha512-mtgWEK16uYQFk3kijRlkSpAmDuy7rxYuv0pgyEBDmLT1PCPY8380CoaYnP8znUT6BXIGlJ8oTveK3M50U+B0vw==",
+      "version": "1.18.11",
       "requires": {
-        "prosemirror-model": "^1.1.0",
+        "prosemirror-model": "^1.14.3",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
+      },
+      "dependencies": {
+        "@rollup/plugin-buble": {
+          "requires": {
+            "@rollup/pluginutils": "^3.0.8",
+            "@types/buble": "^0.19.2",
+            "buble": "^0.20.0"
+          }
+        },
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "@types/buble": {
+          "version": "0.19.2",
+          "requires": {
+            "magic-string": "^0.25.0"
+          }
+        },
+        "@types/estree": {
+          "version": "0.0.39"
+        },
+        "acorn": {
+          "version": "6.4.2"
+        },
+        "acorn-dynamic-import": {
+          "version": "4.0.0"
+        },
+        "acorn-jsx": {
+          "version": "5.3.1"
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0"
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "browser-stdout": {
+          "version": "1.3.0"
+        },
+        "buble": {
+          "version": "0.20.0",
+          "requires": {
+            "acorn": "^6.4.1",
+            "acorn-dynamic-import": "^4.0.0",
+            "acorn-jsx": "^5.2.0",
+            "chalk": "^2.4.2",
+            "magic-string": "^0.25.7",
+            "minimist": "^1.2.5",
+            "regexpu-core": "4.5.4"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1"
+        },
+        "debug": {
+          "version": "2.6.8",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.2.0"
+        },
+        "ecstatic": {
+          "version": "1.4.1",
+          "requires": {
+            "he": "^0.5.0",
+            "mime": "^1.2.11",
+            "minimist": "^1.1.0",
+            "url-join": "^1.0.0"
+          },
+          "dependencies": {
+            "he": {
+              "version": "0.5.0"
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5"
+        },
+        "estree-walker": {
+          "version": "1.0.1"
+        },
+        "fs.realpath": {
+          "version": "1.0.0"
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "optional": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-readlink": {
+          "version": "1.0.1"
+        },
+        "growl": {
+          "version": "1.9.2"
+        },
+        "has-flag": {
+          "version": "3.0.0"
+        },
+        "he": {
+          "version": "1.1.1"
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4"
+        },
+        "ist": {},
+        "jsesc": {
+          "version": "0.5.0"
+        },
+        "json3": {
+          "version": "3.3.2"
+        },
+        "lodash._baseassign": {
+          "version": "3.2.0",
+          "requires": {
+            "lodash._basecopy": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1"
+        },
+        "lodash._basecreate": {
+          "version": "3.0.3"
+        },
+        "lodash._getnative": {
+          "version": "3.9.1"
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9"
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "requires": {
+            "lodash._baseassign": "^3.0.0",
+            "lodash._basecreate": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0"
+        },
+        "lodash.isarray": {
+          "version": "3.0.4"
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
+        },
+        "magic-string": {
+          "version": "0.25.7",
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        },
+        "mime": {
+          "version": "1.6.0"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "mocha": {
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.9.0",
+            "debug": "2.6.8",
+            "diff": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.1",
+            "growl": "1.9.2",
+            "he": "1.1.1",
+            "json3": "3.3.2",
+            "lodash.create": "3.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "3.1.2"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0"
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
+          }
+        },
+        "moduleserve": {
+          "requires": {
+            "ecstatic": "^1.4.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0"
+        },
+        "once": {
+          "version": "1.4.0",
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "orderedmap": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-1.1.1.tgz",
+          "integrity": "sha512-3Ux8um0zXbVacKUkcytc0u3HgC0b0bBLT+I60r2J/En72cI0nZffqrA7Xtf2Hqs27j1g82llR5Mhbd0Z1XW4AQ=="
+        },
+        "path-is-absolute": {
+          "version": "1.0.1"
+        },
+        "picomatch": {
+          "version": "2.2.2"
+        },
+        "prosemirror-model": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.14.3.tgz",
+          "integrity": "sha512-yzZlBaSxfUPIIP6U5Edh5zKxJPZ5f7bwZRhiCuH3UYkWhj+P3d8swHsbuAMOu/iDatDc5J/Qs5Mb3++mZf+CvQ==",
+          "requires": {
+            "orderedmap": "^1.1.0"
+          }
+        },
+        "prosemirror-schema-basic": {
+          "version": "1.1.2",
+          "requires": {
+            "prosemirror-model": "^1.2.0"
+          }
+        },
+        "prosemirror-schema-list": {
+          "version": "1.1.4",
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-state": {
+          "version": "1.3.3",
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-transform": "^1.0.0"
+          }
+        },
+        "prosemirror-test-builder": {
+          "requires": {
+            "prosemirror-model": "^1.0.0",
+            "prosemirror-schema-basic": "^1.0.0",
+            "prosemirror-schema-list": "^1.0.0"
+          }
+        },
+        "prosemirror-transform": {
+          "version": "1.2.8",
+          "requires": {
+            "prosemirror-model": "^1.0.0"
+          }
+        },
+        "regenerate": {
+          "version": "1.4.2"
+        },
+        "regenerate-unicode-properties": {
+          "version": "8.2.0",
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.5.4",
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.0.2",
+            "regjsgen": "^0.5.0",
+            "regjsparser": "^0.6.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.1.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.2"
+        },
+        "regjsparser": {
+          "version": "0.6.6",
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        },
+        "rollup": {
+          "requires": {
+            "fsevents": "~2.1.2"
+          }
+        },
+        "sourcemap-codec": {
+          "version": "1.4.8"
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4"
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.2.0"
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.1.0"
+        },
+        "url-join": {
+          "version": "1.1.0"
+        },
+        "wrappy": {
+          "version": "1.0.2"
+        }
       }
     },
     "pseudomap": {


### PR DESCRIPTION
## What does this change?

Removes and re-adds the `package-lock.json` file from the project to fix a problem with inconsistent `react` and `react-dom` versions, as at the moment they're resolving to `17.0.2` and `16.13.1` respectively.

## How to test

Run `npm ls react` and `npm ls react-dom` in the project root. `17.0.2` should be the only version that resolves.