### PR TITLE
feat: Add additional exports to library so that Composer can use own sidebar

### DIFF
--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,4 +1,6 @@
 import type { IMatch, ICategory, IBlock, ISuggestion } from './interfaces/IMatch'
+import type { IPluginState } from './state/reducer';
+import type { IMatchTypeToColourMap } from './utils/decoration';
 import Store, { STORE_EVENT_NEW_STATE } from './state/store';
 import createTyperighterPlugin from "./createTyperighterPlugin";
 import MatcherService from "./services/MatcherService";
@@ -13,9 +15,8 @@ import { createOverlayView } from "./components/createOverlayView";
 import { filterByMatchState, getState } from './utils/plugin';
 import '../css/index.scss';
 import { getSquiggleAsUri } from './utils/squiggle';
-import * as decoration from  './utils/decoration'
+import { MatchType, getMatchType, getColourForMatch, getColourForMatchType, getMatchOffset } from  './utils/decoration'
 import TelemetryContext from './contexts/TelemetryContext';
-import { IPluginState } from './state/reducer';
 import { findAncestor, getHtmlFromMarkdown } from './utils/dom';
 
 export {
@@ -44,6 +45,11 @@ export {
   getSquiggleAsUri,
   findAncestor,
   getHtmlFromMarkdown,
-  decoration,
+  MatchType, 
+  IMatchTypeToColourMap, 
+  getMatchType, 
+  getColourForMatch, 
+  getColourForMatchType, 
+  getMatchOffset,
   TelemetryContext
 };

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,5 +1,5 @@
-import type { IMatch, IBlock } from './interfaces/IMatch'
-import Store from './state/store';
+import type { IMatch, ICategory, IBlock, ISuggestion } from './interfaces/IMatch'
+import Store, { STORE_EVENT_NEW_STATE } from './state/store';
 import createTyperighterPlugin from "./createTyperighterPlugin";
 import MatcherService from "./services/MatcherService";
 import { UserTelemetryEventSender, IUserTelemetryEvent} from "@guardian/user-telemetry-client";
@@ -9,10 +9,14 @@ import TyperighterChunkedAdapter from "./services/adapters/TyperighterChunkedAda
 import { commands, createBoundCommands } from "./commands";
 import * as selectors from "./state/selectors";
 import { getBlocksFromDocument } from './utils/prosemirror';
-import { createSidebarView } from "./components/createSidebarView";
 import { createOverlayView } from "./components/createOverlayView";
 import { filterByMatchState, getState } from './utils/plugin';
 import '../css/index.scss';
+import { getSquiggleAsUri } from './utils/squiggle';
+import * as decoration from  './utils/decoration'
+import TelemetryContext from './contexts/TelemetryContext';
+import { IPluginState } from './state/reducer';
+import { findAncestor, getHtmlFromMarkdown } from './utils/dom';
 
 export {
   MatcherService,
@@ -24,7 +28,6 @@ export {
   convertTyperighterResponse,
   createBoundCommands,
   commands,
-  createSidebarView,
   createOverlayView,
   selectors,
   getState,
@@ -32,6 +35,15 @@ export {
   filterByMatchState,
   IMatch,
   IBlock,
+  ICategory,
+  ISuggestion,
   IUserTelemetryEvent,
-  Store
+  IPluginState,
+  Store,
+  STORE_EVENT_NEW_STATE,
+  getSquiggleAsUri,
+  findAncestor,
+  getHtmlFromMarkdown,
+  decoration,
+  TelemetryContext
 };


### PR DESCRIPTION
## What does this change?
Composer will now have it's own copy of the Typerighter sidebar so that UI changes can be iterated upon more quickly. 

This adds extra exports to make that possible.

## How to test
You don't need to do much other than make sure that this repo can build, following the instructions in the readme.
