### PR TITLE
feat: Enable realtime checking without the user interacting with the contro…

### DIFF
--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -12,6 +12,9 @@ import TelemetryContext from "./contexts/TelemetryContext";
 import { EditorView } from "prosemirror-view";
 import { IPluginState } from "./state/reducer";
 import { MatchType } from "./utils/decoration";
+import { requestMatchesForDocument } from "./state/actions";
+import { v4 } from "uuid";
+import { selectPluginConfig } from "./state/selectors";
 
 interface IViewOptions<TPluginState extends IPluginState> {
   view: EditorView;
@@ -64,6 +67,17 @@ const createView = <TPluginState extends IPluginState<MatchType[]>>({
   // match messages when the user hovers over highlighted ranges.
   overlayNode.classList.add("TyperighterPlugin__tooltip-overlay");
   logger.info("Typerighter plugin starting");
+
+  const pluginState = store.getState();
+
+  if (pluginState){
+    const { requestMatchesOnDocModified } = selectPluginConfig(pluginState)
+    requestMatchesOnDocModified ?? requestMatchesForDocument(
+      v4(),
+      matcherService.getCurrentCategories().map(_ => _.id)
+    );
+  }
+
 
   // Finally, render our components.
   render(


### PR DESCRIPTION
## What does this change?
Currently, real time checking is not kicking in until the 'Check Document' button is checked, which makes liveblog testing difficult.

With this PR - If 'requestMatchesOnDocModified' is true, request matches on initialisation of the view.

(Is this a bad idea?)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `prosemirror-typerighter` locally according to the instructions in the readme (alongside `typerighter`. Tick 'Enable real-time checking'. Make changes to the document. Do checks take place? Are new matches checked?
