### PR TITLE
fix: Show multiple suggestions for dictionary rules

### DIFF
--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -47,8 +47,8 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       ruleId
     };
 
-    // render suggestions if they exist (the case for dictionary rules), otherwise render the replacement (as sometimes exists for classic Typerighter rules)
-    const suggestionsToRender = suggestions && suggestions.length > 0 ? suggestions : replacement ? [replacement] : [];
+    // render up to 6 suggestions if they exist (e.g. dictionary rules), otherwise render the replacement (as sometimes exists for classic Typerighter rules)
+    const suggestionsToRender = suggestions && suggestions.length > 0 ? suggestions.slice(0, 6) : replacement ? [replacement] : [];
     const suggestionContent = (
       <div className="MatchWidget__suggestion-list">
         {suggestionsToRender && applySuggestions && !markAsCorrect && (

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -47,7 +47,8 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       ruleId
     };
 
-    const suggestionsToRender = replacement ? [replacement] : suggestions || [];
+    // render suggestions if they exist (the case for dictionary rules), otherwise render the replacement (as sometimes exists for classic Typerighter rules)
+    const suggestionsToRender = suggestions && suggestions.length > 0 ? suggestions : replacement ? [replacement] : [];
     const suggestionContent = (
       <div className="MatchWidget__suggestion-list">
         {suggestionsToRender && applySuggestions && !markAsCorrect && (


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR makes sure that more than just the first suggested replacement word is shown for Collins dictionary rules. The first suggestion will still appear when users hover over an underlined word. When there is more than one suggestion, a 'See more suggestions' button will appear, which users can click to see additional suggested words.

Before this, only the first dictionary rule suggestion was being shown.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

This can be tested locally using [`yalc`](https://github.com/guardian/prosemirror-typerighter#testing-locally-in-applications-that-use-prosemirror-typerighter) to locally publish this branch's version of prosemirror-typerighter and to run this package in Composer.

Steps to test:
- create an article
- add a Collins dictionary misspelled word e.g. 'primery' - after running Typerighter you should see a single suggested replacement word with a 'See more suggestions' button underneath - clicking this should reveal alternative replacement words
- add a Style Guide misspelled word e.g. 'learnt' - after running Typerighter you should still see a suggested replacement word

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

### Before
<img width="342" alt="Screenshot 2023-09-08 at 16 10 58" src="https://github.com/guardian/prosemirror-typerighter/assets/7883129/fec4d74b-c7a8-4077-9d32-7b668ab614fe">

### After
<img width="346" alt="Screenshot 2023-09-08 at 16 07 08" src="https://github.com/guardian/prosemirror-typerighter/assets/7883129/1b517559-4842-46f5-b055-b4190c0088b1">

<img width="346" alt="Screenshot 2023-09-08 at 16 07 19" src="https://github.com/guardian/prosemirror-typerighter/assets/7883129/c1a4e5db-1997-44b7-90d8-3c1d5e462d74">


