### PR TITLE
fix: Keep track of dirty ranges when requests are inflight so they supercede incoming matches

### DIFF
--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -448,14 +448,15 @@ const handleNewDirtyRanges = <TPluginState extends IPluginState>(
     output => findOverlappingRangeIndex(output, dirtiedRanges) === -1
   );
 
+  const shouldPersistNewDirtyRanges = state.config.requestMatchesOnDocModified
+    || !!Object.keys(state.requestsInFlight).length;
+
   return {
     ...state,
     currentMatches,
     decorations: newDecorations,
-    // We only care about storing dirtied ranges if we're validating
-    // in response to user edits.
     requestPending: state.config.requestMatchesOnDocModified ? true : false,
-    dirtiedRanges: state.config.requestMatchesOnDocModified
+    dirtiedRanges: shouldPersistNewDirtyRanges
       ? state.dirtiedRanges.concat(dirtiedRanges)
       : []
   };
@@ -690,7 +691,10 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     currentMatches,
     decorations: state.decorations
       .remove(decsToRemove)
-      .add(tr.doc, newDecorations)
+      .add(tr.doc, newDecorations),
+    dirtiedRanges: state.config.requestMatchesOnDocModified
+      ? state.dirtiedRanges
+      : []
   };
 };
 

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -685,6 +685,10 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     state.requestsInFlight
   );
 
+  const dirtiedRanges = (state.config.requestMatchesOnDocModified || Object.keys(newBlockQueriesInFlight).length)
+    ? state.dirtiedRanges
+    : []
+
   return {
     ...state,
     requestsInFlight: newBlockQueriesInFlight,
@@ -692,9 +696,7 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     decorations: state.decorations
       .remove(decsToRemove)
       .add(tr.doc, newDecorations),
-    dirtiedRanges: state.config.requestMatchesOnDocModified
-      ? state.dirtiedRanges
-      : []
+    dirtiedRanges
   };
 };
 

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -9,7 +9,7 @@ import {
   IRange
 } from "../../interfaces/IMatch";
 import { createBlockId, createMatchId } from "../../utils/block";
-import { IPluginState, IBlocksInFlightState, createReducer } from "../../state/reducer";
+import { IPluginState, IBlocksInFlightState, createReducer, IPluginConfig } from "../../state/reducer";
 import { Mapping } from "prosemirror-transform";
 import { Transaction } from "prosemirror-state";
 import { Node } from "prosemirror-model";
@@ -180,7 +180,11 @@ export const createInitialTr = (doc: Node = defaultDoc) => {
   return tr;
 };
 
-export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
+export const createInitialData = (
+  doc: Node = defaultDoc,
+  time = 0,
+  config: Partial<IPluginConfig> = {}
+) => {
   const tr = createInitialTr(doc);
   tr.doc = doc;
   tr.time = time;
@@ -191,7 +195,8 @@ export const createInitialData = (doc: Node = defaultDoc, time = 0) => {
       config: {
         debug: false,
         requestMatchesOnDocModified: true,
-        matchColours: defaultMatchColours
+        matchColours: defaultMatchColours,
+        ...config
       },
       currentThrottle: 100,
       initialThrottle: 100,


### PR DESCRIPTION
## What does this change?

When Typerighter's operating in realtime mode (`requestMatchesOnDocModified = true`), it keeps track of dirtied ranges, and ensures that any ranges dirtied whilst a request for that range is in flight invalidate matches made in that request.

In non-realtime mode, it ... doesn't. See #189.

This change corrects that oversight, ensuring that dirtied ranges are tracked whilst requests are in flight. Once the request is complete, `dirtiedRanges` is reset, and ranges are no longer tracked.

## How to test

- The automated tests should pass, and you should be satisfied they test for the correct behaviour.
- Try to reproduce #189, perhaps by [manually increasing browser latency](https://umaar.com/dev-tips/66-network-throttling-profiles/#:~:text=Go%20to%20Settings%20%3E%20Throttling.,the%20Network%20Panel%20throttle%20options.). It should no longer be possible.
