### PR TITLE
feat: Add typerighter enabled command

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -66,9 +66,10 @@ const {
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
   requestMatchesOnDocModified: true,
   adapter: new TyperighterChunkedAdapter(
-    "https://checker.typerighter.local.dev-gutools.co.uk"
+    "https://checker.typerighter.code.dev-gutools.co.uk"
   ),
-  telemetryAdapter: typerighterTelemetryAdapter
+  telemetryAdapter: typerighterTelemetryAdapter,
+  typerighterEnabled: true
 });
 
 if (editorElement && sidebarNode) {

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -66,7 +66,7 @@ const {
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
   requestMatchesOnDocModified: true,
   adapter: new TyperighterChunkedAdapter(
-    "https://checker.typerighter.code.dev-gutools.co.uk"
+    "https://checker.typerighter.local.dev-gutools.co.uk"
   ),
   telemetryAdapter: typerighterTelemetryAdapter,
   typerighterEnabled: true

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -33,6 +33,7 @@ import {
   getPatchesFromReplacementText,
   applyPatchToTransaction
 } from "./utils/prosemirror";
+import { v4 } from "uuid";
 
 type Command = (
   state: EditorState,
@@ -439,5 +440,25 @@ export const createBoundCommands = <TPluginState extends IPluginState>(
     setTyperighterEnabled: bindCommand(setTyperighterEnabledCommand)
   };
 };
+
+export const commands = {
+  ignoreMatchCommand,
+  clearMatchesCommand,
+  applySuggestionsCommand,
+  selectMatchCommand,
+  applyAutoFixableSuggestionsCommand,
+  requestMatchesForDocumentCommand,
+  requestMatchesForDirtyRangesCommand,
+  startHoverCommand,
+  stopHoverCommand,
+  startHighlightCommand,
+  stopHighlightCommand,
+  setConfigValueCommand,
+  applyMatcherResponseCommand,
+  applyRequestErrorCommand,
+  applyRequestCompleteCommand,
+  setFilterStateCommand,
+  setTyperighterEnabledCommand,  
+}
 
 export type Commands = ReturnType<typeof createBoundCommands>;

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -33,7 +33,6 @@ import {
   getPatchesFromReplacementText,
   applyPatchToTransaction
 } from "./utils/prosemirror";
-import { v4 } from "uuid";
 
 type Command = (
   state: EditorState,

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -11,7 +11,8 @@ import {
   removeMatch,
   removeAllMatches,
   newHighlightIdReceived,
-  setFilterState
+  setFilterState,
+  setTyperighterEnabled
 } from "./state/actions";
 import {
   selectMatchByMatchId,
@@ -382,6 +383,24 @@ const maybeApplySuggestions = (
 };
 
 /**
+ * Enable or disable typerighter
+ */
+ export const setTyperighterEnabledCommand = (typerighterEnabled: boolean): Command => (
+  state,
+  dispatch
+) => {
+  if (dispatch) {
+    dispatch(
+      state.tr.setMeta(
+        PROSEMIRROR_TYPERIGHTER_ACTION,
+        setTyperighterEnabled(typerighterEnabled)
+      )
+    );
+  }
+  return true;
+};
+
+/**
  * Create a palette of prosemirror-typerighter commands bound to the given EditorView.
  */
 export const createBoundCommands = <TPluginState extends IPluginState>(
@@ -416,7 +435,8 @@ export const createBoundCommands = <TPluginState extends IPluginState>(
     applyMatcherResponse: bindCommand(applyMatcherResponseCommand),
     applyRequestError: bindCommand(applyRequestErrorCommand),
     applyRequestComplete: bindCommand(applyRequestCompleteCommand),
-    setFilterState: bindCommand(setFilterStateCommand)
+    setFilterState: bindCommand(setFilterStateCommand),
+    setTyperighterEnabled: bindCommand(setTyperighterEnabledCommand)
   };
 };
 

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -384,6 +384,14 @@ const maybeApplySuggestions = (
 
 /**
  * Enable or disable typerighter
+ * 
+ * When Typerighter is enabled:
+ *  - a check occurs of the whole document.
+ *  - realtime checks will continue to occur if they are enabled.
+ * When Typerighter is disabled:
+ *  - all matches are removed
+ *  - all pending requests are discarded
+ *  - realtime checks will no longer occur
  */
  export const setTyperighterEnabledCommand = (typerighterEnabled: boolean): Command => (
   state,

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -22,6 +22,7 @@ interface IProps<TPluginState extends IPluginState> {
   clearMatches: () => void;
   setShowPendingInflightChecks: (isEnabled: boolean) => void;
   setRequestOnDocModified: (r: boolean) => void;
+  setTyperighterEnabled: (typerighterEnabled: boolean) => void;
   requestMatchesForDocument: (requestId: string, categoryIds: string[]) => void;
   getCurrentCategories: () => ICategory[];
   addCategory: (id: string) => void;
@@ -54,7 +55,8 @@ const Controls = <TPluginState extends IPluginState>({
   feedbackHref,
   enableDevMode,
   setRequestOnDocModified,
-  setShowPendingInflightChecks
+  setShowPendingInflightChecks,
+  setTyperighterEnabled
 }: IProps<TPluginState>) => {
   const [pluginState, setPluginState] = useState<TPluginState | undefined>(
     undefined
@@ -167,6 +169,7 @@ const Controls = <TPluginState extends IPluginState>({
   }
 
   const { requestMatchesOnDocModified, showPendingInflightChecks } = selectPluginConfig(pluginState)
+  const typerighterEnabled = pluginState.typerighterEnabled;
 
   return (
     <>
@@ -212,6 +215,17 @@ const Controls = <TPluginState extends IPluginState>({
               ></input>
               <label htmlFor="debug" className="Controls__label">
                 Show pending and inflight checks
+              </label>
+            </div>
+            <div className="Controls__input-group">
+              <input
+                type="checkbox"
+                id="debug"
+                checked={typerighterEnabled}
+                onChange={() => setTyperighterEnabled(!typerighterEnabled)}
+              ></input>
+              <label htmlFor="debug" className="Controls__label">
+                Enable Typerighter
               </label>
             </div>
           </div>

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -53,6 +53,7 @@ const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
               commands.setConfigValue("requestMatchesOnDocModified", value)
             }
             requestMatchesForDocument={commands.requestMatchesForDocument}
+            setTyperighterEnabled={commands.setTyperighterEnabled}
             getCurrentCategories={matcherService.getCurrentCategories}
             addCategory={matcherService.addCategory}
             removeCategory={matcherService.removeCategory}

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -185,7 +185,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
         [] as IRange[]
       );
       if (newDirtiedRanges.length) {
-        if (newPluginState.config.requestMatchesOnDocModified) {
+        if (newPluginState.config.requestMatchesOnDocModified && newPluginState.typerighterEnabled) {
           // We wait a tick here, as applyNewDirtiedRanges must run
           // before the newly dirtied range is available in the state.
           // @todo -- this is a bit of a hack, it can be done better.
@@ -259,7 +259,8 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
       const pluginState = store.getState();
       if (
         pluginState &&
-        selectPluginConfig(pluginState).requestMatchesOnDocModified
+        selectPluginConfig(pluginState).requestMatchesOnDocModified &&
+        pluginState.typerighterEnabled
       ) {
         commands.requestMatchesForDocument(
           v4(),

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -137,7 +137,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
     requestMatchesOnDocModified = false,
     adapter,
     telemetryAdapter,
-    typerighterEnabled,
+    typerighterEnabled = true,
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TFilterState, TMatch>;
@@ -163,7 +163,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
           matchColours,
           filterOptions,
           requestMatchesOnDocModified,
-          typerighterEnabled: typerighterEnabled ?? true
+          typerighterEnabled
         });
         store.emit(STORE_EVENT_NEW_STATE, initialState);
         return initialState;

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -108,6 +108,8 @@ export interface IPluginOptions<
   telemetryAdapter?: TyperighterTelemetryAdapter;
   
   adapter: IMatcherAdapter<TMatch>,
+
+  typerighterEnabled?: boolean
 }
 
 /**
@@ -134,7 +136,8 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
     isElementPartOfTyperighterUI = () => false,
     requestMatchesOnDocModified = false,
     adapter,
-    telemetryAdapter
+    telemetryAdapter,
+    typerighterEnabled,
   } = options;
   // A handy alias to reduce repetition
   type TPluginState = IPluginState<TFilterState, TMatch>;
@@ -160,6 +163,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
           matchColours,
           filterOptions,
           requestMatchesOnDocModified,
+          typerighterEnabled: typerighterEnabled ?? true
         });
         store.emit(STORE_EVENT_NEW_STATE, initialState);
         return initialState;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -5,7 +5,7 @@ import MatcherService from "./services/MatcherService";
 import { UserTelemetryEventSender, IUserTelemetryEvent} from "@guardian/user-telemetry-client";
 import TyperighterTelemetryAdapter from "./services/TyperighterTelemetryAdapter";
 import TyperighterAdapter, { convertTyperighterResponse } from "./services/adapters/TyperighterAdapter";
-import { createBoundCommands } from "./commands";
+import { commands, createBoundCommands } from "./commands";
 import { getBlocksFromDocument } from './utils/prosemirror';
 import { filterByMatchState } from './utils/plugin';
 import createView from "./createView";
@@ -19,6 +19,7 @@ export {
   getBlocksFromDocument,
   convertTyperighterResponse,
   createBoundCommands,
+  commands,
   createView,
   createTyperighterPlugin,
   filterByMatchState,

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -22,6 +22,7 @@ export const REMOVE_ALL_MATCHES = "REMOVE_ALL_MATCHES" as const;
 export const APPLY_NEW_DIRTY_RANGES = "HANDLE_NEW_DIRTY_RANGES" as const;
 export const SET_CONFIG_VALUE = "SET_CONFIG_VALUE" as const;
 export const SET_FILTER_STATE = "SET_FILTER_STATE" as const;
+export const SET_TYPERIGHTER_ENABLED = "SET_TYPERIGHTER_ENABLED" as const;
 
 /**
  * Action creators.
@@ -138,6 +139,16 @@ export type ActionSetFilterState<TPluginState extends IPluginState> = {
   payload: { filterState: TPluginState["filterState"] };
 };
 
+export const setTyperighterEnabled = (
+  typerighterEnabled: boolean
+) => ({
+  type: SET_TYPERIGHTER_ENABLED,
+  payload: { typerighterEnabled }
+});
+
+export type ActionSetTyperighterEnabled = ReturnType<typeof setTyperighterEnabled>
+
+
 export type Action<TPluginState extends IPluginState> =
   | ActionNewHoverIdReceived
   | ActionNewHighlightIdReceived
@@ -151,4 +162,5 @@ export type Action<TPluginState extends IPluginState> =
   | ActionSetConfigValue
   | ActionRemoveMatch
   | ActionRemoveAllMatches
-  | ActionSetFilterState<TPluginState>;
+  | ActionSetFilterState<TPluginState>
+  | ActionSetTyperighterEnabled;

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -1,3 +1,4 @@
+import { EditorState, Transaction } from "prosemirror-state";
 import {
   IMatchRequestError,
   IMatcherResponse,
@@ -140,7 +141,7 @@ export type ActionSetFilterState<TPluginState extends IPluginState> = {
 };
 
 export const setTyperighterEnabled = (
-  typerighterEnabled: boolean
+  typerighterEnabled: boolean,
 ) => ({
   type: SET_TYPERIGHTER_ENABLED,
   payload: { typerighterEnabled }

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -1,4 +1,3 @@
-import { EditorState, Transaction } from "prosemirror-state";
 import {
   IMatchRequestError,
   IMatcherResponse,

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -852,15 +852,14 @@ const handleSetTyperighterEnabled = <TPluginState extends IPluginState>(
   state: TPluginState,
   { payload: { typerighterEnabled } }: ActionSetTyperighterEnabled
 ): TPluginState => {
-
   const newState = {...state}
+  
   if (!typerighterEnabled){
     // Typerighter has been disabled
-    // 1. Remove any current matches
-    newState.currentMatches = [];
-    newState.filteredMatches = [];
-    // 2. Stop realtime checking
-    newState.config.requestMatchesOnDocModified = false;
+    // Remove any current matches
+    const { decorations, currentMatches } = handleRemoveAllMatches(_, state)
+    newState.decorations = decorations;
+    newState.currentMatches = currentMatches;
   }
   
   return {

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -25,7 +25,9 @@ import {
   ActionRequestComplete,
   ActionRemoveMatch,
   SET_FILTER_STATE,
-  ActionSetFilterState
+  ActionSetFilterState,
+  SET_TYPERIGHTER_ENABLED,
+  ActionSetTyperighterEnabled
 } from "./actions";
 import {
   IMatch,
@@ -154,6 +156,7 @@ export interface IPluginState<
   // Has the document changed since the last document check?
   docChangedSinceCheck: boolean;
   docIsEmpty: boolean;
+  typerighterEnabled: boolean;
 }
 
 // The transaction meta key that namespaces our actions.
@@ -210,7 +213,8 @@ export const createInitialState = <
     requestErrors: [],
     filterState: filterOptions?.initialFilterState as TFilterState,
     docChangedSinceCheck: false,
-    docIsEmpty: !nodeContainsText(doc)
+    docIsEmpty: !nodeContainsText(doc),
+    typerighterEnabled: true
   };
 
   const stateWithMatches = addMatchesToState(
@@ -293,6 +297,8 @@ export const createReducer = <TPluginState extends IPluginState>(
           return handleSetConfigValue(tr, state, action);
         case SET_FILTER_STATE:
           return handleSetFilterState(tr, state, action);
+        case SET_TYPERIGHTER_ENABLED:
+          return handleSetTyperighterEnabled(tr, state, action);
         default:
           return state;
       }
@@ -840,3 +846,25 @@ const handleSetFilterState = <TPluginState extends IPluginState>(
   ...state,
   filterState
 });
+
+const handleSetTyperighterEnabled = <TPluginState extends IPluginState>(
+  _: Transaction,
+  state: TPluginState,
+  { payload: { typerighterEnabled } }: ActionSetTyperighterEnabled
+): TPluginState => {
+
+  const newState = {...state}
+  if (!typerighterEnabled){
+    // Typerighter has been disabled
+    // 1. Remove any current matches
+    newState.currentMatches = [];
+    newState.filteredMatches = [];
+    // 2. Stop realtime checking
+    newState.config.requestMatchesOnDocModified = false;
+  }
+  
+  return {
+    ...newState,
+    typerighterEnabled
+  }
+}

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -856,17 +856,21 @@ const handleSetTyperighterEnabled = (getIgnoredRanges: TGetSkippedRanges = doNot
 ): TPluginState => {
 
   const matchRequestAction = { type: REQUEST_FOR_DOCUMENT, payload: { requestId: v4(), categoryIds: []}}
-  const updatedState = typerighterEnabled ? {
-    // Run a check if typerighter has been enabled
-    ...createHandleMatchesRequestForDocument(getIgnoredRanges)(_, state, matchRequestAction)
-  } : {
-      // Typerighter has been disabled
-      // Remove any current matches and pending requests
-      ...handleRemoveAllMatches(_, state),
-      requestsInFlight: {},
-      requestPending: false
-  }
-  
+  const updatedState = typerighterEnabled
+    ? // Run a check if typerighter has been enabled
+      createHandleMatchesRequestForDocument(getIgnoredRanges)(
+        _,
+        state,
+        matchRequestAction
+      )
+    : {
+        // Typerighter has been disabled
+        // Remove any current matches and pending requests
+        ...handleRemoveAllMatches(_, state),
+        requestsInFlight: {},
+        requestPending: false
+      };
+
   return {
     ...state,
     ...updatedState,

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -172,7 +172,7 @@ interface IInitialStateOpts<
   matchColours?: IMatchTypeToColourMap;
   filterOptions?: IFilterOptions<TFilterState, TMatch>;
   requestMatchesOnDocModified?: boolean;
-  typerighterEnabled: boolean;
+  typerighterEnabled?: boolean;
 }
 
 /**
@@ -187,7 +187,7 @@ export const createInitialState = <
   ignoreMatch = includeAllMatches,
   matchColours = defaultMatchColours,
   requestMatchesOnDocModified = false,
-  typerighterEnabled,
+  typerighterEnabled = true,
   filterOptions
 }: IInitialStateOpts<TFilterState, TMatch>): IPluginState<
   TFilterState,

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -877,7 +877,7 @@ describe("Action handlers", () => {
       expect(newState.requestsInFlight).toEqual({});
       expect(newState.requestPending).toEqual(false);
     })
-    it("should fetch matches for the entire document when enabled", () => {
+    it("should add requests-in-flight for the entire document when enabled", () => {
       const { state, tr } = createInitialData();
       const expectedRequest = {
         "categoryIds": [], 

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -11,7 +11,8 @@ import {
   newHoverIdReceived,
   requestMatchesComplete as requestComplete,
   removeMatch,
-  removeAllMatches
+  removeAllMatches,
+  setTyperighterEnabled
 } from "../actions";
 import { selectAllBlocksInFlight, selectRequestInFlightById } from "../selectors";
 import { createReducer, IPluginState } from "../reducer";
@@ -839,6 +840,82 @@ describe("Action handlers", () => {
       expect(newState.requestErrors).toEqual(state.requestErrors);
     });
   });
+  describe("setTyperighterEnabled", () => { 
+    it("should remove any matches and decorations when disabled", () => {
+      const { state, tr } = createInitialData();
+      const matcherResponse = createMatcherResponse([{ from: 5, to: 10 }]);
+      let newState = reducer(
+        tr,
+        {
+          ...state,
+          requestsInFlight: createRequestInFlight([createBlock(5, 10)])
+        },
+        requestMatchesSuccess(matcherResponse)
+      );
+
+      newState = reducer(
+        tr,
+        newState,
+        setTyperighterEnabled(false)
+      );
+
+      expect(newState.currentMatches).toEqual([]);
+      expect(newState.decorations).toEqual(state.decorations);
+    })
+    it("should remove any pending requests when disabled", () => {
+      const { state, tr } = createInitialData();
+      let newState = reducer(
+        tr,
+        {
+          ...state,
+          requestsInFlight: createRequestInFlight([createBlock(5, 10)]),
+          requestPending: true,
+        },
+        setTyperighterEnabled(false)
+      );
+
+      expect(newState.requestsInFlight).toEqual({});
+      expect(newState.requestPending).toEqual(false);
+    })
+    it("should fetch matches for the entire document when enabled", () => {
+      const { state, tr } = createInitialData();
+      const expectedRequest = {
+        "categoryIds": [], 
+        "mapping": {
+          "from": 0, 
+          "maps": [], 
+          "mirror": undefined, 
+          "to": 0
+        }, 
+        "pendingBlocks": [{
+          "block": {
+            "from": 1, 
+            "id": "0-from:1-to:23", 
+            "skipRanges": [], 
+            "text": "Example text to check", 
+            "to": 23
+          }, 
+          "pendingCategoryIds": []
+        }], 
+        "totalBlocks": 1
+      }
+
+      const requests = reducer(
+        tr,
+        state,
+        setTyperighterEnabled(true)
+      ).requestsInFlight;
+      
+      
+      const requestNames = Object.keys(requests);
+      const actualRequest = requests[Object.keys(requests)[0]]
+      
+      expect(requestNames.length).toEqual(1); 
+      expect(actualRequest).toMatchObject(
+        expectedRequest
+      ); 
+    });
+  })
   describe("setConfigValue", () => {
     it("should set a config value", () => {
       const { state } = createInitialData();

--- a/src/ts/state/test/store.spec.ts
+++ b/src/ts/state/test/store.spec.ts
@@ -4,7 +4,7 @@ import { createDoc, p } from "../../test/helpers/prosemirror";
 
 describe("store", () => {
   const doc = createDoc(p("Example doc"))
-  const initState = createInitialState({ doc });
+  const initState = createInitialState({ doc, typerighterEnabled: true });
 
   it("should allow consumers to subscribe to all store events, and trigger subscriptions when those events are emitted", () => {
     const store = new Store();

--- a/src/ts/state/test/store.spec.ts
+++ b/src/ts/state/test/store.spec.ts
@@ -4,7 +4,7 @@ import { createDoc, p } from "../../test/helpers/prosemirror";
 
 describe("store", () => {
   const doc = createDoc(p("Example doc"))
-  const initState = createInitialState({ doc, typerighterEnabled: true });
+  const initState = createInitialState({ doc });
 
   it("should allow consumers to subscribe to all store events, and trigger subscriptions when those events are emitted", () => {
     const store = new Store();

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -121,4 +121,41 @@ describe("Commands", () => {
       expect(editorElement.innerHTML).toBe("An a<em>mp</em>le sentence");
     });
   });
+  describe("setTyperighterEnabled", () => { 
+
+    const createExampleEditor = (
+      before: string,
+      from: number,
+      to: number,
+    )  => {
+      const match = createMatch(from, to, [
+        { text: "N/A", type: "TEXT_SUGGESTION" }
+      ]);
+      const { editorElement, commands } = createEditor(before, [match]);
+    
+      return { editorElement, commands };
+    };
+
+    it("should remove any match decorations when Typerighter is disabled", () => {
+      const { editorElement, commands } = createExampleEditor("<p>An example sentence</p>",
+      4,
+      11);
+
+      commands.setTyperighterEnabled(false);
+
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBeFalsy()
+    })
+
+    it("should not remove match decorations when setTyperighterEnabled is set to true", () => {
+      const { editorElement, commands } = createExampleEditor("<p>An example sentence</p>",
+      4,
+      11);
+
+      commands.setTyperighterEnabled(true);
+
+      const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
+      expect(maybeMatchElement).toBeTruthy()
+    })
+  })
 });

--- a/src/ts/test/helpers/createEditor.ts
+++ b/src/ts/test/helpers/createEditor.ts
@@ -34,7 +34,8 @@ export const createEditor = (htmlDoc: string, matches: IMatch[] = []) => {
   const { plugin: validatorPlugin, getState } = createTyperighterPlugin({
     isElementPartOfTyperighterUI,
     matches,
-    adapter: new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk")
+    adapter: new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk"),
+    typerighterEnabled: true
   });
 
   const view = new EditorView(editorElement!, {

--- a/src/ts/test/helpers/createEditor.ts
+++ b/src/ts/test/helpers/createEditor.ts
@@ -35,7 +35,6 @@ export const createEditor = (htmlDoc: string, matches: IMatch[] = []) => {
     isElementPartOfTyperighterUI,
     matches,
     adapter: new TyperighterAdapter("https://checker.typerighter.local.dev-gutools.co.uk"),
-    typerighterEnabled: true
   });
 
   const view = new EditorView(editorElement!, {

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -215,7 +215,8 @@ export const createInitialData = (
       requestPending: false,
       requestErrors: [],
       docChangedSinceCheck: false,
-      docIsEmpty: false
+      docIsEmpty: false,
+      typerighterEnabled: true
     } as IPluginState
   };
 };


### PR DESCRIPTION
This PR adds a command to enable or disable Typerighter. This will be initially used in the liveblog, where Typerighter will be enabled (or disabled) via a toggle, after which realtime checks will occur (or stop occurring).

When Typerighter is enabled: 
- a check occurs of the whole document.
- realtime checks will continue to occur if they are enabled.

When Typerighter is disabled:
- all matches are removed
- all pending requests are discarded
- realtime checks will no longer occur

### How to test:
#### Manual testing
1. Run this repository locally according to the instructions in the readme.
2. Try disabling and enabling Typerighter via the toggle in the local application's UI. Are all of the following true:?
     - matches are removed from the UI when Typerighter is disabled.
     - no pending matches appear after Typerighter is disabled.
     - a check occurs when Typerighter is re-enabled
     - real time checks continue to occur when Typerighter is enabled and changes are made to the document
#### Automated testing
3. All tests can be run using `npm run test`. Are the tests added by this PR (and all others) passing?