### PR TITLE
fix: Fix styling when correct and default matches span multiple lines

### DIFF
--- a/src/css/Sidebar.scss
+++ b/src/css/Sidebar.scss
@@ -32,7 +32,9 @@
 .Sidebar__header-container {
   position: relative;
   padding: $gutter-width;
-  border-bottom: 1px solid $sidebar-border-color;
+  & + & {
+    border-top: 1px solid $sidebar-border-color;
+  }
 }
 
 .Sidebar__header-bottom {

--- a/src/ts/components/Tooltip.tsx
+++ b/src/ts/components/Tooltip.tsx
@@ -54,13 +54,11 @@ export const getPopperConfig = (
 };
 
 const tooltipIconView = css`
-    padding: 2px;
-    height: 20px;
+    height: 18px;
     margin-right: 4px;
   svg {
     height: 18px;
     width: 18px;
-    margin: -1px;
   }
   :hover {
     cursor: pointer;

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -306,9 +306,9 @@ export const createGlobalDecorationStyleTag = (
       box-decoration-break: clone;
       -webkit-box-decoration-break: clone;
       background-color: ${correctColours.backgroundColour};
-      border-image-source: linear-gradient(to right, ${correctColours.borderColour} 0, ${correctColours.borderColour} 45px, transparent 0, transparent 0);
-      border-image-width: 0 0 2px 0;
-      border-image-slice: 19;
+      border-image-source: linear-gradient(to right, ${correctColours.borderColour} 0, ${correctColours.borderColour} 47px, transparent 0, transparent 0);
+      border-image-width: 0 0 3px 0;
+      border-image-slice: 20;
       border-image-repeat: round;
       border-style: solid;
       border-width: 2px;

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -288,41 +288,30 @@ export const createGlobalDecorationStyleTag = (
     .${DecorationClassMap.DEFAULT} {
       position: relative;
       background-color: ${defaultColours.backgroundColour};
-    }
-
-    .${DecorationClassMap.DEFAULT}:after {
-      position: absolute;
-      width: 100%;
-      content: "";
-      bottom: -3px;
-      left: 0px;
-      height: 4px;
-      background-repeat: repeat-x;
-      background-position: top;
-      background-image: url('${getSquiggleAsUri(defaultColours.borderColour)}');
+      border-image-source: url('${getSquiggleAsUri(defaultColours.borderColour)}');
+      border-image-width: 0 0 4px 0;
+      border-image-slice: 4;
+      border-image-repeat: round;
+      border-style: solid;
+      border-width: 2px;
     }
 
     .${DecorationClassMap.DEFAULT}.MatchDecoration--is-selected {
       background-color: ${defaultColours.backgroundColourSelected};
-    }
-    .${DecorationClassMap.DEFAULT}.MatchDecoration--is-selected:after {
-      background-image: linear-gradient(0deg, ${defaultColours.backgroundColourSelected} 3px, transparent 3px), url('${getSquiggleAsUri(defaultColours.borderColour)}');
+      border-image-source: linear-gradient(0deg, ${defaultColours.backgroundColourSelected} 3px, transparent 3px), url('${getSquiggleAsUri(defaultColours.borderColour)}');
     }
 
     .${DecorationClassMap.CORRECT} {
-      background-color: ${correctColours.backgroundColour};
       position: relative;
-    }
-
-    .${DecorationClassMap.CORRECT}:after {
-      position: absolute;
-      width: 100%;
-      content: "";
-      bottom: -2px;
-      left: 0px;
-      height: 2px;
-      background-image: repeating-linear-gradient(to right, ${correctColours.borderColour} 0, ${correctColours.borderColour} 3px, transparent 3px, transparent 5px);
-      background-size: 5px 2px;
+      box-decoration-break: clone;
+      -webkit-box-decoration-break: clone;
+      background-color: ${correctColours.backgroundColour};
+      border-image-source: linear-gradient(to right, ${correctColours.borderColour} 0, ${correctColours.borderColour} 45px, transparent 0, transparent 0);
+      border-image-width: 0 0 2px 0;
+      border-image-slice: 19;
+      border-image-repeat: round;
+      border-style: solid;
+      border-width: 2px;
     }
 
     .${DecorationClassMap.CORRECT}.MatchDecoration--is-selected,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Fixes an issue where as a result of changes in #169, match styling would not apply correctly when matches were broken across lines.

|Before|After|
|-|-|
<img width="108" alt="Screenshot 2022-08-24 at 09 43 19" src="https://user-images.githubusercontent.com/7767575/186373915-fb15e0ff-8017-45f3-8940-591f492265ba.png">|<img width="109" alt="Screenshot 2022-08-24 at 10 04 04" src="https://user-images.githubusercontent.com/7767575/186377763-947ba05a-d874-442c-ae26-d8cacfdec614.png">|

Previously, we were using the `:after` pseudo element to achieve this effect with a background image. This doesn't play nicely with the [multiple border-boxes that constitute a broken span](https://developer.mozilla.org/en-US/docs/Web/API/Element/getClientRects), but [border-image (TIL!)](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image) does.

One caveat – the green line is some subpixel-width fatter than before, I think as a result of being exactly rather than approximately 3px. I think it's still clear. Sadly, I haven't found a way to make match the previous styling exactly, and the next pixel down looks too thin to me: happy to revise. Here's the thinner line:

<img width="108" alt="Screenshot 2022-08-24 at 09 42 25" src="https://user-images.githubusercontent.com/7767575/186377920-ed8aa819-c182-4601-83d1-7cc380cc1e4e.png">

Tested in Chrome and Firefox.

## How to test

Run locally in the sandbox, or use the instructions in ['Testing locally in applications ...'](https://github.com/guardian/prosemirror-typerighter#testing-locally-in-applications-that-use-prosemirror-typerighter) to test in Composer. Do match decorations now behave themselves when split over multiple lines?