### PR TITLE
fix: Remove matches when they do not have a width

### DIFF
--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -1,4 +1,5 @@
 import { identity } from "lodash";
+import { AllSelection } from "prosemirror-state";
 import { DecorationSet } from "prosemirror-view";
 import { IMatch } from "../..";
 import {
@@ -213,6 +214,18 @@ describe("State helpers", () => {
 
       expect(newBlockInFlight.from).toEqual(oldBlockInFlight.from);
       expect(newBlockInFlight.to).toEqual(oldBlockInFlight.to - deleteRange);
+    });
+
+    it("should remove matches when they no longer have a width (for example, when the text they refer to has been deleted)", () => {
+      const matches = [createMatch(1, 4), createMatch(4, 7)];
+      const { tr, state } = getState(matches, [MatchType.DEFAULT]);
+
+      tr.setSelection(new AllSelection(tr.doc));
+      tr.deleteSelection();
+      const { currentMatches, decorations } = getNewStateFromTransaction(tr, state);
+
+      expect(currentMatches.length).toBe(0);
+      expect(decorations.find().length).toBe(0);
     });
   })
 });

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -25,14 +25,18 @@ export const mapAndMergeRanges = <Range extends IRange>(
 ): Range[] => mergeRanges(mapRanges(ranges, mapping));
 
 export const mapRanges = <Range extends IRange>(
-  ranges: Range[],
-  mapping: Mapping
-): Range[] =>
-  ranges.map(range => ({
-    ...range,
-    from: mapping.map(range.from),
-    to: mapping.map(range.to)
-  }));
+         ranges: Range[],
+         mapping: Mapping
+       ): Range[] =>
+         ranges
+           .map(range => ({
+             ...range,
+             from: mapping.map(range.from),
+             to: mapping.map(range.to)
+           }))
+           // If in mapping a range we reduce its size to 0, remove it –
+           // the relevant text no longer exists.
+           .filter(range => range.to > range.from);
 
 export const mapRange = <Range extends IRange>(
   range: Range,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

At the moment, in prosemirror-typerighter, removing the entire document leaves matches in place. This isn't right – touching or removing text that contains matches should remove those matches. Here's an example, as spotted by @rebecca-thompson: 

https://user-images.githubusercontent.com/7767575/189712382-d78a008b-3550-4afd-b377-6662c33f2061.mov

This PR fixes that by removing matches that no longer have a width as a result of being mapped through doc changes.

## Dev notes

The story for removing ranges in response to document edits is now split between our business-as-usual mapping operations in 1) `getNewStateFromTransaction`, which is called on every transaction, and 2) our `applyNewDirtiedRanges` action, which is dispatched as an additional transaction when the document changes. This is because removing zero-width mappings is best done when mapping ranges (it happens automatically when Decorations are mapped, for example), which happens in 1), and removing matches associated with dirtied ranges is handled in 2).

I think it'd be better to remove 2) and do this all in 1) – 
  - it's more efficient, as returning a new transaction from `appendTransaction` will trigger a new `update` cycle.
  - it colocates the logic responsible for this work, which is less surprising.

Probably best done as a no-op in a separate PR.

## How to test

- The automated test should pass, and you should be convinced that it solves the problem in question.
- It should no longer be possible to reproduce the video above.
