### PR TITLE
feat: Add match feedback inline

### DIFF
--- a/pages/index.ts
+++ b/pages/index.ts
@@ -113,7 +113,6 @@ if (editorElement && sidebarNode) {
     store,
     commands,
     overlayNode,
-    feedbackHref: "http://a-form-for-example.com",
     onMarkCorrect: match => console.info("Match ignored!", match),
     telemetryAdapter: typerighterTelemetryAdapter,
   });

--- a/src/css/Feedback.scss
+++ b/src/css/Feedback.scss
@@ -1,0 +1,68 @@
+
+
+
+.Feedback__container {
+  margin-top: $gutter-width;
+  width: 100%;
+  font-size: $font-size-small;
+  a {
+    color: $match-gray;
+  }
+}
+
+.Feedback__responses {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: calc($gutter-width);
+  margin-top: calc($gutter-width / 2);
+}
+
+.Feedback__response {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: none;
+  outline: none;
+  padding: $gutter-width;
+  gap: calc($gutter-width / 2);
+  border-radius: $base-border-radius;
+  font-weight: normal;
+  font-size: $font-size-base;
+  background-color: $match-feedback-background-color;
+  cursor: pointer;
+  &:hover {
+    background-color: darken($match-feedback-background-color, 5%);
+  }
+  svg {
+    color: darken($match-feedback-background-color, 40%);
+  }
+}
+
+.Feedback__feedback-detail {
+  width: 100%;
+  margin-top: calc($gutter-width / 2);
+  padding:  calc($gutter-width / 2);
+  border-color: $match-gray;
+  border-radius:  $base-border-radius;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.Feedback__response-send {
+  margin-top: calc($gutter-width / 2);
+  font-weight: bold;
+  background-color: $match-feedback-send-background-color;
+  color: white;
+  svg {
+    color: white;
+  }
+  &:hover {
+    background-color: $composer-primary-hover;
+  }
+}
+
+.Feedback__feedback-sent {
+  font-size: $font-size-base;
+  min-height: 100px;
+}

--- a/src/css/Feedback.scss
+++ b/src/css/Feedback.scss
@@ -44,6 +44,7 @@
   border-radius:  $base-border-radius;
   font-family: inherit;
   resize: vertical;
+  min-height: 110px;
 }
 
 .Feedback__response-send {

--- a/src/css/Feedback.scss
+++ b/src/css/Feedback.scss
@@ -1,6 +1,3 @@
-
-
-
 .Feedback__container {
   margin-top: $gutter-width;
   width: 100%;

--- a/src/css/MatchWidget.scss
+++ b/src/css/MatchWidget.scss
@@ -145,10 +145,3 @@
 .SidebarMatch__suggestion-list + .MatchWidget__ignore-match {
   margin-top: 3px;
 }
-
-.MatchWidget__feedbackLink {
-  font-size: $font-size-small;
-  a {
-    color: $match-gray;
-  }
-}

--- a/src/css/MatchWidget.scss
+++ b/src/css/MatchWidget.scss
@@ -14,6 +14,9 @@
   transform: translate3d(0, -3px, 0);
   z-index: 100;
   overflow: hidden;
+  * {
+    box-sizing: border-box;
+  }
 }
 
 .MatchWidget__container {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,4 +1,7 @@
 // Variables
+
+$composer-primary: #00ADEE;
+$composer-primary-hover: #008fc5;
 $gutter-width: 8px;
 $sidebar-border-color: #ddd;
 $text-color-secondary: #5f5e5e;
@@ -12,6 +15,9 @@ $match-suggestion-background-color: #228816;
 $match-suggestion-background-color-hover: #1e7014;
 $match-suggestion-color: #fff;
 $match-suggestion-color-hover: #fff;
+$match-feedback-background-color: #e9e9e9;
+$match-feedback-send-background-color: $composer-primary;
+$match-feedback-send-background-color-hover: $composer-primary-hover;
 $icon-fill-color-default: #999999;
 $font-size-base: 15px;
 $font-size-large: 1.1em;
@@ -43,6 +49,18 @@ $sidebar-highlight-color:#01adee;
   }
 }
 
