### PR TITLE
chore: Rename IBlocksInFlightState -> IRequestInFlight

### DIFF
--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -8,7 +8,7 @@ import Store, {
   STORE_EVENT_NEW_DIRTIED_RANGES
 } from "../state/store";
 import { Commands } from "../commands";
-import { selectAllBlockQueriesInFlight } from "../state/selectors";
+import { selectAllBlocksInFlight } from "../state/selectors";
 import { v4 } from "uuid";
 import TyperighterTelemetryAdapter from "./TyperighterTelemetryAdapter";
 import { IPluginState } from "../state/reducer";
@@ -109,7 +109,7 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
   public requestFetchMatches() {
     this.requestPending = false;
     const pluginState = this.store.getState();
-    if (!pluginState || selectAllBlockQueriesInFlight(pluginState).length) {
+    if (!pluginState || selectAllBlocksInFlight(pluginState).length) {
       return this.scheduleRequest();
     }
     const requestId = v4();

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -57,10 +57,10 @@ import { ExpandRanges, IFilterOptions } from "../createTyperighterPlugin";
 import { getBlocksFromDocument, nodeContainsText } from "../utils/prosemirror";
 import { Node } from "prosemirror-model";
 import {
-  selectSingleBlockInFlightById,
-  selectBlockQueriesInFlightForSet,
+  selectSingleBlockInRequestInFlightById,
+  selectRequestInFlightById,
   selectMatchByMatchId,
-  selectBlockQueriesInFlightById
+  selectBlocksInFlightById as selectBlocksInFlightById
 } from "./selectors";
 import { Mapping } from "prosemirror-transform";
 import {
@@ -518,18 +518,18 @@ const handleRequestStart = (
       )
     : state.decorations;
 
-  const newBlockQueriesInFlight: IBlockInFlight[] = blocks
+  const newBlocksInFlight: IBlockInFlight[] = blocks
     .map(block => ({
       block,
       pendingCategoryIds: categoryIds
     }))
     .filter(({ block }) => block.text.length !== 0);
 
-  const newRequestInFlight = newBlockQueriesInFlight.length ?
+  const newRequestInFlight = newBlocksInFlight.length ?
     {
       [requestId]: {
-        totalBlocks: newBlockQueriesInFlight.length,
-        pendingBlocks: newBlockQueriesInFlight,
+        totalBlocks: newBlocksInFlight.length,
+        pendingBlocks: newBlocksInFlight,
         mapping: tr.mapping,
         categoryIds
       }
@@ -550,22 +550,22 @@ const handleRequestStart = (
   };
 };
 
-const amendBlockQueriesInFlight = (
+const amendRequestInFlight = (
   state: IPluginState,
   requestId: string,
   blockId: string,
   categoryIds: string[]
 ) => {
-  const currentBlockQueriesInFlight = selectBlockQueriesInFlightForSet(
+  const currentRequestInFlight = selectRequestInFlightById(
     state,
     requestId
   );
-  if (!currentBlockQueriesInFlight) {
+  if (!currentRequestInFlight) {
     return state.requestsInFlight;
   }
-  const newBlockQueriesInFlight: IRequestInFlight = {
-    ...currentBlockQueriesInFlight,
-    pendingBlocks: currentBlockQueriesInFlight.pendingBlocks.reduce(
+  const newRequestInFlight: IRequestInFlight = {
+    ...currentRequestInFlight,
+    pendingBlocks: currentRequestInFlight.pendingBlocks.reduce(
       (acc, blockInFlight) => {
         // Don't modify blocks that don't match
         if (blockInFlight.block.id !== blockId) {
@@ -584,12 +584,12 @@ const amendBlockQueriesInFlight = (
       [] as IBlockInFlight[]
     )
   };
-  if (!newBlockQueriesInFlight.pendingBlocks.length) {
+  if (!newRequestInFlight.pendingBlocks.length) {
     return omit(state.requestsInFlight, requestId);
   }
   return {
     ...state.requestsInFlight,
-    [requestId]: newBlockQueriesInFlight
+    [requestId]: newRequestInFlight
   };
 };
 
@@ -608,25 +608,25 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     return state;
   }
 
-  const requestsInFlight = selectBlockQueriesInFlightById(
+  const blocksInFlight = selectBlocksInFlightById(
     state,
     response.requestId,
     response.blocks.map(_ => _.id)
   );
 
-  if (!requestsInFlight.length) {
+  if (!blocksInFlight.length) {
     return state;
   }
 
   // Remove matches superceded by the incoming matches.
   let currentMatches = removeOverlappingRanges(
     state.currentMatches,
-    requestsInFlight.map(_ => _.block),
+    blocksInFlight.map(_ => _.block),
     match => !response.categoryIds.includes(match.category.id)
   );
 
   // Remove decorations superceded by the incoming matches.
-  const decsToRemove = requestsInFlight.reduce(
+  const decsToRemove = blocksInFlight.reduce(
     (acc, blockInFlight) =>
       acc.concat(
         state.decorations
@@ -647,7 +647,7 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     [] as Decoration[]
   );
 
-  const currentMapping = selectBlockQueriesInFlightForSet(
+  const currentMapping = selectRequestInFlightById(
     state,
     response.requestId
   )!.mapping;
@@ -674,9 +674,9 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
   );
 
   // Amend the block queries in flight to remove the returned blocks and categories
-  const newBlockQueriesInFlight = requestsInFlight.reduce(
+  const newBlocksInFlight = blocksInFlight.reduce(
     (acc, blockInFlight) =>
-      amendBlockQueriesInFlight(
+      amendRequestInFlight(
         { ...state, requestsInFlight: acc },
         response.requestId,
         blockInFlight.block.id,
@@ -685,13 +685,13 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => <
     state.requestsInFlight
   );
 
-  const dirtiedRanges = (state.config.requestMatchesOnDocModified || Object.keys(newBlockQueriesInFlight).length)
+  const dirtiedRanges = (state.config.requestMatchesOnDocModified || Object.keys(newBlocksInFlight).length)
     ? state.dirtiedRanges
     : []
 
   return {
     ...state,
-    requestsInFlight: newBlockQueriesInFlight,
+    requestsInFlight: newBlocksInFlight,
     currentMatches,
     decorations: state.decorations
       .remove(decsToRemove)
@@ -717,13 +717,13 @@ const handleMatchesRequestError = <TPluginState extends IPluginState>(
     };
   }
 
-  const requestsInFlight = selectBlockQueriesInFlightForSet(state, requestId);
+  const requestsInFlight = selectRequestInFlightById(state, requestId);
 
   if (!requestsInFlight) {
     return state;
   }
 
-  const blockInFlight = selectSingleBlockInFlightById(
+  const blockInFlight = selectSingleBlockInRequestInFlightById(
     state,
     requestId,
     blockId
@@ -770,7 +770,7 @@ const handleMatchesRequestError = <TPluginState extends IPluginState>(
       ? mergeRanges(state.dirtiedRanges.concat(dirtiedRanges))
       : state.dirtiedRanges,
     decorations,
-    requestsInFlight: amendBlockQueriesInFlight(
+    requestsInFlight: amendRequestInFlight(
       state,
       requestId,
       blockId,
@@ -785,7 +785,7 @@ const handleRequestComplete = <TPluginState extends IPluginState>(
   state: TPluginState,
   { payload: { requestId } }: ActionRequestComplete
 ): TPluginState => {
-  const requestInFlight = selectBlockQueriesInFlightForSet(state, requestId);
+  const requestInFlight = selectRequestInFlightById(state, requestId);
   const hasUnfinishedWork =
     requestInFlight &&
     requestInFlight.pendingBlocks.some(

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -90,7 +90,7 @@ export interface IBlockInFlight {
 export type IIgnoreMatchPredicate = (match: IMatch) => boolean;
 export const includeAllMatches: IIgnoreMatchPredicate = () => false;
 
-export interface IBlocksInFlightState {
+export interface IRequestInFlight {
   totalBlocks: number;
   // The category ids that were sent with the request.
   categoryIds: string[];
@@ -145,7 +145,7 @@ export interface IPluginState<
   // The sets of blocks that have been sent to the matcher service
   // and have not yet completed processing.
   requestsInFlight: {
-    [requestId: string]: IBlocksInFlightState;
+    [requestId: string]: IRequestInFlight;
   };
   // The current error message.
   requestErrors: IMatchRequestError[];
@@ -563,7 +563,7 @@ const amendBlockQueriesInFlight = (
   if (!currentBlockQueriesInFlight) {
     return state.requestsInFlight;
   }
-  const newBlockQueriesInFlight: IBlocksInFlightState = {
+  const newBlockQueriesInFlight: IRequestInFlight = {
     ...currentBlockQueriesInFlight,
     pendingBlocks: currentBlockQueriesInFlight.pendingBlocks.reduce(
       (acc, blockInFlight) => {

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -1,7 +1,7 @@
 import { sortBy } from "lodash";
 import { IMatch, ISuggestion } from "../interfaces/IMatch";
 import { getMatchType, MatchType } from "../utils/decoration";
-import { IPluginState, IBlockInFlight, IBlocksInFlightState } from "./reducer";
+import { IPluginState, IBlockInFlight, IRequestInFlight } from "./reducer";
 
 export const selectMatchByMatchId = <TPluginState extends IPluginState>(
   state: TPluginState,
@@ -12,7 +12,7 @@ export const selectMatchByMatchId = <TPluginState extends IPluginState>(
 export const selectBlockQueriesInFlightForSet = (
   state: IPluginState<unknown>,
   requestId: string
-): IBlocksInFlightState | undefined => {
+): IRequestInFlight | undefined => {
   return state.requestsInFlight[requestId];
 };
 
@@ -46,7 +46,7 @@ export const selectAllBlockQueriesInFlight = (
   );
 
 type TSelectRequestInFlight = Array<
-  IBlocksInFlightState & {
+  IRequestInFlight & {
     requestId: string;
   }
 >;

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -9,35 +9,35 @@ export const selectMatchByMatchId = <TPluginState extends IPluginState>(
 ): TPluginState['currentMatches'][number] | undefined =>
   state.currentMatches.find(match => match.matchId === matchId);
 
-export const selectBlockQueriesInFlightForSet = (
+export const selectRequestInFlightById = (
   state: IPluginState<unknown>,
   requestId: string
 ): IRequestInFlight | undefined => {
   return state.requestsInFlight[requestId];
 };
 
-export const selectSingleBlockInFlightById = (
+export const selectSingleBlockInRequestInFlightById = (
   state: IPluginState,
   requestId: string,
   blockId: string
 ): IBlockInFlight | undefined => {
-  const blocksInFlight = selectBlockQueriesInFlightForSet(state, requestId);
+  const blocksInFlight = selectRequestInFlightById(state, requestId);
   if (!blocksInFlight) {
     return;
   }
   return blocksInFlight.pendingBlocks.find(_ => _.block.id === blockId);
 };
 
-export const selectBlockQueriesInFlightById = (
+export const selectBlocksInFlightById = (
   state: IPluginState,
   requestId: string,
   blockIds: string[]
 ): IBlockInFlight[] =>
   blockIds
-    .map(blockId => selectSingleBlockInFlightById(state, requestId, blockId))
+    .map(blockId => selectSingleBlockInRequestInFlightById(state, requestId, blockId))
     .filter(_ => !!_) as IBlockInFlight[];
 
-export const selectAllBlockQueriesInFlight = (
+export const selectAllBlocksInFlight = (
   state: IPluginState
 ): IBlockInFlight[] =>
   Object.values(state.requestsInFlight).reduce(
@@ -60,7 +60,7 @@ export const selectNewBlockInFlight = (
       !oldState.requestsInFlight[requestId]
         ? acc.concat({
             requestId,
-            ...selectBlockQueriesInFlightForSet(newState, requestId)!
+            ...selectRequestInFlightById(newState, requestId)!
           })
         : acc,
     [] as TSelectRequestInFlight

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -2,7 +2,7 @@ import { identity } from "lodash";
 import { DecorationSet } from "prosemirror-view";
 import { IMatch } from "../..";
 import {
-  createBlockQueriesInFlight,
+  createRequestInFlight,
   createInitialTr,
   createMatch,
   createStateWithMatches,
@@ -162,7 +162,7 @@ describe("State helpers", () => {
       const { tr, state } = getState([], [MatchType.DEFAULT]);
       const initState = {
         ...state,
-        requestsInFlight: createBlockQueriesInFlight([createBlock(1, 22, "Example text to check")])
+        requestsInFlight: createRequestInFlight([createBlock(1, 22, "Example text to check")])
       };
 
       tr.delete(deleteFrom, deleteFrom + deleteRange);
@@ -175,7 +175,7 @@ describe("State helpers", () => {
       const deleteRange = 1;
       const deleteFrom = 2;
       const { tr, state } = getState([], [MatchType.DEFAULT]);
-      const requestsInFlight = createBlockQueriesInFlight([createBlock(1, 23, "Example text to check")])
+      const requestsInFlight = createRequestInFlight([createBlock(1, 23, "Example text to check")])
       const initState = {
         ...state,
         requestsInFlight

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -13,7 +13,7 @@ import {
   removeMatch,
   removeAllMatches
 } from "../actions";
-import { selectAllBlockQueriesInFlight, selectBlockQueriesInFlightForSet } from "../selectors";
+import { selectAllBlocksInFlight, selectRequestInFlightById } from "../selectors";
 import { createReducer, IPluginState } from "../reducer";
 import {
   createDebugDecorationFromRange,
@@ -29,7 +29,7 @@ import {
   createMatcherResponse,
   createBlock,
   exampleCategoryIds,
-  createBlockQueriesInFlight,
+  createRequestInFlight,
   exampleRequestId,
   createInitialData,
   defaultDoc,
@@ -63,7 +63,7 @@ describe("Action handlers", () => {
           requestMatchesForDocument(exampleRequestId, exampleCategoryIds)
         )
       ).toMatchObject({
-        requestsInFlight: createBlockQueriesInFlight([
+        requestsInFlight: createRequestInFlight([
           {
             from: 1,
             text: "Example text to check",
@@ -100,7 +100,7 @@ describe("Action handlers", () => {
           createDebugDecorationFromRange({ from: 1, to: 22 }, false)
         ]),
         requestPending: false,
-        requestsInFlight: createBlockQueriesInFlight([
+        requestsInFlight: createRequestInFlight([
           {
             text: "Example text to check",
             from: 1,
@@ -153,7 +153,7 @@ describe("Action handlers", () => {
         requestMatchesForDirtyRanges("id", exampleCategoryIds)
       );
       expect(
-        selectBlockQueriesInFlightForSet(newState, "id")!.totalBlocks
+        selectRequestInFlightById(newState, "id")!.totalBlocks
       ).toEqual(2);
     });
     it("should remove any ranges with no content once they've been expanded", () => {
@@ -168,7 +168,7 @@ describe("Action handlers", () => {
         },
         requestMatchesForDirtyRanges("id", exampleCategoryIds)
       );
-      expect(selectAllBlockQueriesInFlight(newState)).toEqual([]);
+      expect(selectAllBlocksInFlight(newState)).toEqual([]);
     });
   });
   describe("requestMatchesSuccess", () => {
@@ -248,7 +248,7 @@ describe("Action handlers", () => {
         tr,
         {
           ...state,
-          requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
+          requestsInFlight: createRequestInFlight([createBlock(5, 10)])
         },
         requestMatchesSuccess(createMatcherResponse([{ from: 5, to: 10 }]))
       );
@@ -280,7 +280,7 @@ describe("Action handlers", () => {
       const matcherResponse3 = createMatcherResponse([
         { from: 16, to: 37, wordFrom: 17, wordTo: 25 }
       ]); // Some other output for another block
-      const requestsInFlight = createBlockQueriesInFlight(
+      const requestsInFlight = createRequestInFlight(
         blocks,
         exampleRequestId,
         [...matcherResponse1.categoryIds, ...matcherResponse2.categoryIds]
@@ -410,7 +410,7 @@ describe("Action handlers", () => {
             ...state,
             dirtiedRanges: [{ from: 1, to: 3 }],
             requestsInFlight: {
-              ...createBlockQueriesInFlight([createBlock(1, 23, "Example text to check")], "req1", [category.id])
+              ...createRequestInFlight([createBlock(1, 23, "Example text to check")], "req1", [category.id])
             }
           }
 
@@ -436,8 +436,8 @@ describe("Action handlers", () => {
             ...state,
             dirtiedRanges: [{ from: 1, to: 3 }],
             requestsInFlight: {
-              ...createBlockQueriesInFlight([createBlock(1, 23, "Example text to check")], "req1", [category.id]),
-              ...createBlockQueriesInFlight([createBlock(1, 23, "Example text to check")], "req2", [category2.id])
+              ...createRequestInFlight([createBlock(1, 23, "Example text to check")], "req1", [category.id]),
+              ...createRequestInFlight([createBlock(1, 23, "Example text to check")], "req2", [category2.id])
             }
           }
 
@@ -500,7 +500,7 @@ describe("Action handlers", () => {
       const { state: initialState, tr } = createInitialData();
       const state = {
         ...initialState,
-        requestsInFlight: createBlockQueriesInFlight([
+        requestsInFlight: createRequestInFlight([
           createBlock(1, 25, "Example text to check")
         ])
       };
@@ -540,7 +540,7 @@ describe("Action handlers", () => {
     it("should remove the inflight request from the state", () => {
       const state = {
         ...initialState,
-        requestsInFlight: createBlockQueriesInFlight([
+        requestsInFlight: createRequestInFlight([
           createBlock(1, 25, "Example text to check")
         ])
       };
@@ -550,7 +550,7 @@ describe("Action handlers", () => {
     it("should ignore other requests", () => {
       const state = {
         ...initialState,
-        requestsInFlight: createBlockQueriesInFlight([
+        requestsInFlight: createRequestInFlight([
           createBlock(1, 25, "Example text to check"),
           createBlock(26, 47, "More text to check")
         ])
@@ -762,7 +762,7 @@ describe("Action handlers", () => {
         tr,
         {
           ...state,
-          requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
+          requestsInFlight: createRequestInFlight([createBlock(5, 10)])
         },
         requestMatchesSuccess(matcherResponse)
       );
@@ -793,7 +793,7 @@ describe("Action handlers", () => {
           tr,
           {
             ...acc,
-            requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
+            requestsInFlight: createRequestInFlight([createBlock(5, 10)])
           },
           requestMatchesSuccess(cur)
         );
@@ -825,7 +825,7 @@ describe("Action handlers", () => {
           tr,
           {
             ...acc,
-            requestsInFlight: createBlockQueriesInFlight([createBlock(5, 10)])
+            requestsInFlight: createRequestInFlight([createBlock(5, 10)])
           },
           requestError(error)
         );

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -2,12 +2,12 @@ import {
   selectPercentRemaining,
   selectMatchByMatchId,
   selectSuggestionAndRange,
-  selectSingleBlockInFlightById,
+  selectSingleBlockInRequestInFlightById,
   selectNewBlockInFlight
 } from "../selectors";
 import {
   createBlock,
-  createBlockQueriesInFlight,
+  createRequestInFlight,
   exampleRequestId,
   createInitialData,
   exampleCategoryIds
@@ -57,9 +57,9 @@ describe("selectors", () => {
       const input1 = createBlock(0, 5);
       const input2 = createBlock(10, 15);
       expect(
-        selectSingleBlockInFlightById(
+        selectSingleBlockInRequestInFlightById(
           {
-            requestsInFlight: createBlockQueriesInFlight([
+            requestsInFlight: createRequestInFlight([
               input1,
               input2
             ])
@@ -79,22 +79,22 @@ describe("selectors", () => {
         selectNewBlockInFlight(
           {
             ...state,
-            requestsInFlight: createBlockQueriesInFlight([
+            requestsInFlight: createRequestInFlight([
               input1
             ])
           },
           {
             ...state,
             requestsInFlight: {
-              ...createBlockQueriesInFlight([input1]),
-              ...createBlockQueriesInFlight([input2], "set-id-2")
+              ...createRequestInFlight([input1]),
+              ...createRequestInFlight([input2], "set-id-2")
             }
           }
         )
       ).toEqual([
         {
           requestId: "set-id-2",
-          ...createBlockQueriesInFlight([input2], "set-id-2")["set-id-2"]
+          ...createRequestInFlight([input2], "set-id-2")["set-id-2"]
         }
       ]);
     });
@@ -107,13 +107,13 @@ describe("selectors", () => {
           {
             ...state,
             requestsInFlight: {
-              ...createBlockQueriesInFlight([input1]),
-              ...createBlockQueriesInFlight([input2], "set-id-2")
+              ...createRequestInFlight([input1]),
+              ...createRequestInFlight([input2], "set-id-2")
             }
           },
           {
             ...state,
-            requestsInFlight: createBlockQueriesInFlight([
+            requestsInFlight: createRequestInFlight([
               input1
             ], exampleRequestId)
           }
@@ -240,7 +240,7 @@ describe("selectors", () => {
       const input2 = createBlock(10, 15);
       let state = {
         ...initialState,
-        requestsInFlight: createBlockQueriesInFlight(
+        requestsInFlight: createRequestInFlight(
           [input1, input2],
           exampleRequestId,
           ["1", "2"]
@@ -249,7 +249,7 @@ describe("selectors", () => {
       expect(selectPercentRemaining(state)).toEqual(100);
       state = {
         ...initialState,
-        requestsInFlight: createBlockQueriesInFlight(
+        requestsInFlight: createRequestInFlight(
           [input1, input2],
           exampleRequestId,
           ["1", "2"],
@@ -264,7 +264,7 @@ describe("selectors", () => {
       const input2 = createBlock(10, 15);
       let state = {
         ...initialState,
-        requestsInFlight: createBlockQueriesInFlight(
+        requestsInFlight: createRequestInFlight(
           [input1, input2],
           exampleRequestId,
           []
@@ -286,22 +286,22 @@ describe("selectors", () => {
       let state = {
         ...initialState,
         requestsInFlight: {
-          ...createBlockQueriesInFlight([input1, input2]),
-          ...createBlockQueriesInFlight([input3], "set-id-2")
+          ...createRequestInFlight([input1, input2]),
+          ...createRequestInFlight([input3], "set-id-2")
         }
       };
       expect(selectPercentRemaining(state)).toEqual(100);
       state = {
         ...initialState,
         requestsInFlight: {
-          ...createBlockQueriesInFlight(
+          ...createRequestInFlight(
             [input1, input2],
             exampleRequestId,
             exampleCategoryIds,
             [],
             3
           ),
-          ...createBlockQueriesInFlight(
+          ...createRequestInFlight(
             [input3, input4],
             "set-id-2",
             exampleCategoryIds,

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -9,7 +9,7 @@ import {
   IRange
 } from "../../interfaces/IMatch";
 import { createBlockId, createMatchId } from "../../utils/block";
-import { IPluginState, IBlocksInFlightState, createReducer, IPluginConfig } from "../../state/reducer";
+import { IPluginState, IRequestInFlight, createReducer, IPluginConfig } from "../../state/reducer";
 import { Mapping } from "prosemirror-transform";
 import { Transaction } from "prosemirror-state";
 import { Node } from "prosemirror-model";
@@ -159,7 +159,7 @@ export const createBlockQueriesInFlight = (
   categoryIds: string[] = exampleCategoryIds,
   pendingCategoryIds: string[] = categoryIds,
   total?: number
-): { [setId: string]: IBlocksInFlightState } => ({
+): { [setId: string]: IRequestInFlight } => ({
   [setId]: {
     totalBlocks: total || blockQueries.length,
     mapping: new Mapping(),

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -153,18 +153,18 @@ export const exampleCategoryIds = ["example-category"];
 
 export const exampleRequestId = "set-id";
 
-export const createBlockQueriesInFlight = (
-  blockQueries: IBlockWithSkippedRanges[],
+export const createRequestInFlight = (
+  blocksInFlight: IBlockWithSkippedRanges[],
   setId = exampleRequestId,
   categoryIds: string[] = exampleCategoryIds,
   pendingCategoryIds: string[] = categoryIds,
   total?: number
 ): { [setId: string]: IRequestInFlight } => ({
   [setId]: {
-    totalBlocks: total || blockQueries.length,
+    totalBlocks: total || blocksInFlight.length,
     mapping: new Mapping(),
     categoryIds,
-    pendingBlocks: blockQueries.map(block => ({
+    pendingBlocks: blocksInFlight.map(block => ({
       block,
       pendingCategoryIds
     }))


### PR DESCRIPTION
## What does this change?

Renames IBlocksInFlightState -> IRequestInFlight, to address the confusion described in #191.

## How to test

This is a no-op – the library should work as before, and the tests should pass.