### PR TITLE
fix: Do not throw an error when a command is dispatched and the document has been destroyed

### DIFF
--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -436,23 +436,31 @@ export const createBoundCommands = (
   view: EditorView,
   telemetryAdapter?: TyperighterTelemetryAdapter
 ) => {
+  const dispatch = (tr: Transaction) => {
+    if (view.isDestroyed) {
+      return;
+    }
+    return view.dispatch(tr);
+  }
+
   const bindCommand = <CommandArgs extends any[]>(
     action: (...args: CommandArgs) => Command
-  ) => (...args: CommandArgs) => action(...args)(view.state, view.dispatch);
+  ) => (...args: CommandArgs) => action(...args)(view.state, dispatch);
+
   return {
     ignoreMatch: (id: string) =>
-      ignoreMatchCommand(id)(getState)(view.state, view.dispatch),
+      ignoreMatchCommand(id)(getState)(view.state, dispatch),
     clearMatches: () =>
-      clearMatchesCommand()(getState)(view.state, view.dispatch),
+      clearMatchesCommand()(getState)(view.state, dispatch),
     applySuggestions: (suggestionOpts: ApplySuggestionOptions) =>
       applySuggestionsCommand(suggestionOpts, getState)(
         view.state,
-        view.dispatch
+        dispatch
       ),
     selectMatch: (blockId: string) =>
-      selectMatchCommand(blockId, getState)(view.state, view.dispatch),
+      selectMatchCommand(blockId, getState)(view.state, dispatch),
     applyAutoFixableSuggestions: () =>
-      applyAutoFixableSuggestionsCommand(getState)(view.state, view.dispatch),
+      applyAutoFixableSuggestionsCommand(getState)(view.state, dispatch),
     requestMatchesForDocument: bindCommand(requestMatchesForDocumentCommand),
     requestMatchesForDirtyRanges: bindCommand(
       requestMatchesForDirtyRangesCommand
@@ -466,7 +474,7 @@ export const createBoundCommands = (
     applyRequestError: (matchRequestError: TMatchRequestErrorWithDefault) =>
       applyRequestErrorCommand(matchRequestError, telemetryAdapter)(
         view.state,
-        view.dispatch
+        dispatch
       ),
     applyRequestComplete: bindCommand(applyRequestCompleteCommand),
     setFilterState: bindCommand(setFilterStateCommand),

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -22,6 +22,14 @@ const applySuggestionToDoc = (
 };
 
 describe("Commands", () => {
+  describe("General behaviour", () => {
+    it("should not attempt to apply new states when the document has been destroyed", () => {
+      const { view, commands } = createEditor("<p>Example document");
+      view.destroy();
+      expect(commands.clearMatches).not.toThrow();
+    });
+  })
+
   describe("applySuggestionsCommand", () => {
     it("should apply a suggestion to the document", () => {
       const editorElement = applySuggestionToDoc(
@@ -121,8 +129,7 @@ describe("Commands", () => {
       expect(editorElement.innerHTML).toBe("An a<em>mp</em>le sentence");
     });
   });
-  describe("setTyperighterEnabled", () => { 
-
+  describe("setTyperighterEnabled", () => {
     const createExampleEditor = (
       before: string,
       from: number,
@@ -132,7 +139,7 @@ describe("Commands", () => {
         { text: "N/A", type: "TEXT_SUGGESTION" }
       ]);
       const { editorElement, commands } = createEditor(before, [match]);
-    
+
       return { editorElement, commands };
     };
 


### PR DESCRIPTION
## What does this change?

Fixes a bug where Prosemirror will throw an error if commands are dispatched after the editor is destroyed.

This PR solves the immediate problem, but it'd be nice to cancel the relevant fetches when the document is destroyed to avoid redundant work.

## How to test

The automated test for this case should pass. We should also see the related [Sentry errors](https://the-guardian.sentry.io/issues/3686433779/?project=26737&query=&referrer=project-issue-stream) drop off once Composer uses this release.