+// Animations;
+
+.animation__pop-in {
+  animation-duration: 0.2s;
+  animation-name: animation__pop-in;
+}
+
+@keyframes animation__pop-in {
+  0% { opacity: 0; transform: translate3d(0, -10px, 0); }
+  100% { opacity: 1; transform: translate3d(0, 0, 0);  }
+}
+
 // Imports
 @import "./Controls.scss";
 @import "./Sidebar.scss";
@@ -51,6 +69,7 @@ $sidebar-highlight-color:#01adee;
 @import "./SuggestionList.scss";
 @import "./MatchWidget.scss";
 @import "./MatchDebug.scss";
+@import "./Feedback.scss";
 
 // Elements
 

--- a/src/ts/components/Feedback.tsx
+++ b/src/ts/components/Feedback.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from "react";
-import { MappedMatch } from "../interfaces/IMatch";
+import { IMatch } from "../interfaces/IMatch";
 import TelemetryContext from "../contexts/TelemetryContext";
 import { MoreHoriz, Announcement, MailOutline } from "@mui/icons-material";
 
@@ -19,7 +19,7 @@ export const Feedback = ({
   match,
   documentUrl
 }: {
-  match: MappedMatch;
+  match: IMatch;
   documentUrl: string;
 }) => {
   const [formState, setFormState] = useState<keyof typeof FeedbackFormStates>(

--- a/src/ts/components/Feedback.tsx
+++ b/src/ts/components/Feedback.tsx
@@ -5,6 +5,7 @@ import { MoreHoriz, Announcement, MailOutline } from "@mui/icons-material";
 
 const responses = [
   "This doesn't match the style guide.",
+  "This has been flagged incorrectly.",
   "This is a valid word."
 ];
 

--- a/src/ts/components/Feedback.tsx
+++ b/src/ts/components/Feedback.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useContext, useState } from "react";
+import { MappedMatch } from "../interfaces/IMatch";
+import TelemetryContext from "../contexts/TelemetryContext";
+import { MoreHoriz, Announcement, MailOutline } from "@mui/icons-material";
+
+const responses = [
+  "This doesn't match the style guide.",
+  "This is a valid word."
+];
+
+const FeedbackFormStates = {
+  CLOSED: "CLOSED",
+  SELECT_RESPONSE: "SELECT_RESPONSE",
+  ADD_DETAIL: "ADD_DETAIL",
+  FEEDBACK_SENT: "FEEDBACK_SENT"
+} as const;
+
+export const Feedback = ({
+  match,
+  documentUrl
+}: {
+  match: MappedMatch;
+  documentUrl: string;
+}) => {
+  const [formState, setFormState] = useState<keyof typeof FeedbackFormStates>(
+    FeedbackFormStates.CLOSED
+  );
+  const [inputValue, setInputValue] = useState<string>("");
+  const { telemetryAdapter } = useContext(TelemetryContext);
+  const sendFeedback = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      e.preventDefault();
+      telemetryAdapter?.feedbackReceived(match, inputValue, documentUrl);
+      setFormState(FeedbackFormStates.FEEDBACK_SENT);
+    },
+    [setFormState, match, inputValue, documentUrl]
+  );
+
+  const getFormPanelFromState = useCallback(
+    (state: keyof typeof FeedbackFormStates) => {
+      switch (state) {
+        case FeedbackFormStates.CLOSED: {
+          return (
+            <a
+              href="#"
+              onClick={e => {
+                e.preventDefault();
+                setFormState(FeedbackFormStates.SELECT_RESPONSE);
+              }}
+            >
+              Issue with this result? Tell us!
+            </a>
+          );
+        }
+        case FeedbackFormStates.SELECT_RESPONSE: {
+          return (
+            <div className="Feedback__responses animation__pop-in">
+              {responses.map(response => (
+                <button
+                  className="Feedback__response"
+                  key={response}
+                  onClick={() => {
+                    setInputValue(response);
+                    setFormState(FeedbackFormStates.ADD_DETAIL);
+                  }}
+                >
+                  <Announcement fontSize="small" /> {response}
+                </button>
+              ))}
+              <button
+                className="Feedback__response"
+                onClick={() => {
+                  setFormState(FeedbackFormStates.ADD_DETAIL);
+                }}
+              >
+                <MoreHoriz fontSize="small" /> Other
+              </button>
+            </div>
+          );
+        }
+        case FeedbackFormStates.ADD_DETAIL: {
+          return (
+            <div className="Feedback__add-detail animation__pop-in">
+              <div>
+                <label htmlFor="Feedback__feedback-detail">
+                  Add additional information here
+                </label>
+                <textarea
+                  id="Feedback__feedback-detail"
+                  className="Feedback__feedback-detail"
+                  value={inputValue}
+                  onChange={e => setInputValue(e.target.value)}
+                />
+              </div>
+              <div
+                className="Feedback__response Feedback__response-send"
+                onClick={sendFeedback}
+              >
+                <MailOutline fontSize="small" />
+                Send feedback
+              </div>
+            </div>
+          );
+        }
+        case FeedbackFormStates.FEEDBACK_SENT: {
+          return <div className="Feedback__feedback-sent">Thanks for your feedback – we really appreciate it.</div>
+        }
+      }
+    },
+    [inputValue, setInputValue, formState, sendFeedback]
+  );
+
+  return (
+    <div className="Feedback__container">
+      {getFormPanelFromState(formState)}
+    </div>
+  );
+};

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -6,6 +6,7 @@ import SuggestionList from "./SuggestionList";
 import { getColourForMatch, IMatchTypeToColourMap } from "../utils/decoration";
 import { Check } from "@mui/icons-material";
 import { getHtmlFromMarkdown } from "../utils/dom";
