### PR TITLE
feat: Allow enabling real-time checking when the plugin is instantiated

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -59,7 +59,8 @@ const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin({
   getSkippedRanges: (node, from, to) =>
     findMarkPositions(node, from, to, mySchema.marks.code),
   onMatchDecorationClicked: match =>
-    typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL)
+    typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
+    requestMatchesOnDocModified: true
 });
 
 if (editorElement && sidebarNode) {
@@ -104,7 +105,7 @@ if (editorElement && sidebarNode) {
     onMarkCorrect: match => console.info("Match ignored!", match),
     editorScrollElement: editorElement,
     getScrollOffset,
-    telemetryAdapter: typerighterTelemetryAdapter
+    telemetryAdapter: typerighterTelemetryAdapter,
   });
 
   // Handy debugging tools

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -3,7 +3,8 @@ import {
   IPluginState,
   PROSEMIRROR_TYPERIGHTER_ACTION,
   IIgnoreMatchPredicate,
-  includeAllMatches
+  includeAllMatches,
+  IPluginConfig
 } from "./state/reducer";
 import { createInitialState, createReducer } from "./state/reducer";
 import {
@@ -46,10 +47,12 @@ export interface IFilterOptions<TFilterState, TMatch extends IMatch> {
   initialFilterState: TFilterState;
 }
 
+type PluginOptionsFromConfig = Partial<Pick<IPluginConfig, "requestMatchesOnDocModified">>;
+
 export interface IPluginOptions<
   TFilterState = undefined,
   TMatch extends IMatch = IMatch
-> {
+> extends PluginOptionsFromConfig {
   /**
    * A function that receives ranges that have been dirtied since the
    * last request, and returns the new ranges to find matches for. The
@@ -94,9 +97,6 @@ export interface IPluginOptions<
    * Called when a match decoration is clicked.
    */
   onMatchDecorationClicked?: (match: TMatch) => void;
-
-  // @see IPluginConfig
-  requestMatchesOnDocModified?: boolean;
 }
 
 /**

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -94,6 +94,9 @@ export interface IPluginOptions<
    * Called when a match decoration is clicked.
    */
   onMatchDecorationClicked?: (match: TMatch) => void;
+
+  // @see IPluginConfig
+  requestMatchesOnDocModified?: boolean;
 }
 
 /**
@@ -116,7 +119,8 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
     ignoreMatch = includeAllMatches,
     matchColours = defaultMatchColours,
     onMatchDecorationClicked = () => undefined,
-    isElementPartOfTyperighterUI = () => false
+    isElementPartOfTyperighterUI = () => false,
+    requestMatchesOnDocModified = false,
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TFilterState, TMatch>;
@@ -139,7 +143,8 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
           matches,
           ignoreMatch,
           matchColours,
-          filterOptions
+          filterOptions,
+          requestMatchesOnDocModified,
         });
         store.emit(STORE_EVENT_NEW_STATE, initialState);
         return initialState;

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -99,7 +99,8 @@ export interface IRequestInFlight {
 }
 
 export interface IPluginConfig {
-  // Should we trigger a request when the document is modified?
+  // Should we trigger a request for matches when the document is modified (e.g.
+  // real-time checking)?
   requestMatchesOnDocModified: boolean;
   // Is the plugin in debug mode? Debug mode adds marks to show dirtied
   // and expanded ranges.
@@ -168,6 +169,7 @@ interface IInitialStateOpts<
   ignoreMatch?: IIgnoreMatchPredicate;
   matchColours?: IMatchTypeToColourMap;
   filterOptions?: IFilterOptions<TFilterState, TMatch>;
+  requestMatchesOnDocModified?: boolean;
 }
 
 /**
@@ -181,6 +183,7 @@ export const createInitialState = <
   matches = [],
   ignoreMatch = includeAllMatches,
   matchColours = defaultMatchColours,
+  requestMatchesOnDocModified = false,
   filterOptions
 }: IInitialStateOpts<TFilterState, TMatch>): IPluginState<
   TFilterState,
@@ -189,8 +192,8 @@ export const createInitialState = <
   const initialState = {
     config: {
       debug: false,
-      requestMatchesOnDocModified: false,
-      matchColours
+      requestMatchesOnDocModified,
+      matchColours,
     },
     decorations: DecorationSet.create(
       doc,

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -57,6 +57,11 @@ describe("createTyperighterPlugin", () => {
     const { getState, view } = createPlugin();
     expect(getState(view.state).currentMatches).toEqual(matches);
   });
+  it("should allow us to specify real time checking when creating the plugin", () => {
+    const { getState, view } = createPlugin({ requestMatchesOnDocModified: true });
+    expect(getState(view.state).config.requestMatchesOnDocModified).toEqual(true);
+  });
+
   describe("Match persistence/removal", () => {
     it("should add matches to the document by default", () => {
       const { editorElement } = createEditor("123456", [createMatch(2, 4)]);


### PR DESCRIPTION
## What does this change?

Allows enabling real-time checking when the plugin is instantiated, via the options passed to the plugin creator function.

Previously, this was only possible by dispatching a transaction to alter a configuration option, adding complexity and work.

## How to test

- I've added a test to check that we're passing the option through.
- Run locally, and begin editing the document. You should see that requests for matches are triggered after modification (the [default throttle is 2000ms](https://github.com/guardian/prosemirror-typerighter/blob/af470ec0741f3ec232004eeea1cf76fd512da92a/src/ts/services/MatcherService.ts#L34)).