### PR TITLE
fix: Another fix for border styles

### DIFF
--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -309,7 +309,6 @@ export const createGlobalDecorationStyleTag = (
       border-image-source: repeating-linear-gradient(to right, ${correctColours.borderColour} 0, ${correctColours.borderColour} 3px, transparent 3px, transparent 5px);
       border-image-width: 0 0 auto 0;
       border-image-slice: 0 0 3 0;
-      border-image-repeat: stretch;
       border-style: solid;
       border-width: 0 0 2px 0;
     }

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -289,11 +289,11 @@ export const createGlobalDecorationStyleTag = (
       position: relative;
       background-color: ${defaultColours.backgroundColour};
       border-image-source: url('${getSquiggleAsUri(defaultColours.borderColour)}');
-      border-image-width: 0 0 4px 0;
+      border-image-width: 0 0 auto 0;
       border-image-slice: 4;
       border-image-repeat: round;
       border-style: solid;
-      border-width: 2px;
+      border-width: 0 0 2px 0;
     }
 
     .${DecorationClassMap.DEFAULT}.MatchDecoration--is-selected {
@@ -306,12 +306,12 @@ export const createGlobalDecorationStyleTag = (
       box-decoration-break: clone;
       -webkit-box-decoration-break: clone;
       background-color: ${correctColours.backgroundColour};
-      border-image-source: linear-gradient(to right, ${correctColours.borderColour} 0, ${correctColours.borderColour} 47px, transparent 0, transparent 0);
-      border-image-width: 0 0 3px 0;
-      border-image-slice: 20;
-      border-image-repeat: round;
+      border-image-source: repeating-linear-gradient(to right, ${correctColours.borderColour} 0, ${correctColours.borderColour} 3px, transparent 3px, transparent 5px);
+      border-image-width: 0 0 auto 0;
+      border-image-slice: 0 0 3 0;
+      border-image-repeat: stretch;
       border-style: solid;
-      border-width: 2px;
+      border-width: 0 0 2px 0;
     }
 
     .${DecorationClassMap.CORRECT}.MatchDecoration--is-selected,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

A quick follow up to fix something I didn't spot while testing #225 – the styling for 'correct' matches was stretched with the span width 😱 It's trivial to spot with longer matches.

|Before|After|
|-|-|
|<img width="579" alt="Screenshot 2022-08-24 at 12 32 27" src="https://user-images.githubusercontent.com/7767575/186408461-a8797608-f74e-491c-ab8f-35483df8f622.png">|
<img width="579" alt="Screenshot 2022-08-24 at 12 31 54" src="https://user-images.githubusercontent.com/7767575/186408537-29688685-b836-4b3e-a581-9969710b1011.png">|

This was a result of me misunderstanding the border-image docs, specifically [border-image-slice.](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-slice) We now sample from a static repeating pattern, which should be nice and robust.

## How to test

See #225.