### PR TITLE
feat: Add a 'dev mode' flag to the view, and a few developer utilities

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -106,6 +106,7 @@ if (editorElement && sidebarNode) {
     editorScrollElement: editorElement,
     getScrollOffset,
     telemetryAdapter: typerighterTelemetryAdapter,
+    enableDevMode: true
   });
 
   // Handy debugging tools

--- a/src/css/Controls.scss
+++ b/src/css/Controls.scss
@@ -10,10 +10,14 @@
   padding-bottom: calc($gutter-width / 2);
 }
 
+.Controls__input-group {
+  display: flex;
+}
+
 .Controls__label {
+  margin-left: calc($gutter-width / 2);
   font-weight: normal;
   cursor: pointer;
-  width: 100%;
 }
 
 .Controls__error-message {

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -67,10 +67,6 @@ const Controls = <TPluginState extends IPluginState>({
     setPluginState(store.getState());
   }, []);
 
-  if (!pluginState) {
-    return null;
-  }
-  const { requestMatchesOnDocModified, debug } = selectPluginConfig(pluginState)
   const { telemetryAdapter } = useContext(TelemetryContext);
 
   const requestMatches = () => {
@@ -165,6 +161,12 @@ const Controls = <TPluginState extends IPluginState>({
       </div>
     );
   };
+
+  if (!pluginState) {
+    return null;
+  }
+
+  const { requestMatchesOnDocModified, debug } = selectPluginConfig(pluginState)
 
   return (
     <>

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -20,7 +20,7 @@ import TelemetryContext from "../contexts/TelemetryContext";
 interface IProps<TPluginState extends IPluginState> {
   store: Store<TPluginState>;
   clearMatches: () => void;
-  setDebugState: (debug: boolean) => void;
+  setShowPendingInflightChecks: (isEnabled: boolean) => void;
   setRequestOnDocModified: (r: boolean) => void;
   requestMatchesForDocument: (requestId: string, categoryIds: string[]) => void;
   getCurrentCategories: () => ICategory[];
@@ -54,7 +54,7 @@ const Controls = <TPluginState extends IPluginState>({
   feedbackHref,
   enableDevMode,
   setRequestOnDocModified,
-  setDebugState
+  setShowPendingInflightChecks
 }: IProps<TPluginState>) => {
   const [pluginState, setPluginState] = useState<TPluginState | undefined>(
     undefined
@@ -166,7 +166,7 @@ const Controls = <TPluginState extends IPluginState>({
     return null;
   }
 
-  const { requestMatchesOnDocModified, debug } = selectPluginConfig(pluginState)
+  const { requestMatchesOnDocModified, showPendingInflightChecks } = selectPluginConfig(pluginState)
 
   return (
     <>
@@ -207,8 +207,8 @@ const Controls = <TPluginState extends IPluginState>({
               <input
                 type="checkbox"
                 id="debug"
-                checked={debug}
-                onChange={() => setDebugState(!debug)}
+                checked={showPendingInflightChecks}
+                onChange={() => setShowPendingInflightChecks(!showPendingInflightChecks)}
               ></input>
               <label htmlFor="debug" className="Controls__label">
                 Show pending and inflight checks

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -188,23 +188,29 @@ const Controls = <TPluginState extends IPluginState>({
         {enableDevMode && (
           <div>
             <hr />
-            <div>
+            <div className="Controls__input-group">
               <input
                 type="checkbox"
+                id="real-time-checks"
                 checked={requestMatchesOnDocModified}
                 onChange={() =>
                   setRequestOnDocModified(!requestMatchesOnDocModified)
                 }
               ></input>
-              <label>Enable real-time checking</label>
+              <label htmlFor="real-time-checks" className="Controls__label">
+                Enable real-time checking
+              </label>
             </div>
-            <div>
+            <div className="Controls__input-group">
               <input
                 type="checkbox"
+                id="debug"
                 checked={debug}
                 onChange={() => setDebugState(!debug)}
               ></input>
-              <label>Show pending and inflight checks</label>
+              <label htmlFor="debug" className="Controls__label">
+                Show pending and inflight checks
+              </label>
             </div>
           </div>
         )}

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -48,7 +48,7 @@ const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
           <Controls
             store={store}
             clearMatches={() => commands.clearMatches()}
-            setDebugState={value => commands.setConfigValue("debug", value)}
+            setShowPendingInflightChecks={value => commands.setConfigValue("showPendingInflightChecks", value)}
             setRequestOnDocModified={value =>
               commands.setConfigValue("requestMatchesOnDocModified", value)
             }

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -17,6 +17,7 @@ interface IProps<TPluginState extends IPluginState> {
   feedbackHref?: string;
   editorScrollElement: Element;
   getScrollOffset: () => number;
+  enableDevMode?: boolean;
 }
 
 const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
@@ -26,7 +27,8 @@ const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
   contactHref,
   editorScrollElement,
   getScrollOffset,
-  feedbackHref
+  feedbackHref,
+  enableDevMode
 }: IProps<TPluginState>) => {
   const [pluginState, setPluginState] = useState<IPluginState | undefined>(
     undefined
@@ -55,6 +57,7 @@ const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
             addCategory={matcherService.addCategory}
             removeCategory={matcherService.removeCategory}
             feedbackHref={feedbackHref}
+            enableDevMode={enableDevMode}
           />
           <Results
             store={store}

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -33,6 +33,8 @@ interface IViewOptions<TPluginState extends IPluginState> {
   // document might change during the lifecycle of the page.
   getScrollOffset?: () => number;
   telemetryAdapter?: TyperighterTelemetryAdapter;
+  // Expose useful utilities for developers.
+  enableDevMode?: boolean;
 }
 
 /**
@@ -55,7 +57,8 @@ const createView = <TPluginState extends IPluginState<MatchType[]>>({
   logger = consoleLogger,
   onMarkCorrect,
   editorScrollElement,
-  getScrollOffset = () => 50
+  getScrollOffset = () => 50,
+  enableDevMode = false
 }: IViewOptions<TPluginState>) => {
   // Create our overlay node, which is responsible for displaying
   // match messages when the user hovers over highlighted ranges.
@@ -106,6 +109,7 @@ const createView = <TPluginState extends IPluginState<MatchType[]>>({
         feedbackHref={feedbackHref}
         editorScrollElement={editorScrollElement}
         getScrollOffset={getScrollOffset}
+        enableDevMode={enableDevMode}
       />
     </TelemetryContext.Provider>,
     sidebarNode

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -82,7 +82,7 @@ export const deriveFilteredDecorations = <TPluginState extends IPluginState>(
   const decorationsToRemove = newState.decorations.find(
     undefined,
     undefined,
-    spec => !filteredMatchIds.includes(spec.id)
+    spec => spec.id && !filteredMatchIds.includes(spec.id)
   );
 
   const decorations = newState.decorations

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -810,13 +810,31 @@ const handleSetConfigValue = <TPluginState extends IPluginState>(
   _: Transaction,
   state: TPluginState,
   { payload: { key, value } }: ActionSetConfigValue
-): TPluginState => ({
-  ...state,
-  config: {
-    ...state.config,
-    [key]: value
+): TPluginState => {
+  const newState = {
+    ...state,
+    config: {
+      ...state.config,
+      [key]: value
+    }
+  };
+
+  const shouldRemovePendingInflightDecos = key === "showPendingInflightChecks" && !!state.config.showPendingInflightChecks && value === false
+  if (shouldRemovePendingInflightDecos) {
+    return {
+      ...newState,
+      decorations: state.decorations.remove(
+        state.decorations.find(
+          undefined,
+          undefined,
+          spec =>
+            spec.type === DECORATION_INFLIGHT || spec.type === DECORATION_DIRTY
+        )
+      )
+    };
   }
-});
+  return newState;
+};
 
 const handleSetFilterState = <TPluginState extends IPluginState>(
   _: Transaction,

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -180,3 +180,5 @@ export const selectDocumentHasChanged = (state: IPluginState): boolean => {
 export const selectDocumentIsEmpty = (state: IPluginState): boolean => {
   return state.docIsEmpty;
 };
+
+export const selectPluginConfig = (state: IPluginState) => state.config

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -8,15 +8,20 @@ import {
   createStateWithMatches,
   defaultDoc,
   createBlock,
-  exampleRequestId,
+  exampleRequestId
 } from "../../test/helpers/fixtures";
 import {
+  createDebugDecorationFromRange,
   getNewDecorationsForCurrentMatches,
   MatchType
 } from "../../utils/decoration";
 import { filterByMatchState, IDefaultFilterState } from "../../utils/plugin";
 import { expandRangesToParentBlockNode } from "../../utils/range";
-import { deriveFilteredDecorations, getNewStateFromTransaction, isFilterStateStale } from "../helpers";
+import {
+  deriveFilteredDecorations,
+  getNewStateFromTransaction,
+  isFilterStateStale
+} from "../helpers";
 import { createReducer, IPluginState } from "../reducer";
 
 describe("State helpers", () => {
@@ -120,6 +125,25 @@ describe("State helpers", () => {
       expect(currentMatches).toEqual(matches);
       expect(filteredMatches).toEqual([]);
       expect(decorations).toEqual(DecorationSet.empty);
+    });
+
+    it("should not touch non-match-related decorations", () => {
+      const { tr, state } = getState([], [MatchType.DEFAULT]);
+      const debugDecos = DecorationSet.create(tr.doc, [
+        createDebugDecorationFromRange({ from: 0, to: 1 })
+      ]);
+      const stateWithDebugDecos: IPluginState<IDefaultFilterState> = {
+        ...state,
+        decorations: debugDecos
+      };
+
+      const { decorations } = deriveFilteredDecorations(
+        tr.doc,
+        stateWithDebugDecos,
+        filterByMatchState
+      );
+
+      expect(decorations).toEqual(debugDecos);
     });
   });
 

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -870,5 +870,30 @@ describe("Action handlers", () => {
         setConfigValue("debug", "true")
       );
     });
+
+    it("should remove debug decorations if showPendingInflightChecks is no longer true", () => {
+      const { state } = createInitialData();
+
+      const stateWithCurrentMatchesAndDecorations = {
+        ...state,
+        config: {
+          ...state.config,
+          showPendingInflightChecks: true
+        },
+        decorations: DecorationSet.create(defaultDoc, [
+          createDebugDecorationFromRange({ from: 1, to: 2 })
+        ])
+      };
+
+      const newState = reducer(
+        new Transaction(defaultDoc),
+        stateWithCurrentMatchesAndDecorations,
+        setConfigValue("showPendingInflightChecks", false)
+      );
+
+      expect(newState.decorations).toEqual(
+        DecorationSet.create(defaultDoc, [])
+      );
+    });
   });
 });

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -83,7 +83,7 @@ describe("Action handlers", () => {
           tr,
           {
             ...state,
-            config: { ...state.config, debug: true },
+            config: { ...state.config, showPendingInflightChecks: true },
             dirtiedRanges: [{ from: 5, to: 10 }],
             requestPending: true
           },
@@ -93,7 +93,7 @@ describe("Action handlers", () => {
         ...state,
         config: {
           ...state.config,
-          debug: true
+          showPendingInflightChecks: true
         },
         dirtiedRanges: [],
         decorations: DecorationSet.empty.add(tr.doc, [
@@ -117,7 +117,7 @@ describe("Action handlers", () => {
         tr,
         {
           ...state,
-          config: { ...state.config, debug: true },
+          config: { ...state.config, showPendingInflightChecks: true },
           dirtiedRanges: [{ from: 5, to: 10 }],
           decorations: DecorationSet.empty.add(tr.doc, [
             createDebugDecorationFromRange({ from: 1, to: 3 })
@@ -142,7 +142,7 @@ describe("Action handlers", () => {
         tr,
         {
           ...state,
-          config: { ...state.config, debug: true },
+          config: { ...state.config, showPendingInflightChecks: true },
           dirtiedRanges: [
             { from: 5, to: 10 },
             { from: 28, to: 35 }
@@ -848,9 +848,9 @@ describe("Action handlers", () => {
         reducer(
           new Transaction(createDoc),
           state,
-          setConfigValue("debug", true)
+          setConfigValue("showPendingInflightChecks", true)
         )
-      ).toEqual({ ...state, config: { ...state.config, debug: true } });
+      ).toEqual({ ...state, config: { ...state.config, showPendingInflightChecks: true } });
     });
     it("should not accept incorrect config keys", () => {
       const { state } = createInitialData();

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -50,7 +50,7 @@ export const createDebugDecorationFromRange = (range: IRange, dirty = true) => {
   const type = dirty ? DECORATION_DIRTY : DECORATION_INFLIGHT;
   return Decoration.inline(
     range.from,
-    range.to + 1,
+    range.to,
     {
       class: DecorationClassMap[type]
     },


### PR DESCRIPTION
## What does this change?

Adds a 'dev mode' parameter to the view function, which when `true` presents the user with two checkboxes that permit:

- Turning real-time checking on and off
- Adding annotations to ranges that have pending (orange) or in-flight (green) checks.

Pending checks are only really relevant in real time mode – they represent the ranges that have been 'dirtied' since the last check, and are due to be sent to Typerighter. In-flight checks have been sent to Typerighter and have not yet come back.

Here's how the UI looks:

<img width="411" alt="Screenshot 2022-07-13 at 15 08 04" src="https://user-images.githubusercontent.com/7767575/178755556-9d446e91-7d1f-48fa-826d-bc7e7cbf2f97.png">

And here's the annotations at work, with an explanation:

![pm-debug](https://user-images.githubusercontent.com/7767575/178755642-9c192fb5-b3c9-4df0-adc1-4a962d2986db.gif)

I've defaulted dev mode to true in the sandbox – hopefully that makes sense.

## How to test

Fire up prosemirror-typerighter locally and have a play. Does it behave as expected? Do you think these things will be useful?