### PR TITLE
feat: Add error event to telemetry

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -93,7 +93,7 @@ if (editorElement && sidebarNode) {
   const getScrollOffset = () =>
     editorElement.getBoundingClientRect().height / 2 - menuHeight;
 
-  const commands = createBoundCommands(view);
+  const commands = createBoundCommands(view, typerighterTelemetryAdapter);
 
   createSidebarView({
     store,

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -238,8 +238,10 @@ export const applyMatcherResponseCommand = (
  * to be resent on the next request.
  */
 export const applyRequestErrorCommand = (
-  matchRequestError: TMatchRequestErrorWithDefault
+  matchRequestError: TMatchRequestErrorWithDefault,
+  telemetryAdapter?: TyperighterTelemetryAdapter
 ): Command => (state, dispatch) => {
+  telemetryAdapter?.error(matchRequestError.message);
   if (dispatch) {
     dispatch(
       state.tr.setMeta(
@@ -430,7 +432,10 @@ export const setTyperighterEnabledCommand = (
 /**
  * Create a palette of prosemirror-typerighter commands bound to the given EditorView.
  */
-export const createBoundCommands = (view: EditorView) => {
+export const createBoundCommands = (
+  view: EditorView,
+  telemetryAdapter?: TyperighterTelemetryAdapter
+) => {
   const bindCommand = <CommandArgs extends any[]>(
     action: (...args: CommandArgs) => Command
   ) => (...args: CommandArgs) => action(...args)(view.state, view.dispatch);
@@ -458,7 +463,11 @@ export const createBoundCommands = (view: EditorView) => {
     stopHighlight: bindCommand(stopHighlightCommand),
     setConfigValue: bindCommand(setConfigValueCommand),
     applyMatcherResponse: bindCommand(applyMatcherResponseCommand),
-    applyRequestError: bindCommand(applyRequestErrorCommand),
+    applyRequestError: (matchRequestError: TMatchRequestErrorWithDefault) =>
+      applyRequestErrorCommand(matchRequestError, telemetryAdapter)(
+        view.state,
+        view.dispatch
+      ),
     applyRequestComplete: bindCommand(applyRequestCompleteCommand),
     setFilterState: bindCommand(setFilterStateCommand),
     setTyperighterEnabled: bindCommand(setTyperighterEnabledCommand)

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -247,7 +247,7 @@ const createTyperighterPlugin = (
       }
     },
     view(view) {
-      const commands = createBoundCommands(view);
+      const commands = createBoundCommands(view, telemetryAdapter);
       matcherService.setCommands(commands);
 
       // Check the document eagerly on editor initialisation if

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -13,7 +13,8 @@ export enum TYPERIGHTER_TELEMETRY_TYPE {
   TYPERIGHTER_CLEAR_DOCUMENT = "TYPERIGHTER_CLEAR_DOCUMENT",
   TYPERIGHTER_OPEN_STATE_CHANGED = "TYPERIGHTER_OPEN_STATE_CHANGED",
   TYPERIGHTER_SIDEBAR_MATCH_CLICK = "TYPERIGHTER_SIDEBAR_MATCH_CLICK",
-  TYPERIGHTER_FILTER_STATE_CHANGED = "TYPERIGHTER_FILTER_STATE_CHANGED"
+  TYPERIGHTER_FILTER_STATE_CHANGED = "TYPERIGHTER_FILTER_STATE_CHANGED",
+  TYPERIGHTER_ERROR = "TYPERIGHTER_ERROR"
 }
 
 export interface ITyperighterTelemetryEvent extends IUserTelemetryEvent {
@@ -94,4 +95,10 @@ export interface IFilterToggleEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_FILTER_STATE_CHANGED;
   value: 0 | 1;
   tags: ITyperighterTelemetryEvent["tags"] & { matchType: MatchType };
+}
+
+export interface IErrorEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_ERROR;
+  value: 1;
+  tags: ITyperighterTelemetryEvent["tags"] & { message: string };
 }

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -2,6 +2,7 @@ import {
   ICheckDocumentEvent,
   ICheckRangeEvent,
   IClearDocumentEvent,
+  IErrorEvent,
   IFilterToggleEvent,
   IMarkAsCorrectEvent,
   IMatchDecorationClickedEvent,
@@ -12,7 +13,10 @@ import {
   ITyperighterTelemetryEvent,
   TYPERIGHTER_TELEMETRY_TYPE
 } from "../interfaces/ITelemetryData";
-import { IUserTelemetryEvent, UserTelemetryEventSender } from "@guardian/user-telemetry-client";
+import {
+  IUserTelemetryEvent,
+  UserTelemetryEventSender
+} from "@guardian/user-telemetry-client";
 import { IMatch } from "..";
 import { MatchType } from "../utils/decoration";
 
@@ -21,12 +25,12 @@ class TyperighterTelemetryAdapter {
     private telemetryService: UserTelemetryEventSender,
     private app: string,
     private stage: string,
-    private tags?: IUserTelemetryEvent["tags"],
+    private tags?: IUserTelemetryEvent["tags"]
   ) {}
 
   // used to update tags that are only known after the telemetry adaptor has been initialised
   public updateTelemetryTags(tags: IUserTelemetryEvent["tags"]) {
-    this.tags = { ...this.tags, ...tags};
+    this.tags = { ...this.tags, ...tags };
   }
 
   public suggestionIsAccepted(
@@ -135,6 +139,13 @@ class TyperighterTelemetryAdapter {
       value: toggledOn ? 1 : 0,
       tags: { matchType }
     } as IFilterToggleEvent);
+  }
+
+  public error(message: string) {
+    this.addEvent({
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_ERROR,
+      tags: { message }
+    } as IErrorEvent);
   }
 
   private addEvent<TEvent extends ITyperighterTelemetryEvent>(

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -69,7 +69,7 @@ class TyperighterAdapter implements IMatcherAdapter {
           return onRequestError({
             requestId,
             blockId: input.id,
-            message: `${response.status}: ${response.statusText}`,
+            message: `${response.url} responded with ${response.status} ${response.statusText}`,
             categoryIds,
             type: "AUTH_ERROR"
           });


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Adds an error event to the telemetry adapter, and triggers it when there is an error fetching matches. Also adds the URL called to the error message.

## How to test

In the sandbox, trigger an error fetching, perhaps by expiring a cookie or disabling your network connection in your browser developer tools. After a short delay, you should see a network call go out to the event service. It should contain an event that looks a bit like:


```json
[
  {
    "type": "TYPERIGHTER_ERROR",
    "app": "prosemirror-typerighter",
    "stage": "DEV",
    "tags": {
      "message": "https://checker.typerighter.code.dev-gutools.co.uk/checkStream responded with 401"
    },
    "eventTime": "2022-11-01T08:47:19.195Z"
  }
]
```

## How can we measure success?

Better visibility for developers when prosemirror-typerighter has trouble talking to the Typerighter server.
