### PR TITLE
fix: Filter block queries to ensure zero-width blocks are not included in requests

### DIFF
--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -11,7 +11,8 @@ import {
   selectHasAuthError,
   selectRequestsInProgress,
   selectHasMatches,
-  selectDocumentHasChanged
+  selectDocumentHasChanged,
+  selectDocumentIsEmpty
 } from "../state/selectors";
 import TelemetryContext from "../contexts/TelemetryContext";
 
@@ -117,24 +118,31 @@ const Controls = <TPluginState extends IPluginState>({
   };
 
   const renderCheckDocumentButton = () => {
+    const requestInProgress =
+      !!pluginState && selectRequestsInProgress(pluginState);
+    const docIsEmpty = !!pluginState && selectDocumentIsEmpty(pluginState);
+    const docHasChanged =
+      !!pluginState && !docIsEmpty && selectDocumentHasChanged(pluginState);
+
+    const isDisabled = requestInProgress || docIsEmpty;
+    const message = docIsEmpty ? "The document has no text to check" : "";
+
     const plainButton = (
-      <button
-        type="button"
-        className="Button"
-        onClick={handleCheckDocumentButtonClick}
-        disabled={pluginState && selectRequestsInProgress(pluginState)}
-      >
-        Check document
-      </button>
+      <>
+        <button
+          type="button"
+          className="Sidebar__header-button Button"
+          onClick={handleCheckDocumentButtonClick}
+          disabled={isDisabled}
+          title={message}
+        >
+          Check document
+        </button>
+
+      </>
     );
 
-    if (!pluginState) {
-      return plainButton;
-    }
-
-    const docHasChanged = selectDocumentHasChanged(pluginState);
-
-    if (!docHasChanged) {
+    if (!pluginState || !docHasChanged) {
       return plainButton;
     }
 

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -14,6 +14,7 @@ import {
 import { DecorationSet } from "prosemirror-view";
 import { TFilterMatches } from "../utils/plugin";
 import { mapAndMergeRanges, mapRange, mapRanges } from "../utils/range";
+import { nodeContainsText } from "../utils/prosemirror";
 
 export const addMatchesToState = <TPluginState extends IPluginState>(
   state: TPluginState,
@@ -135,6 +136,7 @@ export const getNewStateFromTransaction = <TPluginState extends IPluginState>(
     dirtiedRanges: mapAndMergeRanges(incomingState.dirtiedRanges, tr.mapping),
     currentMatches: mapRanges(incomingState.currentMatches, tr.mapping),
     requestsInFlight: mappedRequestsInFlight,
-    docChangedSinceCheck: true
+    docChangedSinceCheck: true,
+    docIsEmpty: !nodeContainsText(tr.doc)
   };
 };

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -471,9 +471,9 @@ const createHandleMatchesRequestForDirtyRanges = (
   { payload: { requestId, categoryIds } }: ActionRequestMatchesForDirtyRanges
 ): TPluginState => {
   const ranges = expandRanges(state.dirtiedRanges, tr.doc);
-  const blocks = ranges.map(range =>
-    createBlock(tr.doc, range, tr.time, getIgnoredRanges)
-  );
+  const blocks = ranges
+    .filter(({ from, to }) => from < to)
+    .map(range => createBlock(tr.doc, range, tr.time, getIgnoredRanges));
   return handleRequestStart(requestId, blocks, categoryIds)(tr, state);
 };
 

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -471,7 +471,9 @@ const createHandleMatchesRequestForDirtyRanges = (
   { payload: { requestId, categoryIds } }: ActionRequestMatchesForDirtyRanges
 ): TPluginState => {
   const ranges = expandRanges(state.dirtiedRanges, tr.doc);
-  const blocks = ranges.map(range => createBlock(tr.doc, range, tr.time, getIgnoredRanges));
+  const blocks = ranges.map(range =>
+    createBlock(tr.doc, range, tr.time, getIgnoredRanges)
+  );
   return handleRequestStart(requestId, blocks, categoryIds)(tr, state);
 };
 
@@ -518,7 +520,7 @@ const handleRequestStart = (
       block,
       pendingCategoryIds: categoryIds
     }))
-    .filter(({ block }) => block.text !== "")
+    .filter(({ block }) => block.text.trim() !== "")
 
   const newRequestInFlight = newBlockQueriesInFlight.length ?
     {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -54,7 +54,7 @@ import {
   removeOverlappingRanges
 } from "../utils/range";
 import { ExpandRanges, IFilterOptions } from "../createTyperighterPlugin";
-import { getBlocksFromDocument } from "../utils/prosemirror";
+import { getBlocksFromDocument, nodeContainsText } from "../utils/prosemirror";
 import { Node } from "prosemirror-model";
 import {
   selectSingleBlockInFlightById,

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -520,7 +520,7 @@ const handleRequestStart = (
       block,
       pendingCategoryIds: categoryIds
     }))
-    .filter(({ block }) => block.text.trim() !== "")
+    .filter(({ block }) => block.text.length !== 0);
 
   const newRequestInFlight = newBlockQueriesInFlight.length ?
     {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -153,6 +153,7 @@ export interface IPluginState<
   filterState: TFilterState;
   // Has the document changed since the last document check?
   docChangedSinceCheck: boolean;
+  docIsEmpty: boolean;
 }
 
 // The transaction meta key that namespaces our actions.
@@ -163,10 +164,10 @@ interface IInitialStateOpts<
   TMatch extends IMatch
 > {
   doc: Node;
-  matches: TMatch[];
-  ignoreMatch: IIgnoreMatchPredicate;
-  matchColours: IMatchTypeToColourMap;
-  filterOptions: IFilterOptions<TFilterState, TMatch> | undefined;
+  matches?: TMatch[];
+  ignoreMatch?: IIgnoreMatchPredicate;
+  matchColours?: IMatchTypeToColourMap;
+  filterOptions?: IFilterOptions<TFilterState, TMatch>;
 }
 
 /**
@@ -206,7 +207,8 @@ export const createInitialState = <
     requestPending: false,
     requestErrors: [],
     filterState: filterOptions?.initialFilterState as TFilterState,
-    docChangedSinceCheck: false
+    docChangedSinceCheck: false,
+    docIsEmpty: !nodeContainsText(doc)
   };
 
   const stateWithMatches = addMatchesToState(

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -176,3 +176,7 @@ export const selectMatches = <TMatch extends IMatch>(
 export const selectDocumentHasChanged = (state: IPluginState): boolean => {
   return state.docChangedSinceCheck;
 };
+
+export const selectDocumentIsEmpty = (state: IPluginState): boolean => {
+  return state.docIsEmpty;
+};

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -163,7 +163,7 @@ describe("Action handlers", () => {
         tr,
         {
           ...state,
-          dirtiedRanges: [{ from: 2, to: 2 }],
+          dirtiedRanges: [{ from: 2, to: 3 }],
           requestPending: true
         },
         requestMatchesForDirtyRanges("id", exampleCategoryIds)

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -13,7 +13,7 @@ import {
   removeMatch,
   removeAllMatches
 } from "../actions";
-import { selectBlockQueriesInFlightForSet } from "../selectors";
+import { selectAllBlockQueriesInFlight, selectBlockQueriesInFlightForSet } from "../selectors";
 import { createReducer, IPluginState } from "../reducer";
 import {
   createDebugDecorationFromRange,
@@ -155,6 +155,20 @@ describe("Action handlers", () => {
       expect(
         selectBlockQueriesInFlightForSet(newState, "id")!.totalBlocks
       ).toEqual(2);
+    });
+    it("should remove any ranges of zero width once they've been expanded", () => {
+      const doc = createDoc(p(""));
+      const { state, tr } = createInitialData(doc);
+      const newState = reducer(
+        tr,
+        {
+          ...state,
+          dirtiedRanges: [{ from: 2, to: 2 }],
+          requestPending: true
+        },
+        requestMatchesForDirtyRanges("id", exampleCategoryIds)
+      );
+      expect(selectAllBlockQueriesInFlight(newState)).toEqual([]);
     });
   });
   describe("requestMatchesSuccess", () => {

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -156,8 +156,22 @@ describe("Action handlers", () => {
         selectBlockQueriesInFlightForSet(newState, "id")!.totalBlocks
       ).toEqual(2);
     });
-    it("should remove any ranges of zero width once they've been expanded", () => {
+    it("should remove any ranges with no content once they've been expanded", () => {
       const doc = createDoc(p(""));
+      const { state, tr } = createInitialData(doc);
+      const newState = reducer(
+        tr,
+        {
+          ...state,
+          dirtiedRanges: [{ from: 2, to: 3 }],
+          requestPending: true
+        },
+        requestMatchesForDirtyRanges("id", exampleCategoryIds)
+      );
+      expect(selectAllBlockQueriesInFlight(newState)).toEqual([]);
+    });
+    it("should remove any ranges that contain only whitespace once they've been expanded", () => {
+      const doc = createDoc(p("           "));
       const { state, tr } = createInitialData(doc);
       const newState = reducer(
         tr,

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -170,20 +170,6 @@ describe("Action handlers", () => {
       );
       expect(selectAllBlockQueriesInFlight(newState)).toEqual([]);
     });
-    it("should remove any ranges that contain only whitespace once they've been expanded", () => {
-      const doc = createDoc(p("           "));
-      const { state, tr } = createInitialData(doc);
-      const newState = reducer(
-        tr,
-        {
-          ...state,
-          dirtiedRanges: [{ from: 2, to: 3 }],
-          requestPending: true
-        },
-        requestMatchesForDirtyRanges("id", exampleCategoryIds)
-      );
-      expect(selectAllBlockQueriesInFlight(newState)).toEqual([]);
-    });
   });
   describe("requestMatchesSuccess", () => {
     it("shouldn't do anything if there's nothing in the response and nothing to clean up", () => {

--- a/src/ts/state/test/store.spec.ts
+++ b/src/ts/state/test/store.spec.ts
@@ -3,16 +3,18 @@ import { createInitialState } from "../reducer";
 import { createDoc, p } from "../../test/helpers/prosemirror";
 
 describe("store", () => {
+  const doc = createDoc(p("Example doc"))
+  const initState = createInitialState({ doc });
+
   it("should allow consumers to subscribe to all store events, and trigger subscriptions when those events are emitted", () => {
     const store = new Store();
     const newStateSub = jest.fn();
     const newSub = jest.fn();
-    const state = createInitialState(createDoc(p("Example doc")));
     store.on("STORE_EVENT_NEW_STATE", newStateSub);
     store.on("STORE_EVENT_NEW_MATCHES", newSub);
 
-    store.emit("STORE_EVENT_NEW_STATE", state);
-    expect(newStateSub.mock.calls[0]).toEqual([state]);
+    store.emit("STORE_EVENT_NEW_STATE", initState);
+    expect(newStateSub.mock.calls[0]).toEqual([initState]);
 
     const notABlockInFlight = { exampleBlockInFlight: "" } as any;
     store.emit("STORE_EVENT_NEW_MATCHES", notABlockInFlight, []);
@@ -23,9 +25,10 @@ describe("store", () => {
     const newStateSub = jest.fn();
     store.on("STORE_EVENT_NEW_STATE", newStateSub);
     store.removeEventListener("STORE_EVENT_NEW_STATE", newStateSub);
+
     store.emit(
       "STORE_EVENT_NEW_STATE",
-      createInitialState(createDoc(p("Example doc")))
+      initState
     );
     expect(newStateSub.mock.calls.length).toBe(0);
   });

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -209,7 +209,8 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       requestsInFlight: {},
       requestPending: false,
       requestErrors: [],
-      docChangedSinceCheck: false
+      docChangedSinceCheck: false,
+      docIsEmpty: false
     } as IPluginState
   };
 };

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -285,3 +285,25 @@ export const findMarkPositions = (
   });
   return matched.map(match => ({ from: match.from, to: match.to }));
 };
+
+/**
+ * Does the given node contain any text content?
+ *
+ * Necessary to roll our own, as there's not a ProseMirror-native function that
+ * will return early once text is found, and a complete traversal through a
+ * large document would be inefficient.
+ */
+export const nodeContainsText = (node: Node): boolean => {
+  if (node.isText) {
+    return true;
+  }
+
+  let hasText = false;
+
+  for (let i = 0; hasText === false && i < node.content.childCount; i++) {
+    const child = node.content.maybeChild(i) as Node;
+    hasText = nodeContainsText(child);
+  }
+
+  return hasText;
+}


### PR DESCRIPTION
## What does this change?

Filters the block queries before they're added to our plugin state (and subsequently sent to our checking service) to cull any that are empty.

This should ensure that we don't send requests for ranges with no content.

For good measure, we remove any ranges that just contain whitespace.

## How to test

- The unit tests should pass, and you should be convinced they handle the scenario above.
- Try hitting removing all of the content in a document in a running demo instance, and hit 'check document'. You should not see a request go out. Contentful documents should issue requests as normal.

## How can we measure success?

No requests for checks that contain empty ranges.