### PR TITLE
feat: Add chunked adapter

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -14,12 +14,12 @@ import "../src/css/index.scss";
 import createTyperighterPlugin from "../src/ts/createTyperighterPlugin";
 import createView from "../src/ts/createView";
 import { createBoundCommands } from "../src/ts/commands";
-import { TyperighterAdapter } from "../src/ts";
 import TyperighterTelemetryAdapter from "../src/ts/services/TyperighterTelemetryAdapter";
 import { UserTelemetryEventSender } from "@guardian/user-telemetry-client";
 import { MatchType } from "../src/ts/utils/decoration";
 import { filterByMatchState } from "../src/ts/utils/plugin";
 import { findMarkPositions } from "../src/ts/utils/prosemirror";
+import TyperighterChunkedAdapter from "../src/ts/services/adapters/TyperighterChunkedAdapter";
 
 const mySchema = new Schema({
   nodes: addListNodes(schema.spec.nodes as any, "paragraph block*", "block"),
@@ -49,7 +49,12 @@ const typerighterTelemetryAdapter = new TyperighterTelemetryAdapter(
   "DEV"
 );
 
-const { plugin: validatorPlugin, store, getState, matcherService } = createTyperighterPlugin({
+const {
+  plugin: validatorPlugin,
+  store,
+  getState,
+  matcherService
+} = createTyperighterPlugin({
   isElementPartOfTyperighterUI,
   filterOptions: {
     filterMatches: filterByMatchState,
@@ -59,8 +64,10 @@ const { plugin: validatorPlugin, store, getState, matcherService } = createTyper
     findMarkPositions(node, from, to, mySchema.marks.code),
   onMatchDecorationClicked: match =>
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
-    requestMatchesOnDocModified: true,
-  adapter: new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk"), 
+  requestMatchesOnDocModified: true,
+  adapter: new TyperighterChunkedAdapter(
+    "https://checker.typerighter.local.dev-gutools.co.uk"
+  ),
   telemetryAdapter: typerighterTelemetryAdapter
 });
 

--- a/src/ts/services/adapters/TyperighterChunkedAdapter.ts
+++ b/src/ts/services/adapters/TyperighterChunkedAdapter.ts
@@ -43,6 +43,17 @@ class TyperighterChunkedAdapter extends TyperighterAdapter
       })
     });
 
+    if (response.status === 401 || response.status === 419) {
+      onRequestError({
+        requestId,
+        blockId: inputs[0]?.id ?? "no-id",
+        message: `${response.status}: ${response.statusText}`,
+        categoryIds,
+        type: "AUTH_ERROR"
+      });
+      onRequestComplete(requestId);
+    }
+
     const reader = response.body?.getReader();
 
     if (!reader) {

--- a/src/ts/services/adapters/TyperighterChunkedAdapter.ts
+++ b/src/ts/services/adapters/TyperighterChunkedAdapter.ts
@@ -1,0 +1,114 @@
+import { IBlock } from "../../interfaces/IMatch";
+import TyperighterAdapter from "./TyperighterAdapter";
+import {
+  TMatchesReceivedCallback,
+  TRequestErrorCallback,
+  IMatcherAdapter,
+  TRequestCompleteCallback
+} from "../../interfaces/IMatcherAdapter";
+
+/**
+ * An adapter for the Typerighter service that uses a chunked response.
+ */
+class TyperighterChunkedAdapter extends TyperighterAdapter
+  implements IMatcherAdapter {
+  private decoder = new TextDecoder();
+
+  public fetchMatches = async (
+    requestId: string,
+    inputs: IBlock[],
+    categoryIds: string[],
+    onMatchesReceived: TMatchesReceivedCallback,
+    onRequestError: TRequestErrorCallback,
+    onRequestComplete: TRequestCompleteCallback
+  ) => {
+    const blocks = inputs.map(input => ({
+      id: input.id,
+      text: input.text,
+      from: input.from,
+      to: input.to,
+      categoryIds
+    }));
+
+    const response = await fetch(`${this.url}/checkStream`, {
+      method: "POST",
+      credentials: "include",
+      headers: new Headers({
+        "Content-Type": "application/json"
+      }),
+      body: JSON.stringify({
+        requestId,
+        blocks
+      })
+    });
+
+    const reader = response.body?.getReader();
+
+    if (!reader) {
+      onRequestError({
+        requestId,
+        message: "Typerighter did not send a response",
+        categoryIds
+      });
+      onRequestComplete(requestId);
+
+      return;
+    }
+
+    const readStream = reader.read().then(initialChunk => {
+      const RECORD_SEPARATOR = String.fromCharCode(31);
+      let buffer = "";
+
+      const processStringChunk = (chunk: string, includeBuffer = true) => {
+        const textChunks = (includeBuffer ? buffer + chunk : chunk).split(RECORD_SEPARATOR);
+
+        for (const rawJson of textChunks) {
+          const json = rawJson.trim();
+          if (!json.length) {
+            break;
+          }
+
+          try {
+            const message = JSON.parse(json.trim());
+            this.responseBuffer.push(message);
+            this.throttledHandleResponse(requestId, onMatchesReceived);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+
+        buffer = textChunks[textChunks.length - 1].trim();
+      };
+
+      const streamIterator = ({
+        done,
+        value
+      }: ReadableStreamDefaultReadResult<Uint8Array>): Promise<void> => {
+        if (done) {
+          if (buffer.length) {
+            processStringChunk(buffer, false);
+          }
+          return Promise.resolve();
+        }
+
+        const textChunks = this.decoder.decode(value);
+        processStringChunk(textChunks);
+
+        // Read some more, and call this function again
+        return reader.read().then(streamIterator);
+      };
+
+      return streamIterator(initialChunk);
+    });
+
+    readStream
+      .catch(error => {
+        onRequestError({ requestId, message: error.message, categoryIds });
+      })
+      .finally(() => {
+        onRequestComplete(requestId);
+      });
+  };
+}
+
+export default TyperighterChunkedAdapter;

--- a/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
+++ b/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
@@ -1,40 +1,123 @@
-import { noop, partial } from "lodash";
+import { noop } from "lodash";
 import { ReadableStream } from "stream/web";
-import { TextDecoder, TextEncoder } from "util";
-import {
+import { TextEncoder } from "util";
+import { IMatcherResponse } from "../../../interfaces/IMatch";
+import TyperighterChunkedAdapter, {
   readJsonSeqStream,
   RECORD_SEPARATOR
 } from "../TyperighterChunkedAdapter";
 
-describe("readJsonSeqStream", () => {
-  const textDecoder = new TextDecoder();
-  const textEncoder = new TextEncoder();
+const textEncoder = new TextEncoder();
 
-  const createJsonSeqArrFromRecords = (
-    records: Array<Record<string, unknown>>
-  ) => records.map(record => JSON.stringify(record) + RECORD_SEPARATOR);
+const createJsonSeqArrFromRecords = (records: any[]) =>
+  records.map(record => JSON.stringify(record) + RECORD_SEPARATOR);
 
-  const createStream = (records: string[]) => {
-    const stream = new ReadableStream({
-      start: controller => {
-        records.forEach(record =>
-          controller.enqueue(textEncoder.encode(record))
-        );
-        controller.close();
+const createStream = (records: string[]) =>
+  new ReadableStream({
+    start: controller => {
+      records.forEach(record => controller.enqueue(textEncoder.encode(record)));
+      controller.close();
+    }
+  });
+
+describe("TyperighterChunkedAdapter", () => {
+  const localFetch = global.fetch;
+  const onReceived = jest.fn();
+  const onError = jest.fn();
+  const onComplete = jest.fn();
+
+  const mockFetchBody = (partialRequest: Partial<Response>) =>
+    (global.fetch = jest.fn(() => Promise.resolve(partialRequest) as any));
+
+  afterAll(() => {
+    global.fetch = localFetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("on a successful response, it should call `onMatchesReceived` for each record, and finally call `onRequestComplete`", async () => {
+    const adapter = new TyperighterChunkedAdapter("https://example.com");
+    const input: IMatcherResponse[] = [
+      {
+        blocks: [],
+        categoryIds: ["1"],
+        matches: [],
+        requestId: "request-id"
+      },
+      {
+        blocks: [],
+        categoryIds: ["2"],
+        matches: [],
+        requestId: "request-id"
       }
-    });
-    return stream.getReader();
-  };
+    ];
+    const jsonSeq = createJsonSeqArrFromRecords(input);
+    const stream = createStream(jsonSeq);
+    mockFetchBody({ body: stream });
 
+    await adapter.fetchMatches(
+      "request-id",
+      [],
+      [],
+      onReceived,
+      onError,
+      onComplete
+    );
+
+    expect(onReceived).toHaveBeenCalledWith(input[0]);
+    expect(onReceived).toHaveBeenCalledWith(input[1]);
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it("on an empty response, it should call `onRequestError`, and finally call `onRequestComplete`", async () => {
+    const adapter = new TyperighterChunkedAdapter("https://example.com");
+    mockFetchBody({ body: undefined });
+
+    await adapter.fetchMatches(
+      "request-id",
+      [],
+      [],
+      onReceived,
+      onError,
+      onComplete
+    );
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      message: "Typerighter did not send a response"
+    });
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it("on an non-2XX response, it should call `onRequestError`, and finally call `onRequestComplete`", async () => {
+    const adapter = new TyperighterChunkedAdapter("https://example.com");
+    mockFetchBody({ status: 500, statusText: "Server error" });
+
+    await adapter.fetchMatches(
+      "request-id",
+      [],
+      [],
+      onReceived,
+      onError,
+      onComplete
+    );
+
+    expect(onError.mock.calls[0][0]).toMatchObject({
+      message: "Typerighter did not send a response"
+    });
+    expect(onComplete).toHaveBeenCalled();
+  });
+});
+
+describe("readJsonSeqStream", () => {
   it("should consume record-separated JSON – single record", async () => {
     const input = [{ id: 1 }];
     const jsonSeq = createJsonSeqArrFromRecords(input);
-    const stream = createStream(jsonSeq);
+    const stream = createStream(jsonSeq).getReader();
     const outputBuffer = [] as Array<Record<string, unknown>>;
 
-    await readJsonSeqStream(stream, textDecoder as any, message =>
-      outputBuffer.push(message)
-    );
+    await readJsonSeqStream(stream, message => outputBuffer.push(message));
 
     expect(outputBuffer).toEqual(input);
   });
@@ -42,12 +125,10 @@ describe("readJsonSeqStream", () => {
   it("should consume record-separated JSON – multiple records", async () => {
     const input = [{ id: 1 }, { id: 2 }, { id: 3 }];
     const jsonSeq = createJsonSeqArrFromRecords(input);
-    const stream = createStream(jsonSeq);
+    const stream = createStream(jsonSeq).getReader();
     const outputBuffer = [] as Array<Record<string, unknown>>;
 
-    await readJsonSeqStream(stream, textDecoder as any, message =>
-      outputBuffer.push(message)
-    );
+    await readJsonSeqStream(stream, message => outputBuffer.push(message));
 
     expect(outputBuffer).toEqual(input);
   });
@@ -64,27 +145,25 @@ describe("readJsonSeqStream", () => {
     const [longMessage] = createJsonSeqArrFromRecords(input);
 
     // Split a single record into multiple strings that are only valid when
-    // recombined
+    // recombined. By splitting on a double quote, we have lots of little records
     const partialMessages = longMessage
       .split('"')
       .map((msg, i) => (i > 0 ? '"' + msg : msg));
     expect(partialMessages.length).toBeGreaterThan(1);
 
-    const stream = createStream(partialMessages);
+    const stream = createStream(partialMessages).getReader();
     const outputBuffer = [] as Array<Record<string, unknown>>;
 
-    await readJsonSeqStream(stream, textDecoder as any, message =>
-      outputBuffer.push(message)
-    );
+    await readJsonSeqStream(stream, message => outputBuffer.push(message));
 
     expect(outputBuffer).toEqual(input);
   });
 
   it("should throw when it receives invalid json", async () => {
     expect.assertions(1);
-    const stream = createStream(["This is not JSON"]);
+    const stream = createStream(["This is not JSON"]).getReader();
 
-    const readInvalidStream = readJsonSeqStream(stream, textDecoder as any, noop);
+    const readInvalidStream = readJsonSeqStream(stream, noop);
 
     await expect(readInvalidStream).rejects.toBeInstanceOf(SyntaxError);
   });

--- a/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
+++ b/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
@@ -90,7 +90,7 @@ describe("TyperighterChunkedAdapter", () => {
     expect(onComplete).toHaveBeenCalled();
   });
 
-  it("on an non-2XX response, it should call `onRequestError`, and finally call `onRequestComplete`", async () => {
+  it("it should call `onRequestError` for an non-2XX response, and finally call `onRequestComplete`", async () => {
     const adapter = new TyperighterChunkedAdapter("https://example.com");
     mockFetchBody({ status: 500, statusText: "Server error" });
 

--- a/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
+++ b/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
@@ -1,0 +1,91 @@
+import { noop, partial } from "lodash";
+import { ReadableStream } from "stream/web";
+import { TextDecoder, TextEncoder } from "util";
+import {
+  readJsonSeqStream,
+  RECORD_SEPARATOR
+} from "../TyperighterChunkedAdapter";
+
+describe("readJsonSeqStream", () => {
+  const textDecoder = new TextDecoder();
+  const textEncoder = new TextEncoder();
+
+  const createJsonSeqArrFromRecords = (
+    records: Array<Record<string, unknown>>
+  ) => records.map(record => JSON.stringify(record) + RECORD_SEPARATOR);
+
+  const createStream = (records: string[]) => {
+    const stream = new ReadableStream({
+      start: controller => {
+        records.forEach(record =>
+          controller.enqueue(textEncoder.encode(record))
+        );
+        controller.close();
+      }
+    });
+    return stream.getReader();
+  };
+
+  it("should consume record-separated JSON – single record", async () => {
+    const input = [{ id: 1 }];
+    const jsonSeq = createJsonSeqArrFromRecords(input);
+    const stream = createStream(jsonSeq);
+    const outputBuffer = [] as Array<Record<string, unknown>>;
+
+    await readJsonSeqStream(stream, textDecoder as any, message =>
+      outputBuffer.push(message)
+    );
+
+    expect(outputBuffer).toEqual(input);
+  });
+
+  it("should consume record-separated JSON – multiple records", async () => {
+    const input = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const jsonSeq = createJsonSeqArrFromRecords(input);
+    const stream = createStream(jsonSeq);
+    const outputBuffer = [] as Array<Record<string, unknown>>;
+
+    await readJsonSeqStream(stream, textDecoder as any, message =>
+      outputBuffer.push(message)
+    );
+
+    expect(outputBuffer).toEqual(input);
+  });
+
+  it("should buffer incomplete records", async () => {
+    const input = [
+      {
+        id: 1,
+        type: "LONG_RECORD",
+        description:
+          "This is a long record that will be split into multiple parts"
+      }
+    ];
+    const [longMessage] = createJsonSeqArrFromRecords(input);
+
+    // Split a single record into multiple strings that are only valid when
+    // recombined
+    const partialMessages = longMessage
+      .split('"')
+      .map((msg, i) => (i > 0 ? '"' + msg : msg));
+    expect(partialMessages.length).toBeGreaterThan(1);
+
+    const stream = createStream(partialMessages);
+    const outputBuffer = [] as Array<Record<string, unknown>>;
+
+    await readJsonSeqStream(stream, textDecoder as any, message =>
+      outputBuffer.push(message)
+    );
+
+    expect(outputBuffer).toEqual(input);
+  });
+
+  it("should throw when it receives invalid json", async () => {
+    expect.assertions(1);
+    const stream = createStream(["This is not JSON"]);
+
+    const readInvalidStream = readJsonSeqStream(stream, textDecoder as any, noop);
+
+    await expect(readInvalidStream).rejects.toBeInstanceOf(SyntaxError);
+  });
+});

--- a/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
+++ b/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
@@ -71,7 +71,7 @@ describe("TyperighterChunkedAdapter", () => {
     expect(onComplete).toHaveBeenCalled();
   });
 
-  it("on an empty response, it should call `onRequestError`, and finally call `onRequestComplete`", async () => {
+  it("should call `onRequestError` for an empty response, and finally call `onRequestComplete`", async () => {
     const adapter = new TyperighterChunkedAdapter("https://example.com");
     mockFetchBody({ body: undefined });
 

--- a/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
+++ b/src/ts/services/adapters/test/TyperighterChunkedAdapter.spec.ts
@@ -37,7 +37,7 @@ describe("TyperighterChunkedAdapter", () => {
     jest.restoreAllMocks();
   });
 
-  it("on a successful response, it should call `onMatchesReceived` for each record, and finally call `onRequestComplete`", async () => {
+  it("should call `onMatchesReceived` for each record in a successful response, and finally call `onRequestComplete`", async () => {
     const adapter = new TyperighterChunkedAdapter("https://example.com");
     const input: IMatcherResponse[] = [
       {


### PR DESCRIPTION
## What does this change?

Adds a TyperighterAdapter that handles a chunked response that returns [json-seq](https://en.wikipedia.org/wiki/JSON_streaming#Record_separator-delimited_JSON_2). The counterpart to [this PR](https://github.com/guardian/typerighter/pull/20) in Typerighter.

## Dev notes

Reading the stream was more involved than expected, because there is no guarantee that the chunks we read from the stream correspond to complete records – even if (as is explained in the PR above) the server is sending chunks that happen to correspond to complete records. As a result, we maintain a buffer and wait until we see a `RECORD_SEPARATOR` before flushing records to Typerighter.

That chunk-to-record behaviour isn't specified anywhere, and so it's best probably best not to rely on it, anyhow.

## How to test

- The automated tests should pass. The coverage should be good, as there are a few edge cases I wanted to guard against (and I discovered more when writing the tests.)
- Try running this branch against a version of typerighter Typerighter that supports chunked responses ([e.g. this branch.](https://github.com/guardian/typerighter/pull/20)) You should see a single request going out, and matches streaming into the document as usual.