### PR TITLE
chore: Add instructions for local testing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,10 +21,6 @@ If your Typerighter service does require pan-domain authentication, you will nee
 
 The plugin must be pointed to the address of a running Typerighter service to submit a document and receive matches. To modify this address, change the address passed to the `TyperighterAdapter` in `pages/index.ts`.
 
-To test this plugin in applications that use it before publishing a release, use [`npm link`](https://docs.npmjs.com/cli/link) –
-- Run `npm link` in the root of this project
-- Run `npm link @guardian/prosemirror-typerighter` in the root of the project that's consuming this package.
-
 ## Testing locally in applications that use `prosemirror-typerighter`
 
 We've found yalc useful in testing local changes to prosemirror-typerighter in applications that use it.
@@ -32,10 +28,10 @@ We've found yalc useful in testing local changes to prosemirror-typerighter in a
 Setup: 
 
 1. Install `yalc` globally with `npm i yalc -g` or `yarn global add yalc`.
-2. Run `yarn yalc` in your local project from your current branch, to build the project and push changes to yalc.
+2. Run `npm run yalc` in your local project from your current branch, to build the project and push changes to yalc.
 3. Run `yalc add @guardian/prosemirror-typerighter` within the project consuming prosemirror-typerighter locally.
 
-Note: any changes you make to your local prosemirror-typerighter branch must be republished (step 3). Don't forget to run `yarn yalc` again!
+Note: any changes you make to your local prosemirror-typerighter branch must be republished (step 3). Don't forget to run `npm run yalc` again!
 
 ## Updating documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,18 @@ To test this plugin in applications that use it before publishing a release, use
 - Run `npm link` in the root of this project
 - Run `npm link @guardian/prosemirror-typerighter` in the root of the project that's consuming this package.
 
+## Testing locally in applications that use `prosemirror-typerighter`
+
+We've found yalc useful in testing local changes to prosemirror-typerighter in applications that use it.
+
+Setup: 
+
+1. Install `yalc` globally with `npm i yalc -g` or `yarn global add yalc`.
+2. Run `yarn yalc` in your local project from your current branch, to build the project and push changes to yalc.
+3. Run `yalc add @guardian/prosemirror-typerighter` within the project consuming prosemirror-typerighter locally.
+
+Note: any changes you make to your local prosemirror-typerighter branch must be republished (step 3). Don't forget to run `yarn yalc` again!
+
 ## Updating documentation
 
 To update the project readme, edit the README.md in ./build and run `build:doc`. This runs Typedoc and appends the generated type information to the readme file, which is then published to the ./docs folder.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "report-coverage": "jest --env=jsdom --coverage --coverageReporters=text-lcov | coveralls",
     "prepublishOnly": "npm run build",
     "format": "prettier --write './src/**/*.ts'",
-    "publish-pages": "git subtree push --prefix pages/dist origin gh-pages"
+    "publish-pages": "git subtree push --prefix pages/dist origin gh-pages",
+    "yalc": "npm run build && yalc push"
   },
   "devDependencies": {
     "@testing-library/dom": "^7.23.0",


### PR DESCRIPTION
## What does this change?

Adds instructions for local testing. Cribbed from [prosemirror-elements.](https://github.com/guardian/prosemirror-elements)

## How to test

Do the instructions make sense? Do they work?
