### PR TITLE
fix: Fix continuous deployment

### DIFF
--- a/.github/workflows/node-js.yml
+++ b/.github/workflows/node-js.yml
@@ -16,6 +16,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+      
     strategy:
       matrix:
         node-version: [18.15.0]


### PR DESCRIPTION
Fixes CD by adding now-required permissions.

As seen in https://github.com/guardian/cdk/pull/1874