### PR TITLE
fix: Add spellcheck=false to match decorations

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
     </div>
     <div class="App__body">
       <div class="Editor__container">
-        <div id="editor" class="Editor" spellcheck="false"></div>
+        <div id="editor" class="Editor"></div>
         <div id="content" class="hide">
           <p><strong>I</strong>n December, I did my last day on call. My last ever out-of-hours session in general
             practice. In a 13-hour shift on Boxing Day, I did a lot of home visits, during which I offered advice and

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -66,7 +66,7 @@ const {
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
   requestMatchesOnDocModified: true,
   adapter: new TyperighterChunkedAdapter(
-    "https://checker.typerighter.local.dev-gutools.co.uk"
+    "https://checker.typerighter.code.dev-gutools.co.uk"
   ),
   telemetryAdapter: typerighterTelemetryAdapter,
   typerighterEnabled: true

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -127,7 +127,8 @@ export const createDecorationsForMatch = (
       match.to,
       {
         class: className,
-        [DECORATION_ATTRIBUTE_ID]: match.matchId
+        [DECORATION_ATTRIBUTE_ID]: match.matchId,
+        spellcheck: "false"
       },
       spec
     )


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Disable browser spellchecking in matched text.

|Before|After|
|--|--|
|<img width="373" alt="Screenshot 2022-11-07 at 09 31 56" src="https://user-images.githubusercontent.com/7767575/200277941-e74c39ba-46b1-4b84-862f-fba710cb43be.png">|<img width="373" alt="Screenshot 2022-11-07 at 09 32 30" src="https://user-images.githubusercontent.com/7767575/200277950-873184d7-2a66-4d65-bb7b-a16254d9b6a3.png">|


## How to test

Running locally, and making sure your browser's spellcheck is on, introduce some words to the sandbox that result in a hit from the spellcheck and Typerighter simultaneously ('Keir Starmer' does the trick for the basic spellcheck in Chrome.) They should match the result above.