### PR TITLE
chore: Remove type parameters from plugin state

### DIFF
--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -40,9 +40,7 @@ type Command = (
   dispatch?: (tr: Transaction) => void
 ) => boolean;
 
-type GetState<TPluginState extends IPluginState = IPluginState> = (
-  state: EditorState
-) => TPluginState | null | undefined;
+type GetState = (state: EditorState) => IPluginState | null | undefined;
 
 /**
  * Requests matches for an entire document.
@@ -153,9 +151,9 @@ export const stopHighlightCommand = (): Command => (state, dispatch) => {
 /**
  * Mark a given match as active.
  */
-export const selectMatchCommand = <TPluginState extends IPluginState>(
+export const selectMatchCommand = (
   matchId: string,
-  getState: GetState<TPluginState>
+  getState: GetState
 ): Command => (state, dispatch) => {
   const pluginState = getState(state);
   if (!pluginState) {
@@ -345,9 +343,7 @@ export const ignoreMatchCommand = (id: string) => (getState: GetState) => (
   return !!match;
 };
 
-export const clearMatchesCommand = () => <TPluginState extends IPluginState>(
-  _: GetState<TPluginState>
-) => (
+export const clearMatchesCommand = () => (_: GetState) => (
   state: EditorState,
   dispatch?: (tr: Transaction<any>) => void
 ): boolean => {

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -11,8 +11,8 @@ import { debounce } from "lodash"
 import { Placement } from "@popperjs/core";
 
 
-interface IProps<TPluginState extends IPluginState> {
-  store: Store<TPluginState>;
+interface IProps {
+  store: Store<IPluginState>;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   stopHover: () => void;
   feedbackHref?: string;
@@ -22,13 +22,13 @@ interface IProps<TPluginState extends IPluginState> {
 /**
  * An overlay to display match tooltips.
  */
-const matchOverlay = <TPluginState extends IPluginState>({
+const matchOverlay = ({
   applySuggestions,
   feedbackHref,
   onMarkCorrect,
   stopHover,
   store
-}: IProps<TPluginState>) => {
+}: IProps) => {
   const [pluginState, setPluginState] = useState<IPluginState | undefined>(
     undefined
   );
@@ -91,7 +91,7 @@ const matchOverlay = <TPluginState extends IPluginState>({
       const lastRect = rects[rects.length - 1];
       //Determine the X offset as the difference between the last rect (bottom left) and the current rect.
       //This will only work if the placement is set to the "bottom-start". If we wanted to change this we
-      //would need to build more flexibility into how this is calculated. 
+      //would need to build more flexibility into how this is calculated.
       const x = hoverRect.left - lastRect.left;
       //Determine the Y offset by taking the rect height and multiplying by the number of rects (lines)
       //This adjustment depends on if the popup is displayed above or below the content.

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -11,8 +11,8 @@ import { MatchType } from "../utils/decoration";
 import _ from "lodash";
 import SidebarMatches from "./SidebarMatches";
 
-interface IProps<TPluginState extends IPluginState> {
-  store: Store<TPluginState>;
+interface IProps {
+  store: Store<IPluginState>;
   applyAutoFixableSuggestions: () => void;
   applyFilterState: (filterState: MatchType[]) => void;
   selectMatch: (matchId: string) => void;
@@ -27,7 +27,7 @@ interface IProps<TPluginState extends IPluginState> {
  * Displays current matches and allows users to apply suggestions.
  */
 
-const Results = <TPluginState extends IPluginState<MatchType[]>>({
+const Results = ({
   store,
   selectMatch,
   indicateHighlight,
@@ -36,13 +36,13 @@ const Results = <TPluginState extends IPluginState<MatchType[]>>({
   editorScrollElement,
   getScrollOffset,
   applyFilterState
-}: IProps<TPluginState>) => {
-  const [pluginState, setPluginState] = useState<TPluginState | undefined>(
+}: IProps) => {
+  const [pluginState, setPluginState] = useState<IPluginState | undefined>(
     undefined
   );
   const [loadingBarVisible, setLoadingBarVisible] = useState<boolean>(false);
 
-  const handleNewState = (incomingState: TPluginState) => {
+  const handleNewState = (incomingState: IPluginState) => {
     setPluginState({
       ...incomingState,
       currentMatches: sortBy(incomingState.currentMatches, "from")

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -4,14 +4,12 @@ import Store, { STORE_EVENT_NEW_STATE } from ".././state/store";
 import Results from "./Results";
 import Controls from "./Controls";
 import { Commands } from ".././commands";
-import { IMatch } from ".././interfaces/IMatch";
 import { MatcherService } from "..";
 import { IPluginState } from "../state/reducer";
-import { MatchType } from "../utils/decoration";
 
-interface IProps<TPluginState extends IPluginState> {
-  store: Store<TPluginState>;
-  matcherService: MatcherService<TPluginState["filterState"], IMatch>;
+interface IProps {
+  store: Store<IPluginState>;
+  matcherService: MatcherService;
   commands: Commands;
   contactHref?: string;
   feedbackHref?: string;
@@ -20,7 +18,7 @@ interface IProps<TPluginState extends IPluginState> {
   enableDevMode?: boolean;
 }
 
-const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
+const Sidebar = ({
   store,
   matcherService,
   commands,
@@ -29,7 +27,7 @@ const Sidebar = <TPluginState extends IPluginState<MatchType[]>>({
   getScrollOffset,
   feedbackHref,
   enableDevMode
-}: IProps<TPluginState>) => {
+}: IProps) => {
   const [pluginState, setPluginState] = useState<IPluginState | undefined>(
     undefined
   );

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -17,7 +17,8 @@ import {
   defaultMatchColours,
   maybeGetDecorationMatchIdFromEvent,
   createGlobalDecorationStyleTag,
-  GLOBAL_DECORATION_STYLE_ID
+  GLOBAL_DECORATION_STYLE_ID,
+  MatchType
 } from "./utils/decoration";
 import { EditorView } from "prosemirror-view";
 import { Plugin, Transaction } from "prosemirror-state";
@@ -32,7 +33,7 @@ import Store, {
 } from "./state/store";
 import { doNotSkipRanges, TGetSkippedRanges } from "./utils/block";
 import { createBoundCommands, startHoverCommand, stopHoverCommand } from "./commands";
-import { TFilterMatches, maybeResetHoverStates } from "./utils/plugin";
+import { IFilterMatches, maybeResetHoverStates } from "./utils/plugin";
 import { pluginKey } from "./utils/plugin";
 import { getClientRectIndex } from "./utils/clientRect";
 import MatcherService from "./services/MatcherService";
@@ -42,24 +43,21 @@ import { v4 } from "uuid";
 
 export type ExpandRanges = (ranges: IRange[], doc: Node<any>) => IRange[];
 
-export interface IFilterOptions<TFilterState, TMatch extends IMatch> {
+export interface IFilterOptions{
   /**
    * A function to filter matches given a user-defined filter state.
    */
-  filterMatches: TFilterMatches<TFilterState, TMatch>;
+  filterMatches: IFilterMatches;
 
   /**
    * The initial state to pass to the filter predicate.
    */
-  initialFilterState: TFilterState;
+  initialFilterState: MatchType[];
 }
 
 type PluginOptionsFromConfig = Partial<Pick<IPluginConfig, "requestMatchesOnDocModified">>;
 
-export interface IPluginOptions<
-  TFilterState = undefined,
-  TMatch extends IMatch = IMatch
-> extends PluginOptionsFromConfig {
+export interface IPluginOptions extends PluginOptionsFromConfig {
   /**
    * A function that receives ranges that have been dirtied since the
    * last request, and returns the new ranges to find matches for. The
@@ -71,14 +69,14 @@ export interface IPluginOptions<
   /**
    * The initial set of matches to apply to the document, if any.
    */
-  matches?: TMatch[];
+  matches?: IMatch[];
 
   /**
    * Ignore matches when this predicate returns true.
    */
   ignoreMatch?: IIgnoreMatchPredicate;
 
-  filterOptions?: IFilterOptions<TFilterState, TMatch>;
+  filterOptions?: IFilterOptions;
 
   /**
    * The colours to use for document matches.
@@ -103,11 +101,11 @@ export interface IPluginOptions<
   /**
    * Called when a match decoration is clicked.
    */
-  onMatchDecorationClicked?: (match: TMatch) => void;
+  onMatchDecorationClicked?: (match: IMatch) => void;
 
   telemetryAdapter?: TyperighterTelemetryAdapter;
 
-  adapter: IMatcherAdapter<TMatch>,
+  adapter: IMatcherAdapter,
 
   typerighterEnabled?: boolean
 }
@@ -117,12 +115,12 @@ export interface IPluginOptions<
  * document is changed via the supplied servier, decorating the document with matches
  * when they are are returned, and applying suggestions to the document.
  */
-const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
-  options: IPluginOptions<TFilterState, TMatch>
+const createTyperighterPlugin = (
+  options: IPluginOptions
 ): {
-  plugin: Plugin<IPluginState<TFilterState, TMatch>>;
-  store: Store<IPluginState<TFilterState, TMatch>>;
-  matcherService: MatcherService<TFilterState, TMatch>
+  plugin: Plugin<IPluginState>;
+  store: Store<IPluginState>;
+  matcherService: MatcherService
 } => {
   const {
     expandRanges = expandRangesToParentBlockNodes,
@@ -138,24 +136,22 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
     telemetryAdapter,
     typerighterEnabled = true,
   } = options;
-  // A handy alias to reduce repetition
-  type TPluginState = IPluginState<TFilterState, TMatch>;
-
   // Set up our store, which we'll use to notify consumer code of state updates.
-  const store = new Store<TPluginState>();
-  const reducer = createReducer<TPluginState>(
+  const store = new Store<IPluginState>();
+  const reducer = createReducer(
     expandRanges,
     ignoreMatch,
     filterOptions?.filterMatches,
     getSkippedRanges
   );
+
   const matcherService = new MatcherService(store, adapter, telemetryAdapter)
 
-  const plugin: Plugin<TPluginState> = new Plugin({
+  const plugin: Plugin<IPluginState> = new Plugin({
     key: pluginKey,
     state: {
       init: (_, { doc }) => {
-        const initialState = createInitialState<TFilterState, TMatch>({
+        const initialState = createInitialState({
           doc,
           matches,
           ignoreMatch,
@@ -167,7 +163,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
         store.emit(STORE_EVENT_NEW_STATE, initialState);
         return initialState;
       },
-      apply(tr: Transaction, state: TPluginState): TPluginState {
+      apply(tr: Transaction, state: IPluginState): IPluginState {
         // We use the reducer pattern to handle state transitions.
         return reducer(tr, state, tr.getMeta(PROSEMIRROR_TYPERIGHTER_ACTION));
       }
@@ -178,8 +174,8 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
      * in response to state transitions.
      */
     appendTransaction(trs: Transaction[], oldState, newState) {
-      const oldPluginState: TPluginState = plugin.getState(oldState);
-      const newPluginState: TPluginState = plugin.getState(newState);
+      const oldPluginState: IPluginState = plugin.getState(oldState);
+      const newPluginState: IPluginState = plugin.getState(newState);
 
       const newTr = newState.tr;
 
@@ -213,10 +209,7 @@ const createTyperighterPlugin = <TFilterState, TMatch extends IMatch>(
       );
     },
     props: {
-      decorations: state => {
-        const { decorations }: TPluginState = plugin.getState(state);
-        return decorations;
-      },
+      decorations: state => plugin.getState(state).decorations,
       handleDOMEvents: {
         mouseleave: (view, event) => {
           maybeResetHoverStates(view, isElementPartOfTyperighterUI, event);

--- a/src/ts/createView.tsx
+++ b/src/ts/createView.tsx
@@ -11,12 +11,11 @@ import TyperighterTelemetryAdapter from "./services/TyperighterTelemetryAdapter"
 import TelemetryContext from "./contexts/TelemetryContext";
 import { EditorView } from "prosemirror-view";
 import { IPluginState } from "./state/reducer";
-import { MatchType } from "./utils/decoration";
 
-interface IViewOptions<TPluginState extends IPluginState> {
+interface IViewOptions {
   view: EditorView;
-  store: Store<TPluginState>;
-  matcherService: MatcherService<TPluginState["filterState"], IMatch>;
+  store: Store<IPluginState>;
+  matcherService: MatcherService;
   commands: Commands;
   sidebarNode: Element;
   overlayNode: Element;
@@ -44,7 +43,7 @@ interface IViewOptions<TPluginState extends IPluginState> {
  *  - The plugin configuration pane
  *  - The plugin results pane
  */
-const createView = <TPluginState extends IPluginState<MatchType[]>>({
+const createView = ({
   view,
   store,
   matcherService,
@@ -59,7 +58,7 @@ const createView = <TPluginState extends IPluginState<MatchType[]>>({
   editorScrollElement,
   getScrollOffset = () => 50,
   enableDevMode = false
-}: IViewOptions<TPluginState>) => {
+}: IViewOptions) => {
   // Create our overlay node, which is responsible for displaying
   // match messages when the user hovers over highlighted ranges.
   overlayNode.classList.add("TyperighterPlugin__tooltip-overlay");

--- a/src/ts/interfaces/IMatcherAdapter.ts
+++ b/src/ts/interfaces/IMatcherAdapter.ts
@@ -9,9 +9,7 @@ import {
 /**
  * @internal
  */
-export declare class IMatcherAdapter<
-  TMatch extends IMatch = IMatch
-> {
+export declare class IMatcherAdapter {
   /**
    * Fetch the matches for the given inputs.
    */
@@ -19,7 +17,7 @@ export declare class IMatcherAdapter<
     requestId: string,
     input: IBlock[],
     categoryIds: string[],
-    onMatchesReceived: TMatchesReceivedCallback<TMatch>,
+    onMatchesReceived: TMatchesReceivedCallback,
     onRequestError: TRequestErrorCallback,
     onRequestComplete: TRequestCompleteCallback
   ) => void;
@@ -32,9 +30,7 @@ export declare class IMatcherAdapter<
   constructor(apiUrl: string);
 }
 
-export type TMatchesReceivedCallback<
-  TMatch extends IMatch = IMatch
-> = (response: IMatcherResponse<TMatch[]>) => void;
+export type TMatchesReceivedCallback = (response: IMatcherResponse<IMatch[]>) => void;
 
 export type TRequestErrorCallback = (
   matchRequestError: TMatchRequestErrorWithDefault

--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -19,7 +19,7 @@ import { mapMatchThroughBlocks } from "../utils/match";
  * A matcher service to manage the interaction between the prosemirror-typerighter plugin
  * and the remote matching service.
  */
-class MatcherService<TFilterState, TMatch extends IMatch> {
+class MatcherService {
   // The current throttle duration, which increases during backoff.
   private currentThrottle: number;
   private currentCategories = [] as ICategory[];
@@ -28,8 +28,8 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
   private commands: Commands | undefined;
 
   constructor(
-    private store: Store<IPluginState<TFilterState, TMatch>>,
-    private adapter: IMatcherAdapter<TMatch>,
+    private store: Store<IPluginState>,
+    private adapter: IMatcherAdapter,
     private telemetryAdapter?: TyperighterTelemetryAdapter,
     // The initial throttle duration for pending requests.
     private initialThrottle = 2000,
@@ -49,8 +49,8 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
     return this.commands
   }
 
-  private sendMatchTelemetryEvents = (matches: TMatch[]) => {
-    matches.forEach((match: TMatch) =>
+  private sendMatchTelemetryEvents = (matches: IMatch[]) => {
+    matches.forEach((match: IMatch) =>
       this.telemetryAdapter?.matchFound(match, document.URL)
     );
   };
@@ -90,7 +90,7 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
   public async fetchMatches(requestId: string, blocks: IBlockWithSkippedRanges[]) {
     const commands = this.getCommands();
     if (!commands) return;
-    const applyMatcherResponse: TMatchesReceivedCallback<TMatch> = response => {
+    const applyMatcherResponse: TMatchesReceivedCallback = response => {
       this.sendMatchTelemetryEvents(response.matches);
       // For matches, map through skipped ranges on the way in
       const transformedMatches = response.matches.map(match => mapMatchThroughBlocks(match, blocks))
@@ -131,8 +131,8 @@ class MatcherService<TFilterState, TMatch extends IMatch> {
   }
 
   /**
-   * Provide the matcher service with commands, which must be 
-   * bound to an `EditorView` instance, and so cannot be provided 
+   * Provide the matcher service with commands, which must be
+   * bound to an `EditorView` instance, and so cannot be provided
    * until the Typerighter plugin is instantiated by an `EditorView`.
    */
   public setCommands(commands: Commands) {

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -59,9 +59,9 @@ export const requestMatchesSuccess = <TPluginState extends IPluginState>(
 // We must repeat ourselves here, as ReturnType doesn't play nicely with type parameters.
 // See https://github.com/microsoft/TypeScript/issues/26856
 // tslint:disable-next-line:interface-over-type-literal
-export type ActionRequestMatchesSuccess<TPluginState extends IPluginState> = {
+export type ActionRequestMatchesSuccess = {
   type: "REQUEST_SUCCESS";
-  payload: { response: IMatcherResponse<TPluginState["currentMatches"]> };
+  payload: { response: IMatcherResponse<IPluginState["currentMatches"]> };
 };
 
 export const requestError = (matchRequestError: IMatchRequestError) => ({
@@ -76,7 +76,10 @@ export const requestMatchesComplete = (requestId: string) => ({
 });
 export type ActionRequestComplete = ReturnType<typeof requestMatchesComplete>;
 
-export const newHoverIdReceived = (matchId: string | undefined, rectIndex: number | undefined) => ({
+export const newHoverIdReceived = (
+  matchId: string | undefined,
+  rectIndex: number | undefined
+) => ({
   type: NEW_HOVER_ID,
   payload: { matchId, rectIndex }
 });
@@ -134,25 +137,24 @@ export const setFilterState = <TPluginState extends IPluginState>(
   payload: { filterState }
 });
 // tslint:disable-next-line:interface-over-type-literal
-export type ActionSetFilterState<TPluginState extends IPluginState> = {
+export type ActionSetFilterState = {
   type: typeof SET_FILTER_STATE;
-  payload: { filterState: TPluginState["filterState"] };
+  payload: { filterState: IPluginState["filterState"] };
 };
 
-export const setTyperighterEnabled = (
-  typerighterEnabled: boolean,
-) => ({
+export const setTyperighterEnabled = (typerighterEnabled: boolean) => ({
   type: SET_TYPERIGHTER_ENABLED,
   payload: { typerighterEnabled }
 });
 
-export type ActionSetTyperighterEnabled = ReturnType<typeof setTyperighterEnabled>
+export type ActionSetTyperighterEnabled = ReturnType<
+  typeof setTyperighterEnabled
+>;
 
-
-export type Action<TPluginState extends IPluginState> =
+export type Action =
   | ActionNewHoverIdReceived
   | ActionNewHighlightIdReceived
-  | ActionRequestMatchesSuccess<TPluginState>
+  | ActionRequestMatchesSuccess
   | ActionRequestMatchesForDirtyRanges
   | ActionRequestMatchesForDocument
   | ActionRequestError
@@ -162,5 +164,5 @@ export type Action<TPluginState extends IPluginState> =
   | ActionSetConfigValue
   | ActionRemoveMatch
   | ActionRemoveAllMatches
-  | ActionSetFilterState<TPluginState>
+  | ActionSetFilterState
   | ActionSetTyperighterEnabled;

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -12,16 +12,16 @@ import {
   createDecorationsForMatches
 } from "../utils/decoration";
 import { DecorationSet } from "prosemirror-view";
-import { TFilterMatches } from "../utils/plugin";
+import { IFilterMatches } from "../utils/plugin";
 import { mapAndMergeRanges, mapRange, mapRanges } from "../utils/range";
 import { nodeContainsText } from "../utils/prosemirror";
 
-export const addMatchesToState = <TPluginState extends IPluginState>(
-  state: TPluginState,
+export const addMatchesToState = (
+  state: IPluginState,
   doc: any,
-  matches: Array<TPluginState["currentMatches"][number]>,
+  matches: Array<IPluginState["currentMatches"][number]>,
   ignoreMatch: IIgnoreMatchPredicate = includeAllMatches
-) => {
+): IPluginState => {
   const matchesToApply = matches.filter(match => !ignoreMatch(match));
   const decorations = matchesToApply.reduce(
     (set, output) => set.add(doc, createDecorationsForMatch(output)),
@@ -37,11 +37,11 @@ export const addMatchesToState = <TPluginState extends IPluginState>(
 /**
  * Is the current filter state stale, given the incoming state?
  */
-export const isFilterStateStale = <TPluginState extends IPluginState>(
-  oldState: TPluginState,
-  newState: TPluginState,
-  filterMatches?: TFilterMatches<TPluginState["filterState"]>
-): filterMatches is TFilterMatches<TPluginState["filterState"]> => {
+export const isFilterStateStale = (
+  oldState: IPluginState,
+  newState: IPluginState,
+  filterMatches?: IFilterMatches
+): filterMatches is IFilterMatches => {
   const matchesChanged = oldState.currentMatches !== newState.currentMatches;
   const filterStateChanged = oldState.filterState !== newState.filterState;
   const noFilterApplied = !oldState.filterState && !newState.filterState;
@@ -52,14 +52,11 @@ export const isFilterStateStale = <TPluginState extends IPluginState>(
   );
 };
 
-export const deriveFilteredDecorations = <TPluginState extends IPluginState>(
+export const deriveFilteredDecorations = (
   doc: Node,
-  newState: TPluginState,
-  filterMatches: TFilterMatches<
-    TPluginState["filterState"],
-    TPluginState["currentMatches"][number]
-  >
-): TPluginState => {
+  newState: IPluginState,
+  filterMatches: IFilterMatches
+): IPluginState => {
   const filteredMatches = filterMatches(
     newState.filterState,
     newState.currentMatches
@@ -102,10 +99,10 @@ export const deriveFilteredDecorations = <TPluginState extends IPluginState>(
  * We need to respond to each transaction in our reducer, whether or not there's
  * an action present, in order to maintain mappings and respond to user input.
  */
-export const getNewStateFromTransaction = <TPluginState extends IPluginState>(
+export const getNewStateFromTransaction = (
   tr: Transaction,
-  incomingState: TPluginState
-): TPluginState => {
+  incomingState: IPluginState
+): IPluginState => {
   const mappedRequestsInFlight = Object.entries(
     incomingState.requestsInFlight
   ).reduce((acc, [requestId, requestsInFlight]) => {

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -6,11 +6,11 @@ import { IPluginState, IBlockInFlight, IRequestInFlight } from "./reducer";
 export const selectMatchByMatchId = <TPluginState extends IPluginState>(
   state: TPluginState,
   matchId: string
-): TPluginState['currentMatches'][number] | undefined =>
+): TPluginState["currentMatches"][number] | undefined =>
   state.currentMatches.find(match => match.matchId === matchId);
 
 export const selectRequestInFlightById = (
-  state: IPluginState<unknown>,
+  state: IPluginState,
   requestId: string
 ): IRequestInFlight | undefined => {
   return state.requestsInFlight[requestId];
@@ -34,7 +34,9 @@ export const selectBlocksInFlightById = (
   blockIds: string[]
 ): IBlockInFlight[] =>
   blockIds
-    .map(blockId => selectSingleBlockInRequestInFlightById(state, requestId, blockId))
+    .map(blockId =>
+      selectSingleBlockInRequestInFlightById(state, requestId, blockId)
+    )
     .filter(_ => !!_) as IBlockInFlight[];
 
 export const selectAllBlocksInFlight = (
@@ -66,14 +68,14 @@ export const selectNewBlockInFlight = (
     [] as TSelectRequestInFlight
   );
 
-export const selectPercentRemaining = <TPluginState extends IPluginState>(
-  state?: TPluginState
+export const selectPercentRemaining = (
+  state?: IPluginState
 ) => {
   if (!state) {
     return 0;
   }
   if (state.percentageRequestComplete) {
-    return Math.max(100 - state.percentageRequestComplete, 0)
+    return Math.max(100 - state.percentageRequestComplete, 0);
   }
   const [totalWork, totalRemainingWork] = Object.values(
     state.requestsInFlight
@@ -115,9 +117,7 @@ export const selectSuggestionAndRange = (
   };
 };
 
-export const selectAllAutoFixableMatches = <T, TMatch extends IMatch>(
-  state: IPluginState<T, TMatch>
-): TMatch[] =>
+export const selectAllAutoFixableMatches = (state: IPluginState): IMatch[] =>
   state.currentMatches.filter(
     _ => _.replacement && _.replacement.text === _.message
   );
@@ -137,9 +137,8 @@ export const selectHasAuthError = (state: IPluginState): boolean => {
 export const selectRequestsInProgress = (state: IPluginState): boolean =>
   !!Object.keys(state.requestsInFlight).length;
 
-export const selectHasMatches = <TMatch extends IMatch>(
-  state: IPluginState<unknown, TMatch>
-): boolean => !!state.currentMatches && state.currentMatches.length > 0;
+export const selectHasMatches = (state: IPluginState): boolean =>
+  !!state.currentMatches && state.currentMatches.length > 0;
 
 const getSortOrderForMatchType = (match: IMatch) => {
   const matchType = getMatchType(match);
@@ -154,13 +153,13 @@ const getSortOrderForMatchType = (match: IMatch) => {
 
 const getSortOrderForMatchAppearance = (match: IMatch) => match.from;
 
-export const selectDocumentOrderedMatches = <TMatch extends IMatch>(
-  state: IPluginState<unknown, TMatch>
+export const selectDocumentOrderedMatches = (
+  state: IPluginState
 ): Array<IMatch<ISuggestion>> =>
   sortBy(state.filteredMatches, getSortOrderForMatchAppearance);
 
-export const selectImportanceOrderedMatches = <TMatch extends IMatch>(
-  state: IPluginState<unknown, TMatch>
+export const selectImportanceOrderedMatches = (
+  state: IPluginState
 ): Array<IMatch<ISuggestion>> =>
   sortBy(
     state.filteredMatches,
@@ -176,4 +175,4 @@ export const selectDocumentIsEmpty = (state: IPluginState): boolean => {
   return state.docIsEmpty;
 };
 
-export const selectPluginConfig = (state: IPluginState) => state.config
+export const selectPluginConfig = (state: IPluginState) => state.config;

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -15,7 +15,7 @@ import {
   getNewDecorationsForCurrentMatches,
   MatchType
 } from "../../utils/decoration";
-import { filterByMatchState, IDefaultFilterState } from "../../utils/plugin";
+import { filterByMatchState } from "../../utils/plugin";
 import { expandRangesToParentBlockNodes } from "../../utils/range";
 import {
   deriveFilteredDecorations,
@@ -40,7 +40,7 @@ describe("State helpers", () => {
       state: {
         ...state,
         filterState
-      } as IPluginState<TFilterState>
+      } as IPluginState
     };
   };
 
@@ -54,10 +54,7 @@ describe("State helpers", () => {
     });
     it("should report fresh when the filter state is undefined and the matches change", () => {
       const { state: oldState } = getState([] as IMatch[], undefined);
-      const { state: newState } = getState(
-        [createMatch(1, 2)],
-        undefined
-      );
+      const { state: newState } = getState([createMatch(1, 2)], undefined);
       const isStale = isFilterStateStale(oldState, newState, identity);
       expect(isStale).toBe(false);
     });
@@ -86,7 +83,7 @@ describe("State helpers", () => {
       const { tr, state } = getState([], []);
       const { filteredMatches, decorations } = deriveFilteredDecorations(
         tr.doc,
-        state as IPluginState<IDefaultFilterState>,
+        state as IPluginState,
         filterByMatchState
       );
       expect(filteredMatches).toEqual([]);
@@ -101,7 +98,7 @@ describe("State helpers", () => {
         decorations
       } = deriveFilteredDecorations(
         tr.doc,
-        state as IPluginState<IDefaultFilterState>,
+        state as IPluginState,
         filterByMatchState
       );
       expect(filteredMatches).toEqual(currentMatches);
@@ -118,7 +115,7 @@ describe("State helpers", () => {
         decorations
       } = deriveFilteredDecorations(
         tr.doc,
-        state as IPluginState<IDefaultFilterState>,
+        state as IPluginState,
         filterByMatchState
       );
 
@@ -132,7 +129,7 @@ describe("State helpers", () => {
       const debugDecos = DecorationSet.create(tr.doc, [
         createDebugDecorationFromRange({ from: 0, to: 1 })
       ]);
-      const stateWithDebugDecos: IPluginState<IDefaultFilterState> = {
+      const stateWithDebugDecos: IPluginState = {
         ...state,
         decorations: debugDecos
       };
@@ -159,7 +156,9 @@ describe("State helpers", () => {
 
       expect(newState.currentMatches[0].from).toBe(matches[0].from);
       expect(newState.currentMatches[0].to).toBe(matches[0].to - deleteRange);
-      expect(newState.currentMatches[1].from).toBe(matches[1].from - deleteRange);
+      expect(newState.currentMatches[1].from).toBe(
+        matches[1].from - deleteRange
+      );
       expect(newState.currentMatches[1].to).toBe(matches[1].to - deleteRange);
     });
 
@@ -171,13 +170,15 @@ describe("State helpers", () => {
       const initState = {
         ...state,
         dirtiedRanges: [dirtiedRange]
-      }
+      };
 
       tr.delete(deleteFrom, deleteFrom + deleteRange);
       const newState = getNewStateFromTransaction(tr, initState);
 
       expect(newState.dirtiedRanges[0].from).toEqual(dirtiedRange.from);
-      expect(newState.dirtiedRanges[0].to).toEqual(dirtiedRange.to - deleteRange);
+      expect(newState.dirtiedRanges[0].to).toEqual(
+        dirtiedRange.to - deleteRange
+      );
     });
 
     it("should add mapping to the requests in flight", () => {
@@ -186,20 +187,26 @@ describe("State helpers", () => {
       const { tr, state } = getState([], [MatchType.DEFAULT]);
       const initState = {
         ...state,
-        requestsInFlight: createRequestInFlight([createBlock(1, 22, "Example text to check")])
+        requestsInFlight: createRequestInFlight([
+          createBlock(1, 22, "Example text to check")
+        ])
       };
 
       tr.delete(deleteFrom, deleteFrom + deleteRange);
       const newState = getNewStateFromTransaction(tr, initState);
 
-      expect(newState.requestsInFlight[exampleRequestId].mapping).toEqual(tr.mapping);
+      expect(newState.requestsInFlight[exampleRequestId].mapping).toEqual(
+        tr.mapping
+      );
     });
 
     it("should map requestsInFlight blocks through the incoming transaction mapping", () => {
       const deleteRange = 1;
       const deleteFrom = 2;
       const { tr, state } = getState([], [MatchType.DEFAULT]);
-      const requestsInFlight = createRequestInFlight([createBlock(1, 23, "Example text to check")])
+      const requestsInFlight = createRequestInFlight([
+        createBlock(1, 23, "Example text to check")
+      ]);
       const initState = {
         ...state,
         requestsInFlight
@@ -208,11 +215,13 @@ describe("State helpers", () => {
       tr.delete(deleteFrom, deleteFrom + deleteRange);
       const newState = getNewStateFromTransaction(tr, initState);
 
-      const oldBlockInFlight = state.requestsInFlight[exampleRequestId].pendingBlocks[0].block
-      const newBlockInFlight = newState.requestsInFlight[exampleRequestId].pendingBlocks[0].block
+      const oldBlockInFlight =
+        state.requestsInFlight[exampleRequestId].pendingBlocks[0].block;
+      const newBlockInFlight =
+        newState.requestsInFlight[exampleRequestId].pendingBlocks[0].block;
 
       expect(newBlockInFlight.from).toEqual(oldBlockInFlight.from);
       expect(newBlockInFlight.to).toEqual(oldBlockInFlight.to - deleteRange);
     });
-  })
+  });
 });

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -17,7 +17,7 @@ import { createBoundCommands } from "../commands";
 import { IMatch, IMatcherResponse } from "../interfaces/IMatch";
 import { getBlocksFromDocument } from "../utils/prosemirror";
 import { createDecorationsForMatches, MatchType } from "../utils/decoration";
-import { filterByMatchState, getState, IDefaultFilterState } from "../utils/plugin";
+import { filterByMatchState, getState } from "../utils/plugin";
 import TyperighterAdapter from "../services/adapters/TyperighterAdapter";
 
 const doc = createDoc(p("Example text to check"), p("More text to check"));
@@ -30,8 +30,8 @@ const matchWithReplacement: IMatch = {
 const endpoint = "http://typerighter-service-endpoint.rad";
 const adapter = new TyperighterAdapter(endpoint);
 
-const createPlugin = <TFilterState = unknown>(
-  opts?: IPluginOptions<TFilterState>
+const createPlugin = (
+  opts?: IPluginOptions
 ) => {
   const { plugin, store } = createTyperighterPlugin({
     matches,
@@ -233,7 +233,7 @@ describe("createTyperighterPlugin", () => {
     };
     it("should filter matches with the supplied predicate when the plugin initialises – remove matches", () => {
       const correctMatches = [{ ...createMatch(1), markAsCorrect: true }];
-      const { view } = createPlugin<IDefaultFilterState>({
+      const { view } = createPlugin({
         adapter,
         matches: correctMatches,
         filterOptions
@@ -247,7 +247,7 @@ describe("createTyperighterPlugin", () => {
         { ...createMatch(1), markAsCorrect: true },
         matchWithReplacement
       ];
-      const { view } = createPlugin<IDefaultFilterState>({
+      const { view } = createPlugin({
         adapter,
         matches: correctMatches,
         filterOptions
@@ -264,7 +264,7 @@ describe("createTyperighterPlugin", () => {
         createMatch(2),
         createMatch(3)
       ];
-      const { view, commands } = createPlugin<IDefaultFilterState>({
+      const { view, commands } = createPlugin({
         adapter,
         matches: matchesWithReplacements,
         filterOptions

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -191,7 +191,7 @@ export const createInitialData = (
   return {
     tr,
     state: {
-      filterState: undefined,
+      filterState: [],
       config: {
         debug: false,
         requestMatchesOnDocModified: true,

--- a/src/ts/utils/plugin.ts
+++ b/src/ts/utils/plugin.ts
@@ -6,7 +6,9 @@ import { IMatch } from "..";
 import { IPluginState } from "../state/reducer";
 
 export const pluginKey = new PluginKey("prosemirror-typerighter");
-export const getState = (pluginKey as PluginKey<IPluginState>).getState.bind(pluginKey);
+export const getState = (pluginKey as PluginKey<IPluginState>).getState.bind(
+  pluginKey
+);
 
 export const maybeResetHoverStates = (
   view: EditorView,
@@ -39,15 +41,10 @@ export type IDefaultFilterState = MatchType[];
  * A function that, receiving a filter state, returns a filtered list of matches.
  * Generic to allow plugin consumers to apply their own filter behaviour.
  */
-export type TFilterMatches<
-  TFilterState,
-  TMatch extends IMatch = IMatch
-> = (
-  filterState: TFilterState,
-  matches: TMatch[]
-) => TMatch[];
+export type IFilterMatches = (
+  filterState: MatchType[],
+  matches: IMatch[]
+) => IMatch[];
 
-export const filterByMatchState: TFilterMatches<IDefaultFilterState> = (
-  filterState,
-  matches
-) => matches.filter(match => !filterState.includes(getMatchType(match)));
+export const filterByMatchState: IFilterMatches = (filterState, matches) =>
+  matches.filter(match => !filterState.includes(getMatchType(match)));


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Removes the type parameters from our plugin state.

These were added in anticipation of a changing set of use cases, but add some complexity to the codebase.

Prompted by @rebecca-thompson wondering what they were for,   we don't currently make use of them in consuming code, and so I think it's fair to say the complexity cost now outweighs any future benefit.
 
We can always add 'em back if needed.

## How to test

This is a no-op. The automated tests should work. When running the sandbox, `prosemirror-typerighter` should work as usual.

## How can we measure success?

A codebase that's easier to understand.