### PR TITLE
feat: Add double border to AMEND match tooltips and sidebar

### DIFF
--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -83,7 +83,7 @@ const matchOverlay = ({
     // If there's a gap, the tooltip library detects a `mouseleave` event
     // and closes the tooltip prematurely. We account for this with
     // padding on the tooltip container – see the styling for MatchWidget.
-    const yOffset = -3;
+    const yOffset = -4;
     const isTop = placement.indexOf("top") >= 0;
     const isBottom = placement.indexOf("bottom") >= 0
     if (referenceElement && currentRectIndex !== undefined && (isTop || isBottom)) {

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -69,7 +69,7 @@ export const getSidebarMatchStyles = (
       `;
     case MatchType.AMEND:
       return css`
-        border-left: 2px solid ${color};
+        border-left: 4px double ${color};
       `;
   }
 };

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -279,7 +279,7 @@ export const createGlobalDecorationStyleTag = (
   const styleContent = `
     .${DecorationClassMap.AMEND} {
       background-color: ${hasReplacementColours.backgroundColour};
-      border-bottom: 2px solid ${hasReplacementColours.borderColour};
+      border-bottom: 4px double ${hasReplacementColours.borderColour};
     }
 
     .${DecorationClassMap.AMEND}.MatchDecoration--is-selected {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Adds a double border AMEND match tooltips and sidebar matches.

Here's an example of what that looks like in Composer (click an image for detail):

|Before|After|
|--|--|
|<img width="632" alt="Screenshot 2022-11-30 at 15 29 01" src="https://user-images.githubusercontent.com/7767575/204839467-e70c781c-816c-4520-ba54-5a7df3c820c4.png">|<img width="632" alt="Screenshot 2022-11-30 at 15 29 29" src="https://user-images.githubusercontent.com/7767575/204839488-724abdd4-3a63-4bbc-8246-6c5c9a4dc374.png">|


## How to test

Running locally or in a consuming app, take a look at some red matches (the sentence, `The style guide at The Guardian.` will give you a red match.) Do they look OK in the document content and the sidebar?