### PR TITLE
feat!: Pass categories through to backend

### DIFF
--- a/src/ts/services/adapters/TyperighterChunkedAdapter.ts
+++ b/src/ts/services/adapters/TyperighterChunkedAdapter.ts
@@ -37,7 +37,8 @@ class TyperighterChunkedAdapter extends TyperighterAdapter
       }),
       body: JSON.stringify({
         requestId,
-        blocks
+        blocks,
+        categoryIds
       })
     });
 

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -41,10 +41,11 @@ export type ActionRequestMatchesForDirtyRanges = ReturnType<
 
 export const requestMatchesForDocument = (
   requestId: string,
-  categoryIds: string[]
+  categoryIds: string[],
+  excludeCategoryIds: string[]
 ) => ({
   type: REQUEST_FOR_DOCUMENT,
-  payload: { requestId, categoryIds }
+  payload: { requestId, categoryIds, excludeCategoryIds }
 });
 export type ActionRequestMatchesForDocument = ReturnType<
   typeof requestMatchesForDocument

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -42,10 +42,9 @@ export type ActionRequestMatchesForDirtyRanges = ReturnType<
 export const requestMatchesForDocument = (
   requestId: string,
   categoryIds: string[],
-  excludeCategoryIds: string[]
 ) => ({
   type: REQUEST_FOR_DOCUMENT,
-  payload: { requestId, categoryIds, excludeCategoryIds }
+  payload: { requestId, categoryIds }
 });
 export type ActionRequestMatchesForDocument = ReturnType<
   typeof requestMatchesForDocument


### PR DESCRIPTION
## What does this change?
This makes sure that categories passed from Composer are included in the match request to the Typerighter Checker service, where they can be used to filter matches,

## How to test
Test locally with [this Composer branch](https://github.com/guardian/flexible-content/pull/4391) via `yalc` (I can pair to help with this, it's a bit fiddly) - also run this branch of [Typerighter](https://github.com/guardian/typerighter/pull/413) Checker locally.

Good things to check:
- Does Typerighter work as expected?
- If no categories are provided, are all matches returned, regardless of category? (This is the intended behaviour).
- If a category is provided, are only matches with that category returned? 