### PR TITLE
fix: Do not allow matches that fall outside of the doc into the plugin state

### DIFF
--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "prosemirror-state";
+import { AllSelection, Transaction } from "prosemirror-state";
 import {
   ActionSetConfigValue,
   ActionRequestError,
@@ -678,7 +678,10 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     state,
     response.requestId
   )!.mapping;
-  const mappedMatchesToAdd = mapRanges(matchesToAdd, currentMapping);
+  const docSelection = new AllSelection(tr.doc);
+  const mappedMatchesToAdd = mapRanges(matchesToAdd, currentMapping).filter(match =>
+    match.to <= docSelection.to
+  );
 
   // Add the response to the current matches.
   currentMatches = currentMatches.concat(mappedMatchesToAdd);

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -673,14 +673,17 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     [] as Decoration[]
   );
 
-  const matchesToAdd = response.matches.filter(match => !ignoreMatch(match));
   const currentMapping = selectBlockQueriesInFlightForSet(
     state,
     response.requestId
   )!.mapping;
+
+  // Map our matches across any changes, filtering out inapplicable matches
   const docSelection = new AllSelection(tr.doc);
-  const mappedMatchesToAdd = mapRanges(matchesToAdd, currentMapping).filter(match =>
-    match.to <= docSelection.to
+  const mappedMatchesToAdd = mapRanges(response.matches, currentMapping).filter(match =>
+    match.to <= docSelection.to // Match should be within document bounds
+      && match.to !== match.from // Match should not be zero width (can happen as a result of mapping)
+      && !ignoreMatch(match) // Match should not be marked as ignored by consumer
   );
 
   // Add the response to the current matches.

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -173,7 +173,6 @@ export const selectMatches = <TMatch extends IMatch>(
     ? selectImportanceOrderedMatches(state)
     : selectDocumentOrderedMatches(state);
 
-
 export const selectDocumentHasChanged = (state: IPluginState): boolean => {
   return state.docChangedSinceCheck;
 };

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -208,6 +208,26 @@ describe("Action handlers", () => {
         ).currentMatches
       ).toMatchObject([createMatch(1, 4)]);
     });
+    it("should not apply matches if they fall outside the bounds of the document", () => {
+      const { state, tr } = createInitialData();
+      let localState = reducer(
+        tr,
+        state,
+        applyNewDirtiedRanges([{ from: 1, to: 3 }])
+      );
+      localState = reducer(
+        tr,
+        localState,
+        requestMatchesForDirtyRanges(exampleRequestId, exampleCategoryIds)
+      );
+      expect(
+        reducer(
+          tr,
+          localState,
+          requestMatchesSuccess(createMatcherResponse([{ from: 1, to: 22, wordFrom: 1000, wordTo: 1022 }]))
+        ).currentMatches
+      ).toEqual([]);
+    });
     it("should create decorations for the incoming matches", () => {
       const { state, tr } = createInitialData();
       const newState = reducer(

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -9,10 +9,8 @@ import { Mapping } from "prosemirror-transform";
 /**
  * Find the index of the first range in the given range array that overlaps/abuts with the given range.
  */
-export const findOverlappingRangeIndex = (
-  range: IRange,
-  ranges: IRange[],
-) => ranges.findIndex(
+export const findOverlappingRangeIndex = (range: IRange, ranges: IRange[]) =>
+  ranges.findIndex(
     localRange =>
       // Overlaps or abuts to the left of the range
       (localRange.from <= range.from && localRange.to >= range.from) ||
@@ -21,7 +19,6 @@ export const findOverlappingRangeIndex = (
       // Overlaps or abuts to the right of the range
       (localRange.from >= range.from && localRange.to <= range.to)
   );
-
 
 export const mapAndMergeRanges = <Range extends IRange>(
   ranges: Range[],
@@ -37,6 +34,15 @@ export const mapRanges = <Range extends IRange>(
     from: mapping.map(range.from),
     to: mapping.map(range.to)
   }));
+
+export const mapRange = <Range extends IRange>(
+  range: Range,
+  mapping: Mapping
+): Range => ({
+  ...range,
+  from: mapping.map(range.from),
+  to: mapping.map(range.to)
+});
 
 /**
  * Return the first set of ranges with any members overlapping the second set removed.


### PR DESCRIPTION
## What does this change?

At the moment, there's a bug in prosemirror-typerighter: shortening the document whilst a match is in flight can cause unexpected behaviour if the match is now outside the bounds of the document.

This is not a crash in our demo, but does cause problems in the Guardian's CMS, where `ignoreMatches` is operating on matches outside of the bounds of the document in ways that cause a crash.

It also results in a bug phantom matches hanging around in our state – the document disappears, but we still accrue matches in this example:

![tr-bug](https://user-images.githubusercontent.com/7767575/144480097-8cc17083-da2b-4278-b9c7-07fce3fa5f5e.gif)

Thanks to @SHession for pointing out the bug!

## How to test

- The new unit test should pass.
- Attempt to replicate the bug above. It should no longer be possible.