### PR TITLE
feat: Remove summary toggle

### DIFF
--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -90,7 +90,7 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
     <>
       <div className="Sidebar__header-container">
         <div className="Sidebar__header">
-          Results {hasMatches && <span>({filteredMatches.length}) </span>}
+          Results {!!hasMatches && `(${filteredMatches.length})`}
         </div>
         <div className="Sidebar__header-bottom">
           {pluginState && pluginState.config.matchColours && (

--- a/src/ts/components/SidebarMatches.tsx
+++ b/src/ts/components/SidebarMatches.tsx
@@ -78,7 +78,6 @@ interface ISidebarProps {
   selectedMatch: string | undefined;
   editorScrollElement: Element;
   getScrollOffset: () => number;
-  isSummaryView: boolean;
 }
 
 const SidebarMatches = ({
@@ -89,8 +88,7 @@ const SidebarMatches = ({
   stopHighlight,
   selectedMatch,
   editorScrollElement,
-  getScrollOffset,
-  isSummaryView
+  getScrollOffset
 }: ISidebarProps) => {
   const groupedCurrentMatches = chain(matches)
     .groupBy("ruleId")
@@ -100,67 +98,53 @@ const SidebarMatches = ({
 
   return (
     <ul className="Sidebar__list">
-      {isSummaryView
-        ? groupedCurrentMatches.map(group => {
-            const matchElements =
-              group.length > 1 ? (
-                <SidebarMatchGroup
-                  matchColours={matchColours}
-                  matchGroup={group}
-                  selectedMatch={selectedMatch}
-                  selectMatch={selectMatch}
-                  indicateHighlight={indicateHighlight}
-                  stopHighlight={stopHighlight}
-                  editorScrollElement={editorScrollElement}
-                  getScrollOffset={getScrollOffset}
-                  key={group[0].matchId}
-                />
-              ) : (
-                group[0] && (
-                  <SidebarMatch
-                    matchColours={matchColours}
-                    match={group[0]}
-                    selectedMatch={selectedMatch}
-                    selectMatch={selectMatch}
-                    indicateHighlight={indicateHighlight}
-                    stopHighlight={stopHighlight}
-                    editorScrollElement={editorScrollElement}
-                    getScrollOffset={getScrollOffset}
-                    key={group[0].matchId}
-                  />
-                )
-              );
-
-            const matchType = group[0] && getMatchType(group[0]);
-            const shouldInsertHeader = matchType !== currentMatchType;
-            if (shouldInsertHeader) {
-              currentMatchType = matchType;
-              return (
-                <MatchHeader
-                  matchColours={matchColours}
-                  match={group[0]}
-                  matchType={currentMatchType}
-                  key={currentMatchType}
-                >
-                  {matchElements}
-                </MatchHeader>
-              );
-            }
-            return matchElements;
-          })
-        : matches.map(match => (
-            <SidebarMatch
+      {groupedCurrentMatches.map(group => {
+        const matchElements =
+          group.length > 1 ? (
+            <SidebarMatchGroup
               matchColours={matchColours}
-              match={match}
+              matchGroup={group}
               selectedMatch={selectedMatch}
               selectMatch={selectMatch}
               indicateHighlight={indicateHighlight}
               stopHighlight={stopHighlight}
               editorScrollElement={editorScrollElement}
               getScrollOffset={getScrollOffset}
-              key={match.matchId}
+              key={group[0].matchId}
             />
-          ))}
+          ) : (
+            group[0] && (
+              <SidebarMatch
+                matchColours={matchColours}
+                match={group[0]}
+                selectedMatch={selectedMatch}
+                selectMatch={selectMatch}
+                indicateHighlight={indicateHighlight}
+                stopHighlight={stopHighlight}
+                editorScrollElement={editorScrollElement}
+                getScrollOffset={getScrollOffset}
+                key={group[0].matchId}
+              />
+            )
+          );
+
+        const matchType = group[0] && getMatchType(group[0]);
+        const shouldInsertHeader = matchType !== currentMatchType;
+        if (shouldInsertHeader) {
+          currentMatchType = matchType;
+          return (
+            <MatchHeader
+              matchColours={matchColours}
+              match={group[0]}
+              matchType={currentMatchType}
+              key={currentMatchType}
+            >
+              {matchElements}
+            </MatchHeader>
+          );
+        }
+        return matchElements;
+      })}
     </ul>
   );
 };

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -12,7 +12,6 @@ export enum TYPERIGHTER_TELEMETRY_TYPE {
   TYPERIGHTER_CLEAR_DOCUMENT = "TYPERIGHTER_CLEAR_DOCUMENT",
   TYPERIGHTER_OPEN_STATE_CHANGED = "TYPERIGHTER_OPEN_STATE_CHANGED",
   TYPERIGHTER_SIDEBAR_MATCH_CLICK = "TYPERIGHTER_SIDEBAR_MATCH_CLICK",
-  TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED = "TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED",
   TYPERIGHTER_FILTER_STATE_CHANGED = "TYPERIGHTER_FILTER_STATE_CHANGED"
 }
 
@@ -57,7 +56,8 @@ export interface IMarkAsCorrectEvent extends ITyperighterTelemetryEvent {
   tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
 }
 
-export interface IMatchDecorationClickedEvent extends ITyperighterTelemetryEvent {
+export interface IMatchDecorationClickedEvent
+  extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_DECORATION_CLICKED;
   value: 1;
   tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
@@ -82,11 +82,6 @@ export interface ISidebarClickEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK;
   value: 1;
   tags: ITyperighterTelemetryEvent["tags"] & IMatchEventTags;
-}
-
-export interface ISummaryToggleEvent extends ITyperighterTelemetryEvent {
-  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED;
-  value: 0 | 1;
 }
 
 export interface IFilterToggleEvent extends ITyperighterTelemetryEvent {

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -8,7 +8,6 @@ import {
   IOpenTyperighterEvent,
   ISidebarClickEvent,
   ISuggestionAcceptedEvent,
-  ISummaryToggleEvent,
   ITyperighterTelemetryEvent,
   TYPERIGHTER_TELEMETRY_TYPE
 } from "../interfaces/ITelemetryData";
@@ -113,17 +112,6 @@ class TyperighterTelemetryAdapter {
         ...this.getTelemetryTagsFromMatch(match)
       }
     } as IMatchFoundEvent);
-  }
-
-  public summaryViewToggled(
-    toggledOn: boolean,
-    tags: ITyperighterTelemetryEvent["tags"]
-  ) {
-    this.addEvent({
-      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SUMMARY_VIEW_TOGGLE_CHANGED,
-      value: toggledOn ? 1 : 0,
-      tags
-    } as ISummaryToggleEvent);
   }
 
   public filterStateToggled(matchType: MatchType, toggledOn: boolean) {

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -165,14 +165,6 @@ export const selectImportanceOrderedMatches = <TMatch extends IMatch>(
     getSortOrderForMatchAppearance
   );
 
-export const selectMatches = <TMatch extends IMatch>(
-  state: IPluginState<unknown, TMatch>,
-  sortByImportance: boolean
-): Array<IMatch<ISuggestion>> =>
-  sortByImportance
-    ? selectImportanceOrderedMatches(state)
-    : selectDocumentOrderedMatches(state);
-
 export const selectDocumentHasChanged = (state: IPluginState): boolean => {
   return state.docChangedSinceCheck;
 };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Removes the summary toggle. We know from our telemetry that it's no longer used frequently enough to warrant its existence:

<img width="800" alt="Screenshot 2022-07-25 at 13 43 42" src="https://user-images.githubusercontent.com/7767575/180780155-2bcbe231-7611-4fc7-b6d5-dd152a0b0740.png">

|Before|✨After✨|
|-|-|
|<img width="409" alt="Screenshot 2022-07-25 at 13 44 59" src="https://user-images.githubusercontent.com/7767575/180780626-d90e40dc-6c86-46d6-a990-80309c36dc50.png">|<img width="409" alt="Screenshot 2022-07-25 at 13 44 48" src="https://user-images.githubusercontent.com/7767575/180780663-f1a73704-57db-4eeb-bed3-271604b2d74f.png">|


## How to test

Is the toggle gone? Is any related code cleared out?