### PR TITLE
fix: Add z-index to correct positioning of tooltips

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -104,4 +104,6 @@ hr {
 
 .TyperighterPlugin__decoration-container {
   position: absolute;
+  // Raise our tooltips above our sidebar content
+  z-index: 10;
 }


### PR DESCRIPTION
## What does this change?

Adds a z-index to our tooltip container, which ensures that tooltips are raised above sidebar content.

|Before|After|
|--|--|
| <img width="552" alt="Screenshot 2022-01-19 at 13 04 24" src="https://user-images.githubusercontent.com/7767575/150137723-d6abbf5b-d079-4322-92dc-300e5aaf8365.png">|<img width="552" alt="Screenshot 2022-01-19 at 13 04 58" src="https://user-images.githubusercontent.com/7767575/150137690-6737056c-04d0-4695-bf07-bed5c79c366c.png">

## How to test

Does this PR resolve the visual issues present in 'before', above?