### PR TITLE
feat: Trivial readme change to trigger release

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ The plugin must be pointed to the address of a running Typerighter service to su
 
 ## Testing locally in applications that use `prosemirror-typerighter`
 
-We've found yalc useful in testing local changes to prosemirror-typerighter in applications that use it.
+We've found `yalc` useful in testing local changes to prosemirror-typerighter in applications that use it.
 
 Setup: 
 


### PR DESCRIPTION
This PR makes a trivial readme change to trigger a release after some new permissions problems prevented the last release. 

(Re-running[ the action](https://github.com/guardian/prosemirror-typerighter/actions/runs/5948928873) doesn't help because "The local branch main is behind the remote one, therefore a new version won't be published.".)