+import { Feedback } from "./Feedback";
 
 interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
@@ -25,30 +26,21 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       onMarkCorrect
     }: IMatchProps<TMatch> = this.props;
     const {
-      matchId,
       category,
       message,
       suggestions,
       replacement,
-      markAsCorrect,
-      matchContext,
-      ruleId
+      markAsCorrect
     } = match;
     const url = document.URL;
-    const feedbackInfo = {
-      matchId,
-      category,
-      message,
-      suggestions,
-      replacement,
-      url,
-      matchContext,
-      markAsCorrect,
-      ruleId
-    };
 
     // render up to 6 suggestions if they exist (e.g. dictionary rules), otherwise render the replacement (as sometimes exists for classic Typerighter rules)
-    const suggestionsToRender = suggestions && suggestions.length > 0 ? suggestions.slice(0, 6) : replacement ? [replacement] : [];
+    const suggestionsToRender =
+      suggestions && suggestions.length > 0
+        ? suggestions.slice(0, 6)
+        : replacement
+        ? [replacement]
+        : [];
     const suggestionContent = (
       <div className="MatchWidget__suggestion-list">
         {suggestionsToRender && applySuggestions && !markAsCorrect && (
@@ -93,29 +85,12 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
             dangerouslySetInnerHTML={{ __html: getHtmlFromMarkdown(message) }}
           ></div>
           <div className="MatchWidget__footer">
-            {this.props.feedbackHref && (
-              <div className="MatchWidget__feedbackLink">
-                <a
-                  target="_blank"
-                  href={this.getFeedbackLink(
-                    this.props.feedbackHref!,
-                    feedbackInfo
-                  )}
-                >
-                  Issue with this result? Tell us!
-                </a>
-              </div>
-            )}
+            <Feedback documentUrl={url} match={match} />
           </div>
         </div>
       </div>
     );
   }
-
-  private getFeedbackLink = (feedbackHref: string, feedbackInfo: any) => {
-    const data = encodeURIComponent(JSON.stringify(feedbackInfo, undefined, 2));
-    return feedbackHref + data;
-  };
 }
 
 export default Match;

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -12,7 +12,6 @@ interface IMatchProps<TMatch extends IMatch> {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
   match: TMatch;
   matchColours: IMatchTypeToColourMap;
-  feedbackHref?: string;
   onMarkCorrect?: (match: IMatch) => void;
 }
 

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -15,7 +15,6 @@ interface IProps {
   store: Store;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   stopHover: () => void;
-  feedbackHref?: string;
   onMarkCorrect?: (match: IMatch) => void;
 }
 
