### PR TITLE
feat: Add `groupKey` to `IMatch`

### DIFF
--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -69,6 +69,7 @@ export interface IMatch<TSuggestion = ISuggestion> {
   matchContext: string;
   precedingText: string;
   subsequentText: string;
+  groupKey: string;
 }
 
 export interface IBlockResult {

--- a/src/ts/services/adapters/interfaces/ITyperighter.ts
+++ b/src/ts/services/adapters/interfaces/ITyperighter.ts
@@ -28,6 +28,7 @@ export interface ITypeRighterMatch {
   matchContext: string;
   precedingText: string;
   subsequentText: string;
+  groupKey: string;
 }
 
 export interface ITypeRighterReplacement {

--- a/src/ts/services/test/MatcherService.spec.ts
+++ b/src/ts/services/test/MatcherService.spec.ts
@@ -46,7 +46,8 @@ const createResponse = (
     markAsCorrect: false,
     matchContext: "whatever",
     precedingText: "whatever",
-    subsequentText: ""
+    subsequentText: "",
+    groupKey: "group-key"
   }))
 });
 

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -600,7 +600,8 @@ describe("Action handlers", () => {
         },
         matchContext: "some more text",
         precedingText: "some more text",
-        subsequentText: ""
+        subsequentText: "",
+        groupKey: "group-key"
       };
       const localState = {
         ...state,
@@ -638,7 +639,8 @@ describe("Action handlers", () => {
         },
         matchContext: "bigger block of text",
         precedingText: "bigger block of text",
-        subsequentText: ""
+        subsequentText: "",
+        groupKey: "group-key"
       };
 
       const localState = {
@@ -683,7 +685,8 @@ describe("Action handlers", () => {
           markAsCorrect: true,
           matchContext: "bigger block of text",
           precedingText: "bigger block of text",
-          subsequentText: ""
+          subsequentText: "",
+          groupKey: "group-key"
         }
       ];
       const stateWithCurrentMatchesAndDecorations = {
@@ -732,7 +735,8 @@ describe("Action handlers", () => {
             id: "exampleId",
             matchContext: "bigger block of text",
             precedingText: "bigger block of text",
-            subsequentText: ""
+            subsequentText: "",
+            groupKey: "group-key"
           }
         ]
       };

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -151,7 +151,8 @@ describe("selectors", () => {
           matchedText: "hai",
           matchContext: "oh [[hai]]",
           precedingText: "oh ",
-          subsequentText: ""
+          subsequentText: "",
+          groupKey: "group-key"
         }
       ];
       expect(
@@ -190,7 +191,8 @@ describe("selectors", () => {
           matchedText: "hai",
           matchContext: "Oh [[hai]]",
           precedingText: "oh ",
-          subsequentText: ""
+          subsequentText: "",
+          groupKey: "group-key"
         }
       ];
       expect(

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -147,7 +147,8 @@ describe("createTyperighterPlugin", () => {
           },
           matchContext: "bigger block of text",
           precedingText: "bigger block of text",
-          subsequentText: ""
+          subsequentText: "",
+          groupKey: "group-key"
         }
       ],
       requestId: "reqId"

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -106,7 +106,8 @@ export const createMatcherResponse = (
         suggestions,
         matchContext: "here is a [[block text]] match",
         precedingText: "here is a ",
-        subsequentText: " match"
+        subsequentText: " match",
+        groupKey: "group-key"
       };
 
       return {
@@ -146,7 +147,8 @@ export const createMatch = (
   suggestions,
   matchContext: "here is a [[block text]] match",
   precedingText: "here is a ",
-  subsequentText: " match"
+  subsequentText: " match",
+  groupKey: "group-key"
 });
 
 export const exampleCategoryIds = ["example-category"];

--- a/src/ts/utils/test/match.spec.ts
+++ b/src/ts/utils/test/match.spec.ts
@@ -13,7 +13,8 @@ describe("Match helpers", () => {
     matchedText: "placeholder text",
     message: "placeholder message",
     matchContext: "[placeholder text]",
-    matcherType: "regex"
+    matcherType: "regex",
+    groupKey: "group-key"
   });
 
   describe("mapMatchThroughSkippedRanges", () => {


### PR DESCRIPTION
## What does this change?

Makes `groupKey` available to the typerighter client. 

This is the glue needed between [this PR](https://github.com/guardian/typerighter/pull/436) (where `groupKey` is introduced) and [this PR](https://github.com/guardian/flexible-content/pull/4396) (where `groupKey` is consumed by the client).

Once this change goes in, we'll need to bump the version of `prosemirror-typerighter` in https://github.com/guardian/flexible-content/pull/4396.

## How to test

Difficult to test in isolation beyond making sure the unit tests still pass.
