### PR TITLE
fix: Ensure all ranges are correctly checked when realtime checking is enabled

### DIFF
--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -21,7 +21,7 @@ import {
 } from "./utils/decoration";
 import { EditorView } from "prosemirror-view";
 import { Plugin, Transaction, EditorState } from "prosemirror-state";
-import { expandRangesToParentBlockNode } from "./utils/range";
+import { expandRangesToParentBlockNodes } from "./utils/range";
 import { getDirtiedRangesFromTransaction } from "./utils/prosemirror";
 import { IRange, IMatch } from "./interfaces/IMatch";
 import { Node } from "prosemirror-model";
@@ -106,7 +106,7 @@ export interface IPluginOptions<
   onMatchDecorationClicked?: (match: TMatch) => void;
 
   telemetryAdapter?: TyperighterTelemetryAdapter;
-  
+
   adapter: IMatcherAdapter<TMatch>,
 }
 
@@ -124,7 +124,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
   matcherService: MatcherService<TFilterState, TMatch>
 } => {
   const {
-    expandRanges = expandRangesToParentBlockNode,
+    expandRanges = expandRangesToParentBlockNodes,
     getSkippedRanges = doNotSkipRanges,
     matches = [],
     filterOptions,

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -16,7 +16,7 @@ import {
   MatchType
 } from "../../utils/decoration";
 import { filterByMatchState, IDefaultFilterState } from "../../utils/plugin";
-import { expandRangesToParentBlockNode } from "../../utils/range";
+import { expandRangesToParentBlockNodes } from "../../utils/range";
 import {
   deriveFilteredDecorations,
   getNewStateFromTransaction,
@@ -30,7 +30,7 @@ describe("State helpers", () => {
     filterState: TFilterState
   ) => {
     const { state, matches } = createStateWithMatches(
-      createReducer(expandRangesToParentBlockNode),
+      createReducer(expandRangesToParentBlockNodes),
       matchesToAdd
     );
     const tr = createInitialTr(defaultDoc);

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -20,7 +20,7 @@ import {
   getNewDecorationsForCurrentMatches,
   createDecorationsForMatch
 } from "../../utils/decoration";
-import { expandRangesToParentBlockNode } from "../../utils/range";
+import { expandRangesToParentBlockNodes } from "../../utils/range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
 import { IMatch, IMatchRequestError } from "../../interfaces/IMatch";
 import { addMatchesToState } from "../helpers";
@@ -37,7 +37,7 @@ import {
 } from "../../test/helpers/fixtures";
 import { createBlockId } from "../../utils/block";
 
-const reducer = createReducer(expandRangesToParentBlockNode);
+const reducer = createReducer(expandRangesToParentBlockNodes);
 
 describe("Action handlers", () => {
   describe("No action", () => {
@@ -464,7 +464,7 @@ describe("Action handlers", () => {
     });
     it("should not apply matches if they trigger the ignoreMatch predicate", () => {
       const ignoreMatchReducer = createReducer(
-        expandRangesToParentBlockNode,
+        expandRangesToParentBlockNodes,
         match => match.from > 3
       );
 

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -1,4 +1,3 @@
-import clamp from "lodash/clamp";
 import { Node } from "prosemirror-model";
 import { TextSelection } from "prosemirror-state";
 import { findParentNode } from "prosemirror-utils";
@@ -133,58 +132,61 @@ export const blockToRange = (input: IBlock): IRange => ({
 });
 
 /**
- * Expand a range in a document to encompass the nearest ancestor block node.
+ * Given a range and a document, return the textblock nodes covered by this
+ * range, expanding the start and end of the ranges to encompass the entirety of
+ * each textblock.
  */
 export const expandRangeToParentBlockNodes = (
   range: IRange,
   doc: Node
-): IRange | undefined => {
+): IRange[] => {
   try {
-    const $fromPos = doc.resolve(range.from);
-    const $toPos = doc.resolve(range.to);
-    const parentOfStart = findParentNode(node => node.isBlock)(
-      new TextSelection($fromPos, $fromPos)
-    );
-    const parentOfEnd = findParentNode(node => node.isBlock)(
-      new TextSelection($toPos, $toPos)
-    );
-    if (!parentOfStart || !parentOfEnd) {
-      return undefined;
-    }
-    return {
-      from: parentOfStart.start,
-      to: parentOfEnd.start + parentOfEnd.node.textContent.length
-    };
-  } catch (e) {
-    return undefined;
+        const $fromPos = doc.resolve(range.from);
+        const $toPos = doc.resolve(range.to);
+        const parentOfStart = findParentNode(node => node.isBlock)(
+          new TextSelection($fromPos, $fromPos)
+        );
+        const parentOfEnd = findParentNode(node => node.isBlock)(
+          new TextSelection($toPos, $toPos)
+        );
+
+        if (!parentOfStart || !parentOfEnd) {
+          return [];
+        }
+
+        const from = parentOfStart.start;
+        const to = parentOfEnd.start + parentOfEnd.node.textContent.length;
+
+        const expandedBlockRanges: IRange[] = [];
+        // We offset by one to offset into the document node.
+        const docOffset = 1;
+        doc.nodesBetween(from, to, (node, pos) => {
+          // Make sure we're at a node that contains text as its child, as our
+          // ranges need to refer to text nodes.
+          if (node.isTextblock) {
+            expandedBlockRanges.push({
+              from: pos + docOffset,
+              to: pos + node.textContent.length + docOffset
+            })
+            return false;
+          }
+        });
+
+        return expandedBlockRanges;
+      } catch (e) {
+    return [];
   }
 };
 
 /**
- * Expand the given ranges to include their ancestor block nodes.
+ * Expand the given ranges to include the start and end of their textblock nodes.
  */
-export const getRangesOfParentBlockNodes = (ranges: IRange[], doc: Node) => {
-  const matchRanges = ranges.reduce((acc, range: IRange) => {
-    const expandedRange = expandRangeToParentBlockNodes(
-      { from: range.from, to: range.to },
-      doc
-    );
-    return acc.concat(
-      expandedRange
-        ? [
-            {
-              from: expandedRange.from,
-              to: clamp(expandedRange.to, doc.content.size)
-            }
-          ]
-        : []
-    );
-  }, [] as IRange[]);
+export const expandRangesToParentBlockNodes = (ranges: IRange[], doc: Node) => {
+  const matchRanges = ranges.flatMap(range =>
+    expandRangeToParentBlockNodes({ from: range.from, to: range.to }, doc)
+  );
   return mergeRanges(matchRanges);
 };
-
-export const expandRangesToParentBlockNode = (ranges: IRange[], doc: Node) =>
-  getRangesOfParentBlockNodes(ranges, doc);
 
 const getCharsRemovedBeforeFrom = (
   currentRange: IRange,

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -135,22 +135,25 @@ export const blockToRange = (input: IBlock): IRange => ({
 /**
  * Expand a range in a document to encompass the nearest ancestor block node.
  */
-export const expandRangeToParentBlockNode = (
+export const expandRangeToParentBlockNodes = (
   range: IRange,
   doc: Node
 ): IRange | undefined => {
   try {
     const $fromPos = doc.resolve(range.from);
     const $toPos = doc.resolve(range.to);
-    const parentNode = findParentNode(node => node.isBlock)(
-      new TextSelection($fromPos, $toPos)
+    const parentOfStart = findParentNode(node => node.isBlock)(
+      new TextSelection($fromPos, $fromPos)
     );
-    if (!parentNode) {
+    const parentOfEnd = findParentNode(node => node.isBlock)(
+      new TextSelection($toPos, $toPos)
+    );
+    if (!parentOfStart || !parentOfEnd) {
       return undefined;
     }
     return {
-      from: parentNode.start,
-      to: parentNode.start + parentNode.node.textContent.length
+      from: parentOfStart.start,
+      to: parentOfEnd.start + parentOfEnd.node.textContent.length
     };
   } catch (e) {
     return undefined;
@@ -162,7 +165,7 @@ export const expandRangeToParentBlockNode = (
  */
 export const getRangesOfParentBlockNodes = (ranges: IRange[], doc: Node) => {
   const matchRanges = ranges.reduce((acc, range: IRange) => {
-    const expandedRange = expandRangeToParentBlockNode(
+    const expandedRange = expandRangeToParentBlockNodes(
       { from: range.from, to: range.to },
       doc
     );

--- a/src/ts/utils/test/range.spec.ts
+++ b/src/ts/utils/test/range.spec.ts
@@ -49,27 +49,17 @@ describe("Range utils", () => {
         }
       ]);
     });
-    it("should handle multiple ranges for different nodes", () => {
+    it("should handle multiple nodes for a single range", () => {
       expect(
         getRangesOfParentBlockNodes(
           [
-            { from: 1, to: 2 },
-            { from: 30, to: 32 },
-            { from: 50, to: 55 }
+            { from: 1, to: 67 }
           ],
           doc
         )
       ).toEqual([
         {
           from: 1,
-          to: 21
-        },
-        {
-          from: 23,
-          to: 44
-        },
-        {
-          from: 46,
           to: 67
         }
       ]);

--- a/src/ts/utils/test/range.spec.ts
+++ b/src/ts/utils/test/range.spec.ts
@@ -3,7 +3,7 @@ import {
   findOverlappingRangeIndex,
   mergeRanges,
   removeOverlappingRanges,
-  getRangesOfParentBlockNodes,
+  expandRangesToParentBlockNodes,
   mapRemovedRange,
   getIntersection,
   mapAddedRange
@@ -18,7 +18,7 @@ describe("Range utils", () => {
       p("Paragraph 3 - 46 - 67")
     );
     it("should get the range of the nearest ancestor block node", () => {
-      expect(getRangesOfParentBlockNodes([{ from: 1, to: 2 }], doc)).toEqual([
+      expect(expandRangesToParentBlockNodes([{ from: 1, to: 2 }], doc)).toEqual([
         {
           from: 1,
           to: 21
@@ -26,7 +26,7 @@ describe("Range utils", () => {
       ]);
     });
     it("should handle ranges of length 0", () => {
-      expect(getRangesOfParentBlockNodes([{ from: 1, to: 1 }], doc)).toEqual([
+      expect(expandRangesToParentBlockNodes([{ from: 1, to: 1 }], doc)).toEqual([
         {
           from: 1,
           to: 21
@@ -35,7 +35,7 @@ describe("Range utils", () => {
     });
     it("should handle multiple ranges for the same node", () => {
       expect(
-        getRangesOfParentBlockNodes(
+        expandRangesToParentBlockNodes(
           [
             { from: 1, to: 2 },
             { from: 10, to: 12 }
@@ -51,17 +51,16 @@ describe("Range utils", () => {
     });
     it("should handle multiple nodes for a single range", () => {
       expect(
-        getRangesOfParentBlockNodes(
+        expandRangesToParentBlockNodes(
           [
             { from: 1, to: 67 }
           ],
           doc
         )
       ).toEqual([
-        {
-          from: 1,
-          to: 67
-        }
+        { from: 1, to:  21 },
+        { from: 23, to:  44 },
+        { from: 46, to:  67 }
       ]);
     });
   });


### PR DESCRIPTION
_co-authored-by_: @ParisaTork 

<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

In prosemirror-typerighter, when real-time checking is turned on, the plugin sometimes does not check parts of the document.

There are two cases I've found – on paste, and when newlines are introduced more quickly than the plugin is configured to send check requests.

There are two phases to a real time check: 1. gathering dirty ranges (ranges that have been changed since the last check), and 2. expanding those ranges and sending them to the checking service.

We expand the ranges that have been dirtied to ensure that we're checking the text around the changes that have been made to the document, and not just the changed text. For example, when adding punctuation, or changing the spelling of a word, we'll want to check the context of those changes. Our rule of thumb for now is just to re-check the whole paragraph containing the affected text.

The parts of the document affected by these phases are shown in orange and green for phase 1. and 2. respectively. You can see in the gif that dirty ranges (orange) seem to be correct, but that the green ranges don't appear to cover all of the text for phase 2.

![tr-bug-on-paste](https://user-images.githubusercontent.com/7767575/189116018-71130a3f-fecf-4a4a-9d96-c9055eb64e5f.gif)

The bug occurs because the rule of thumb we have for expansion is incorrect – it looks for the parent at the start of the given range, but does not extend the expanded range to include subsequent nodes.

This PR fixes the bug by ensuring that when we expand ranges, we ensure that every node containing text is covered by that range from start to finish:

![prosemirror-range-bug-fix](https://user-images.githubusercontent.com/7767575/189116815-db25cec0-06b9-421f-a900-2f4e4bd14867.gif)

## How to test

- The automated tests that we've added should cover the case we've found, and demonstrate that the approach works.
- In the sandbox, try pasting multiple paragraphs into a document, or quickly adding several paragraphs in succession. Matches should appear as expected.