### PR TITLE
feat: Add optional tags to Typerighter Telemetry Adaptor

### DIFF
--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -23,6 +23,11 @@ class TyperighterTelemetryAdapter {
     private tags?: IUserTelemetryEvent["tags"],
   ) {}
 
+  // used by flexible-content to update tags that are only known after the telemetry adaptor has been initialised
+  public updateTelemetryTags(tags: IUserTelemetryEvent["tags"]) {
+    this.tags = { ...this.tags, ...tags};
+  }
+
   public suggestionIsAccepted(
     match: IMatch,
     documentUrl: string,

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -11,7 +11,7 @@ import {
   ITyperighterTelemetryEvent,
   TYPERIGHTER_TELEMETRY_TYPE
 } from "../interfaces/ITelemetryData";
-import { UserTelemetryEventSender } from "@guardian/user-telemetry-client";
+import { IUserTelemetryEvent, UserTelemetryEventSender } from "@guardian/user-telemetry-client";
 import { IMatch } from "..";
 import { MatchType } from "../utils/decoration";
 
@@ -19,7 +19,8 @@ class TyperighterTelemetryAdapter {
   constructor(
     private telemetryService: UserTelemetryEventSender,
     private app: string,
-    private stage: string
+    private stage: string,
+    private tags?: IUserTelemetryEvent["tags"],
   ) {}
 
   public suggestionIsAccepted(
@@ -126,9 +127,11 @@ class TyperighterTelemetryAdapter {
     event: Omit<TEvent, "app" | "stage" | "eventTime">
   ) {
     this.telemetryService.addEvent({
-      ...event,
+      type: event.type,
+      value: event.value,
       app: this.app,
       stage: this.stage,
+      tags: { ...this.tags, ...event.tags },
       eventTime: new Date().toISOString()
     });
   }

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -23,7 +23,7 @@ class TyperighterTelemetryAdapter {
     private tags?: IUserTelemetryEvent["tags"],
   ) {}
 
-  // used by flexible-content to update tags that are only known after the telemetry adaptor has been initialised
+  // used to update tags that are only known after the telemetry adaptor has been initialised
   public updateTelemetryTags(tags: IUserTelemetryEvent["tags"]) {
     this.tags = { ...this.tags, ...tags};
   }


### PR DESCRIPTION
## What does this change?
This allows applications to pass in optional tags to be added to telemetry events. Examples of tags to be passed in include `contentType`, `contentId`, `documentUrl` and `blockId`.

## How to test
Using the [instructions in the readme](https://github.com/guardian/prosemirror-typerighter/tree/main/docs#testing-locally-in-applications-that-use-prosemirror-typerighter), point your application (eg composer) to your local version pf prosemirror-typerighter. Pass custom tags into the TyperightTelemetryAdaptor and launch the app locally. Monitor the network traffic in developer tools and see your custom tags appear in the typerighter telemetry events.