### PR TITLE
feat!: Separate out view functions for sidebar and overlay

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -6,14 +6,13 @@ import { addListNodes } from "prosemirror-schema-list";
 import { history } from "prosemirror-history";
 import { exampleSetup, buildMenuItems } from "prosemirror-example-setup";
 import applyDevTools from "prosemirror-dev-tools";
-
 import "prosemirror-view/style/prosemirror.css";
 import "prosemirror-menu/style/menu.css";
 import "prosemirror-example-setup/style/style.css";
 import "prosemirror-example-setup/style/style.css";
 import "../src/css/index.scss";
 import createTyperighterPlugin from "../src/ts/createTyperighterPlugin";
-import createView from "../src/ts/createView";
+import { createOverlayView, createSidebarView } from "../src/ts/createView";
 import { createBoundCommands } from "../src/ts/commands";
 import TyperighterTelemetryAdapter from "../src/ts/services/TyperighterTelemetryAdapter";
 import { UserTelemetryEventSender } from "@guardian/user-telemetry-client";
@@ -96,20 +95,27 @@ if (editorElement && sidebarNode) {
 
   const commands = createBoundCommands(view, getState);
 
-  createView({
-    view,
+  createSidebarView({
     store,
     matcherService,
     commands,
     sidebarNode,
-    overlayNode,
     contactHref: "mailto:example@typerighter.co.uk",
     feedbackHref: "http://a-form-for-example.com",
-    onMarkCorrect: match => console.info("Match ignored!", match),
     editorScrollElement: editorElement,
     getScrollOffset,
     telemetryAdapter: typerighterTelemetryAdapter,
     enableDevMode: true
+  });
+
+  createOverlayView({
+    view,
+    store,
+    commands,
+    overlayNode,
+    feedbackHref: "http://a-form-for-example.com",
+    onMarkCorrect: match => console.info("Match ignored!", match),
+    telemetryAdapter: typerighterTelemetryAdapter,
   });
 
   // Handy debugging tools

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -9,7 +9,7 @@ import TyperighterChunkedAdapter from "./services/adapters/TyperighterChunkedAda
 import { commands, createBoundCommands } from "./commands";
 import { getBlocksFromDocument } from './utils/prosemirror';
 import { filterByMatchState } from './utils/plugin';
-import createView from "./createView";
+import { createSidebarView, createOverlayView } from "./createView";
 import '../css/index.scss';
 
 export {
@@ -22,7 +22,8 @@ export {
   convertTyperighterResponse,
   createBoundCommands,
   commands,
-  createView,
+  createSidebarView,
+  createOverlayView,
   createTyperighterPlugin,
   filterByMatchState,
   IMatch,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Separates out view functions for sidebar and overlay views, and has them return unmount functions.

This addresses two oversights:
- we may want more than one instance on the page at once, and we may need to clean up after it is gone
- we may want to instantiate an overlay without a sidebar (in the Guardian's case, in liveblogs.)

## How to test

This is a no-op – the application should run as before. You should see two view functions, rather than one, exported from the project root.
