### PR TITLE
fix: Remove redundant tooltip styling

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -105,12 +105,3 @@ hr {
 .TyperighterPlugin__decoration-container {
   position: absolute;
 }
-
-.TyperighterPlugin__tooltip-overlay {
-  // position: relative provides a new stacking context, which
-  // gives the tooltip a better chance of appearing on top of
-  // other elements.
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-  position: relative;
-  z-index: 10;
-}


### PR DESCRIPTION
## What does this change?

Removes redundant tooltip styling. As well as being unnecessary (due to switching to PopperJS #112), the styling is causing placement problems in consumer code at different zoom levels.

## How to test

You'll need to use `npm link` to use this with your consumer:

```bash
npm link # In prosemirror-typerighter dir
npm link @guardian/prosemirror-typerighter # in consumer project (e.g. Composer)
```

You should see accurate popup placement at non-100% zoom levels. E.g. at 90%:

| before | after |
| --- | --- |
| <img width="335" alt="Screenshot 2021-09-27 at 09 48 14" src="https://user-images.githubusercontent.com/7767575/134875869-afde97ab-e96d-43f4-8b5c-ed9eadae9285.png">|<img width="335" alt="Screenshot 2021-09-27 at 09 48 21" src="https://user-images.githubusercontent.com/7767575/134875858-0ff24637-3a6a-4ef2-945d-16723e0eca2f.png"> |

