### PR TITLE
fix: Tweak to center info icon

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -32,7 +32,9 @@
 .Sidebar__header-container {
   position: relative;
   padding: $gutter-width;
-  border-bottom: 1px solid $sidebar-border-color;
+  & + & {
+    border-top: 1px solid $sidebar-border-color;
+  }
 }
 
 .Sidebar__header-bottom {

--- a/src/ts/components/Tooltip.tsx
+++ b/src/ts/components/Tooltip.tsx
@@ -54,13 +54,11 @@ export const getPopperConfig = (
 };
 
 const tooltipIconView = css`
-    padding: 2px;
-    height: 20px;
+    height: 18px;
     margin-right: 4px;
   svg {
     height: 18px;
     width: 18px;
-    margin: -1px;
   }
   :hover {
     cursor: pointer;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

A small tweak to keep the information icon added in #217 centered in our consuming CMS.

|Before|After|
|-|-|
|<img width="227" alt="Screenshot 2022-08-22 at 14 12 56" src="https://user-images.githubusercontent.com/7767575/185934467-7d1c3184-f63b-487c-a723-e3e24a14cac4.png">|<img width="227" alt="Screenshot 2022-08-22 at 14 37 10" src="https://user-images.githubusercontent.com/7767575/185934501-4020d35b-73b8-4a1c-8fae-1f808645d8b3.png">|

Quite subtle – I've adjusted the position of the icon so it should be dead centre, and removed the gray border above the coloured banner, which in my eyes altered the perception of central-ness for the icon.

## How to test

Take a look at the screenshots, or run locally. (Test in Composer is possible via the instructions in the readme.) Do you get a sense of ... geometric harmony?