### PR TITLE
feat!: Provide matcher service, rather than expecting the consumer to provide one

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -14,7 +14,6 @@ import "../src/css/index.scss";
 import createTyperighterPlugin from "../src/ts/createTyperighterPlugin";
 import createView from "../src/ts/createView";
 import { createBoundCommands } from "../src/ts/commands";
-import MatcherService from "../src/ts/services/MatcherService";
 import { TyperighterAdapter } from "../src/ts";
 import TyperighterTelemetryAdapter from "../src/ts/services/TyperighterTelemetryAdapter";
 import { UserTelemetryEventSender } from "@guardian/user-telemetry-client";
@@ -50,7 +49,7 @@ const typerighterTelemetryAdapter = new TyperighterTelemetryAdapter(
   "DEV"
 );
 
-const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin({
+const { plugin: validatorPlugin, store, getState, matcherService } = createTyperighterPlugin({
   isElementPartOfTyperighterUI,
   filterOptions: {
     filterMatches: filterByMatchState,
@@ -60,7 +59,9 @@ const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin({
     findMarkPositions(node, from, to, mySchema.marks.code),
   onMatchDecorationClicked: match =>
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
-    requestMatchesOnDocModified: true
+    requestMatchesOnDocModified: true,
+  adapter: new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk"), 
+  telemetryAdapter: typerighterTelemetryAdapter
 });
 
 if (editorElement && sidebarNode) {
@@ -85,13 +86,6 @@ if (editorElement && sidebarNode) {
     editorElement.getBoundingClientRect().height / 2 - menuHeight;
 
   const commands = createBoundCommands(view, getState);
-
-  const matcherService = new MatcherService(
-    store,
-    commands,
-    new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk"),
-    typerighterTelemetryAdapter
-  );
 
   createView({
     view,

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -103,9 +103,6 @@ export interface IPluginOptions<
    */
   onMatchDecorationClicked?: (match: TMatch) => void;
 
-  /**
-   * Expose useful utilities for developers.
-   */
   telemetryAdapter?: TyperighterTelemetryAdapter;
   
   adapter: IMatcherAdapter<TMatch>,

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -254,8 +254,9 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
       const commands = createBoundCommands(view, plugin.getState);
       matcherService.setCommands(commands);
 
+      // Check the document eagerly on editor initialisation if 
+      // requestMatchesOnDocModified is enabled
       const pluginState = store.getState();
-
       if (pluginState){
         const { requestMatchesOnDocModified } = selectPluginConfig(pluginState)
         requestMatchesOnDocModified ?? requestMatchesForDocument(

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -1,4 +1,4 @@
-import { applyNewDirtiedRanges, requestMatchesForDocument } from "./state/actions";
+import { applyNewDirtiedRanges } from "./state/actions";
 import {
   IPluginState,
   PROSEMIRROR_TYPERIGHTER_ACTION,
@@ -254,17 +254,19 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
       const commands = createBoundCommands(view, plugin.getState);
       matcherService.setCommands(commands);
 
-      // Check the document eagerly on editor initialisation if 
+      // Check the document eagerly on editor initialisation if
       // requestMatchesOnDocModified is enabled
       const pluginState = store.getState();
-      if (pluginState){
-        const { requestMatchesOnDocModified } = selectPluginConfig(pluginState)
-        requestMatchesOnDocModified ?? requestMatchesForDocument(
+      if (
+        pluginState &&
+        selectPluginConfig(pluginState).requestMatchesOnDocModified
+      ) {
+        commands.requestMatchesForDocument(
           v4(),
           matcherService.getCurrentCategories().map(_ => _.id)
         );
       }
-      
+
       // Prepend any globally available styles to the document editor if they
       // are not already present.
       if (!document.getElementById(GLOBAL_DECORATION_STYLE_ID)) {

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -30,10 +30,13 @@ import Store, {
   STORE_EVENT_NEW_DIRTIED_RANGES
 } from "./state/store";
 import { doNotSkipRanges, TGetSkippedRanges } from "./utils/block";
-import { startHoverCommand, stopHoverCommand } from "./commands";
+import { createBoundCommands, startHoverCommand, stopHoverCommand } from "./commands";
 import { TFilterMatches, maybeResetHoverStates } from "./utils/plugin";
 import { pluginKey } from "./utils/plugin";
 import { getClientRectIndex } from "./utils/clientRect";
+import MatcherService from "./services/MatcherService";
+import TyperighterTelemetryAdapter from "./services/TyperighterTelemetryAdapter";
+import { IMatcherAdapter } from "./interfaces/IMatcherAdapter";
 
 export type ExpandRanges = (ranges: IRange[], doc: Node<any>) => IRange[];
 
@@ -99,6 +102,13 @@ export interface IPluginOptions<
    * Called when a match decoration is clicked.
    */
   onMatchDecorationClicked?: (match: TMatch) => void;
+
+  /**
+   * Expose useful utilities for developers.
+   */
+  telemetryAdapter?: TyperighterTelemetryAdapter;
+  
+  adapter: IMatcherAdapter<TMatch>,
 }
 
 /**
@@ -107,11 +117,12 @@ export interface IPluginOptions<
  * when they are are returned, and applying suggestions to the document.
  */
 const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
-  options: IPluginOptions<TFilterState, TMatch> = {}
+  options: IPluginOptions<TFilterState, TMatch>
 ): {
   plugin: Plugin<IPluginState<TFilterState, TMatch>>;
   store: Store<IPluginState<TFilterState, TMatch>>;
   getState: (state: EditorState) => IPluginState<TFilterState, TMatch>;
+  matcherService: MatcherService<TFilterState, TMatch>
 } => {
   const {
     expandRanges = expandRangesToParentBlockNode,
@@ -123,6 +134,8 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
     onMatchDecorationClicked = () => undefined,
     isElementPartOfTyperighterUI = () => false,
     requestMatchesOnDocModified = false,
+    adapter,
+    telemetryAdapter
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TFilterState, TMatch>;
@@ -135,6 +148,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
     filterOptions?.filterMatches,
     getSkippedRanges
   );
+  const matcherService = new MatcherService(store, adapter, telemetryAdapter)
 
   const plugin: Plugin<TPluginState> = new Plugin({
     key: pluginKey,
@@ -238,6 +252,9 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
       }
     },
     view(view) {
+      const commands = createBoundCommands(view, plugin.getState);
+      matcherService.setCommands(commands);
+
       // Prepend any globally available styles to the document editor if they
       // are not already present.
       if (!document.getElementById(GLOBAL_DECORATION_STYLE_ID)) {
@@ -260,7 +277,8 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
     store,
     getState: plugin.getState.bind(plugin) as (
       state: EditorState
-    ) => TPluginState
+    ) => TPluginState,
+    matcherService
   };
 };
 

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -12,9 +12,6 @@ import TelemetryContext from "./contexts/TelemetryContext";
 import { EditorView } from "prosemirror-view";
 import { IPluginState } from "./state/reducer";
 import { MatchType } from "./utils/decoration";
-import { requestMatchesForDocument } from "./state/actions";
-import { v4 } from "uuid";
-import { selectPluginConfig } from "./state/selectors";
 
 interface IViewOptions<TPluginState extends IPluginState> {
   view: EditorView;
@@ -67,17 +64,6 @@ const createView = <TPluginState extends IPluginState<MatchType[]>>({
   // match messages when the user hovers over highlighted ranges.
   overlayNode.classList.add("TyperighterPlugin__tooltip-overlay");
   logger.info("Typerighter plugin starting");
-
-  const pluginState = store.getState();
-
-  if (pluginState){
-    const { requestMatchesOnDocModified } = selectPluginConfig(pluginState)
-    requestMatchesOnDocModified ?? requestMatchesForDocument(
-      v4(),
-      matcherService.getCurrentCategories().map(_ => _.id)
-    );
-  }
-
 
   // Finally, render our components.
   render(

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -12,6 +12,9 @@ import TelemetryContext from "./contexts/TelemetryContext";
 import { EditorView } from "prosemirror-view";
 import { IPluginState } from "./state/reducer";
 import { MatchType } from "./utils/decoration";
+import { requestMatchesForDocument } from "./state/actions";
+import { v4 } from "uuid";
+import { selectPluginConfig } from "./state/selectors";
 
 interface IViewOptions<TPluginState extends IPluginState> {
   view: EditorView;
@@ -64,6 +67,17 @@ const createView = <TPluginState extends IPluginState<MatchType[]>>({
   // match messages when the user hovers over highlighted ranges.
   overlayNode.classList.add("TyperighterPlugin__tooltip-overlay");
   logger.info("Typerighter plugin starting");
+
+  const pluginState = store.getState();
+
+  if (pluginState){
+    const { requestMatchesOnDocModified } = selectPluginConfig(pluginState)
+    requestMatchesOnDocModified ?? requestMatchesForDocument(
+      v4(),
+      matcherService.getCurrentCategories().map(_ => _.id)
+    );
+  }
+
 
   // Finally, render our components.
   render(

--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -129,7 +129,9 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
   }
 
   /**
-   * Provide the matcher service with commands, which required an editor
+   * Provide the matcher service with commands, which must be 
+   * bound to an `EditorView` instance, and so cannot be provided 
+   * until the Typerighter plugin is instantiated by an `EditorView`.
    */
   public setCommands(commands: Commands) {
     this.commands = commands;

--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -25,13 +25,14 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
   private currentCategories = [] as ICategory[];
   private allCategories = [] as ICategory[];
   private requestPending = false;
+  private commands: Commands | undefined;
+
   constructor(
     private store: Store<IPluginState<TFilterState, TMatch>>,
-    private commands: Commands,
     private adapter: IMatcherAdapter<TMatch>,
     private telemetryAdapter?: TyperighterTelemetryAdapter,
     // The initial throttle duration for pending requests.
-    private initialThrottle = 2000
+    private initialThrottle = 2000,
   ) {
     this.currentThrottle = this.initialThrottle;
     this.store.on(STORE_EVENT_NEW_MATCHES, (requestId, requestsInFlight) => {
@@ -40,6 +41,10 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
     this.store.on(STORE_EVENT_NEW_DIRTIED_RANGES, () => {
       this.scheduleRequest();
     });
+  }
+  public getCommands = () => {
+    console.warn("[prosemirror-typerighter] Attempted to use commands before they were available")
+    return this.commands
   }
 
   private sendMatchTelemetryEvents = (matches: TMatch[]) => {
@@ -81,12 +86,14 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
    * happens as close to the point of range egress/ingress as possible.
    */
   public async fetchMatches(requestId: string, blocks: IBlockWithSkippedRanges[]) {
+    const commands = this.getCommands();
+    if (!commands) return;
     const applyMatcherResponse: TMatchesReceivedCallback<TMatch> = response => {
       this.sendMatchTelemetryEvents(response.matches);
       // For matches, map through skipped ranges on the way in
       const transformedMatches = response.matches.map(match => mapMatchThroughBlocks(match, blocks))
       const transformedResponse = { ...response, matches: transformedMatches }
-      this.commands.applyMatcherResponse(transformedResponse);
+      commands.applyMatcherResponse(transformedResponse);
     };
 
     // For blocks, remove skipped ranges on the way out
@@ -97,8 +104,8 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
       transformedBlocks,
       this.currentCategories.map(_ => _.id),
       applyMatcherResponse,
-      this.commands.applyRequestError,
-      this.commands.applyRequestComplete
+      commands.applyRequestError,
+      commands.applyRequestComplete
     );
   }
 
@@ -107,16 +114,25 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
    * defer it until the next throttle window.
    */
   public requestFetchMatches() {
+    const commands = this.getCommands();
+    if (!commands) return;
     this.requestPending = false;
     const pluginState = this.store.getState();
     if (!pluginState || selectAllBlocksInFlight(pluginState).length) {
       return this.scheduleRequest();
     }
     const requestId = v4();
-    this.commands.requestMatchesForDirtyRanges(
+    commands.requestMatchesForDirtyRanges(
       requestId,
       this.getCurrentCategories().map(_ => _.id)
     );
+  }
+
+  /**
+   * Provide the matcher service with commands, which required an editor
+   */
+  public setCommands(commands: Commands) {
+    this.commands = commands;
   }
 
   /**
@@ -129,6 +145,7 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
     this.requestPending = true;
     setTimeout(() => this.requestFetchMatches(), this.currentThrottle);
   };
+
 }
 
 export default MatcherService;

--- a/src/ts/services/test/MatcherService.spec.ts
+++ b/src/ts/services/test/MatcherService.spec.ts
@@ -67,8 +67,11 @@ const commands = {
 const requestId = "set-id";
 const store = new Store();
 const endpoint = "http://typerighter-service-endpoint.rad";
-const createMatcherService = () =>
-  new MatcherService(store, commands as any, new TyperighterAdapter(endpoint));
+const createMatcherService = () => {
+  const matcherService = new MatcherService(store, new TyperighterAdapter(endpoint));
+  matcherService.setCommands(commands as any);
+  return matcherService;
+}
 const getLastRequest = () => {
   try {
     const [, request] = fetchMock.lastCall()!;

--- a/src/ts/test/helpers/createEditor.ts
+++ b/src/ts/test/helpers/createEditor.ts
@@ -7,7 +7,6 @@ import { exampleSetup } from "prosemirror-example-setup";
 
 import createTyperighterPlugin from "../../createTyperighterPlugin";
 import { createBoundCommands } from "../../commands";
-import MatcherService from "../../services/MatcherService";
 import TyperighterAdapter from "../../services/adapters/TyperighterAdapter";
 import { IMatch } from "../..";
 
@@ -32,9 +31,10 @@ export const createEditor = (htmlDoc: string, matches: IMatch[] = []) => {
   const isElementPartOfTyperighterUI = (element: HTMLElement) =>
     overlayNode.contains(element);
 
-  const { plugin: validatorPlugin, store, getState } = createTyperighterPlugin({
+  const { plugin: validatorPlugin, getState } = createTyperighterPlugin({
     isElementPartOfTyperighterUI,
-    matches
+    matches,
+    adapter: new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk")
   });
 
   const view = new EditorView(editorElement!, {
@@ -51,12 +51,6 @@ export const createEditor = (htmlDoc: string, matches: IMatch[] = []) => {
   });
 
   const commands = createBoundCommands(view, getState);
-  // @ts-ignore
-  const matcherService = new MatcherService(
-    store,
-    commands,
-    new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk")
-  );
 
   return { editorElement, view, commands, schema: mySchema };
 };


### PR DESCRIPTION
Co-authored by @jonathonherbert and @ParisaTork 

## What does this change?
This PR stops moves the responsibility for creating a MatcherService into `prosemirror-typerighter`, and no longer requires the consuming service to provide a MatcherService.

This simplifies the setup required by the consuming service. The work of providing a matcher service will no longer need to take place within `setupTyperighterView` in consumers, which means that we can run checking from `prosemirror-typerighter` without rendering the UI (e.g. in the liveblog).

This should be a no-op within `prosemirror-typerighter`, but will require some changes in the consumer because of the interface change.

## How to test
1. Run `prosemirror-typerighter` locally. Does the service run as expected? Do all tests pass?