### PR TITLE
ci: Fix snyk config

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,3 @@
-# This action is just a test
 name: Snyk
 
 on: 
@@ -10,7 +9,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
-      ORG: guardian-test
+      ORG: guardian
       SKIP_NODE: false
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

Update the snyk org so it's reporting to the right place (this will report to the "test" org rather than ed-tools. See: https://github.com/guardian/prosemirror-typerighter/pull/223/files#diff-279a5a5997dd6e7a67267df6229cd45adb7acdb39c8ebab573f98e524deb0fd5R13

## How to test

- [x] CI passes
- [ ] This project is visible in the Snyk UI in the ed-tools (guardian) org.

## How can we measure success?

Proper vulnerability monitoring of this repository.