@@ -24,7 +23,6 @@ interface IProps {
  */
 const matchOverlay = ({
   applySuggestions,
-  feedbackHref,
   onMarkCorrect,
   stopHover,
   store
@@ -136,7 +134,6 @@ const matchOverlay = ({
         match={maybeMatch}
         matchColours={pluginState.config.matchColours}
         applySuggestions={applySuggestions}
-        feedbackHref={feedbackHref}
         onMarkCorrect={onMarkCorrect}
       />
     </div>

--- a/src/ts/components/createOverlayView.tsx
+++ b/src/ts/components/createOverlayView.tsx
@@ -13,7 +13,6 @@ interface OverlayViewOptions {
   store: Store;
   commands: Commands;
   overlayNode: Element;
-  feedbackHref?: string;
   onMarkCorrect?: (match: IMatch) => void;
   telemetryAdapter?: TyperighterTelemetryAdapter;
 }
@@ -28,7 +27,6 @@ export const createOverlayView = ({
   telemetryAdapter,
   commands,
   overlayNode,
-  feedbackHref,
   onMarkCorrect
 }: OverlayViewOptions) => {
   overlayNode.classList.add("TyperighterPlugin__tooltip-overlay");
@@ -59,7 +57,6 @@ export const createOverlayView = ({
             telemetryAdapter?.matchIsMarkedAsCorrect(match, document.URL);
           })
         }
-        feedbackHref={feedbackHref}
         stopHover={commands.stopHover}
       />
     </TelemetryContext.Provider>,

--- a/src/ts/interfaces/ITelemetryData.ts
+++ b/src/ts/interfaces/ITelemetryData.ts
@@ -14,7 +14,8 @@ export enum TYPERIGHTER_TELEMETRY_TYPE {
   TYPERIGHTER_OPEN_STATE_CHANGED = "TYPERIGHTER_OPEN_STATE_CHANGED",
   TYPERIGHTER_SIDEBAR_MATCH_CLICK = "TYPERIGHTER_SIDEBAR_MATCH_CLICK",
   TYPERIGHTER_FILTER_STATE_CHANGED = "TYPERIGHTER_FILTER_STATE_CHANGED",
-  TYPERIGHTER_ERROR = "TYPERIGHTER_ERROR"
+  TYPERIGHTER_ERROR = "TYPERIGHTER_ERROR",
+  TYPERIGHTER_FEEDBACK_RECEIVED = "TYPERIGHTER_FEEDBACK_RECEIVED"
 }
 
 export interface ITyperighterTelemetryEvent extends IUserTelemetryEvent {
@@ -101,4 +102,11 @@ export interface IErrorEvent extends ITyperighterTelemetryEvent {
   type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_ERROR;
   value: 1;
   tags: ITyperighterTelemetryEvent["tags"] & { message: string };
+}
+
+export interface IFeedbackReceivedEvent extends ITyperighterTelemetryEvent {
+  type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_FEEDBACK_RECEIVED;
+  value: 1;
+  tags: ITyperighterTelemetryEvent["tags"] &
+    IMatchEventTags & { feedbackMessage: string };
 }

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -3,6 +3,7 @@ import {
   ICheckRangeEvent,
   IClearDocumentEvent,
   IErrorEvent,
+  IFeedbackReceivedEvent,
   IFilterToggleEvent,
   IMarkAsCorrectEvent,
   IMatchDecorationClickedEvent,
@@ -139,6 +140,18 @@ class TyperighterTelemetryAdapter {
       value: toggledOn ? 1 : 0,
       tags: { matchType }
     } as IFilterToggleEvent);
+  }
+
+  public feedbackReceived(match: MappedMatch, feedbackMessage: string, documentUrl: string) {
+    this.addEvent({
+      type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_FEEDBACK_RECEIVED,
+      value: 1,
+      tags: {
+        documentUrl,
+        feedbackMessage,
+        ...this.getTelemetryTagsFromMatch(match)
+      }
+    } as IFeedbackReceivedEvent);
   }
 
   public error(message: string) {

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -142,7 +142,7 @@ class TyperighterTelemetryAdapter {
     } as IFilterToggleEvent);
   }
 
-  public feedbackReceived(match: MappedMatch, feedbackMessage: string, documentUrl: string) {
+  public feedbackReceived(match: IMatch, feedbackMessage: string, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_FEEDBACK_RECEIVED,
       value: 1,


### PR DESCRIPTION
## What does this change?

Adds a little form for inline feedback, replacing the Google form in that context. (The Google form remains for general tool feedback in the sidebar, for now.)

![feedback](https://github.com/guardian/prosemirror-typerighter/assets/7767575/551ee405-635a-4b59-9f9c-2d43c1dd9eb9)

## How to test

Have a play. Does the form work as expected? Any styling or messaging we could improve?

## How can we measure success?

More feedback from users, as a result of a streamlined feedback experience.
