### PR TITLE
feat!: Handle multi-range matches for ignored ranges.

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,10 @@
     #sidebar {
       min-height: 0;
     }
+
+    note {
+      background-color: #c6d7ff;
+    }
   </style>
 </head>
 
@@ -92,7 +96,7 @@
       <h1>prosemirror-typerighter</h1>
       <p>This prosemirror plugin provides a scaffold for document validation. It's presented here with an example UI.
       </p>
-      <p>Any text styled as <span style="font-family: monospace">code</span> will be skipped by Typerighter.</p>
+      <p>Any text that is marked as a note will be skipped by Typerighter. To apply a note to a selection, hit F10.</p>
     </div>
     <div class="App__body">
       <div class="Editor__container">

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -61,7 +61,7 @@ const {
     initialFilterState: [] as MatchType[]
   },
   getIgnoredRanges: (node, from, to) =>
-    findMarkPositions(node, from, to, mySchema.marks.code),
+    findMarkPositions(node, from, to, mySchema.marks.strong),
   onMatchDecorationClicked: match =>
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
   requestMatchesOnDocModified: true,

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -60,7 +60,7 @@ const {
     filterMatches: filterByMatchState,
     initialFilterState: [] as MatchType[]
   },
-  getSkippedRanges: (node, from, to) =>
+  getIgnoredRanges: (node, from, to) =>
     findMarkPositions(node, from, to, mySchema.marks.code),
   onMatchDecorationClicked: match =>
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),

--- a/pages/index.ts
+++ b/pages/index.ts
@@ -4,6 +4,7 @@ import { Schema, DOMParser } from "prosemirror-model";
 import { marks, schema } from "prosemirror-schema-basic";
 import { addListNodes } from "prosemirror-schema-list";
 import { history } from "prosemirror-history";
+import { toggleMark } from "prosemirror-commands";
 import { exampleSetup, buildMenuItems } from "prosemirror-example-setup";
 import applyDevTools from "prosemirror-dev-tools";
 import "prosemirror-view/style/prosemirror.css";
@@ -21,10 +22,19 @@ import { MatchType } from "../src/ts/utils/decoration";
 import { filterByMatchState } from "../src/ts/utils/plugin";
 import { findMarkPositions } from "../src/ts/utils/prosemirror";
 import TyperighterChunkedAdapter from "../src/ts/services/adapters/TyperighterChunkedAdapter";
+import { keymap } from "prosemirror-keymap";
+
+const noteMark = {
+  parseDOM: [{ tag: "note" }],
+  toDOM() { return ['note', 0] as [string, number]; }
+}
 
 const mySchema = new Schema({
   nodes: addListNodes(schema.spec.nodes as any, "paragraph block*", "block"),
-  marks
+  marks: {
+    ...marks,
+    note: noteMark
+  }
 });
 
 const contentElement =
@@ -61,7 +71,7 @@ const {
     initialFilterState: [] as MatchType[]
   },
   getIgnoredRanges: (node, from, to) =>
-    findMarkPositions(node, from, to, mySchema.marks.strong),
+    findMarkPositions(node, from, to, mySchema.marks.note),
   onMatchDecorationClicked: match =>
     typerighterTelemetryAdapter.matchDecorationClicked(match, document.URL),
   requestMatchesOnDocModified: true,
@@ -72,6 +82,8 @@ const {
   typerighterEnabled: true
 });
 
+const toggleNoteMark = toggleMark(mySchema.marks.note);
+
 if (editorElement && sidebarNode) {
   const view = new EditorView(editorElement, {
     state: EditorState.create({
@@ -80,7 +92,10 @@ if (editorElement && sidebarNode) {
         ...exampleSetup({
           schema: mySchema,
           history: false,
-          menuContent: buildMenuItems(mySchema).fullMenu
+          menuContent: buildMenuItems(mySchema).fullMenu,
+        }),
+        keymap({
+          "F10": toggleNoteMark,
         }),
         historyPlugin,
         validatorPlugin

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -24,6 +24,7 @@ import {
 } from "./state/reducer";
 import {
   IMatcherResponse,
+  MappedMatch,
   TMatchRequestErrorWithDefault
 } from "./interfaces/IMatch";
 import { EditorView } from "prosemirror-view";
@@ -218,7 +219,7 @@ export const setFilterStateCommand = <TPluginState extends IPluginState>(
  * Apply a successful matcher response to the document.
  */
 export const applyMatcherResponseCommand = (
-  matcherResponse: IMatcherResponse
+  matcherResponse: IMatcherResponse<MappedMatch[]>
 ): Command => (state, dispatch) => {
   if (dispatch) {
     dispatch(

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -24,7 +24,7 @@ import {
 } from "./state/reducer";
 import {
   IMatcherResponse,
-  MappedMatch,
+  Match,
   TMatchRequestErrorWithDefault
 } from "./interfaces/IMatch";
 import { EditorView } from "prosemirror-view";
@@ -220,7 +220,7 @@ export const setFilterStateCommand = <TPluginState extends IPluginState>(
  * Apply a successful matcher response to the document.
  */
 export const applyMatcherResponseCommand = (
-  matcherResponse: IMatcherResponse<MappedMatch[]>
+  matcherResponse: IMatcherResponse<Match[]>
 ): Command => (state, dispatch) => {
   if (dispatch) {
     dispatch(
@@ -340,7 +340,7 @@ export const clearMatchesCommand = () => (_: GetState) => (
 
 const maybeApplySuggestions = (
   suggestionsToApply: Array<{
-    match: MappedMatch,
+    match: Match,
     text: string | undefined;
   }>,
   state: EditorState,

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -386,12 +386,12 @@ const maybeApplySuggestions = (
       const fragmentToApply = text.slice(textCursor, !isLastRange ? textCursor + (mappedTo - mappedFrom) : Infinity);
       textCursor += fragmentToApply.length;
 
-      return getPatchesFromReplacementText(
+      return getPatchesFromReplacementText({
         tr,
-        mappedFrom,
-        mappedTo,
-        fragmentToApply
-      );
+        from: mappedFrom,
+        to: mappedTo,
+        replacement: fragmentToApply
+      });
     });
 
     applyPatchesToTransaction(patches, match.ranges, tr, state.schema)

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -362,13 +362,21 @@ const maybeApplySuggestions = (
     let textCursor = 0;
 
     // Apply the suggestion to the matched range.
+    //
     // If the match is split into multiple ranges, attempts to preserve a reasonable split between
+    // ranges by allocating the suggestion the same number of characters as the original range. Extra
+    // characters are append.
+    //
+    // For example, given:
+    //   - the match 'ex-a-mple', where dashes denote splits in the match
+    //   - the suggestion 'ample'
+    // We get the result 'am-p-le'.
     match.ranges.forEach(({ from, to }, index) => {
       const isLastRange = index === match.ranges.length - 1;
       const mappedFrom = tr.mapping.map(from);
       const mappedTo = tr.mapping.map(to);
-      const fragmentToApply = text.slice(textCursor, !isLastRange ? to - from : Infinity);
-      textCursor += to - from;
+      const fragmentToApply = text.slice(textCursor, !isLastRange ? textCursor + (to - from) : Infinity);
+      textCursor += fragmentToApply.length;
 
       const replacementFrags = getPatchesFromReplacementText(
         tr,

--- a/src/ts/commands.ts
+++ b/src/ts/commands.ts
@@ -31,7 +31,7 @@ import { EditorView } from "prosemirror-view";
 import { compact } from "./utils/array";
 import {
   getPatchesFromReplacementText,
-  applyPatchToTransaction,
+  applyPatchesToTransaction,
   getFirstMatchingChar
 } from "./utils/prosemirror";
 import { getState } from "./utils/plugin";
@@ -383,20 +383,15 @@ const maybeApplySuggestions = (
       const fragmentToApply = text.slice(textCursor, !isLastRange ? textCursor + (mappedTo - mappedFrom) : Infinity);
       textCursor += fragmentToApply.length;
 
-      const replacementFrags = getPatchesFromReplacementText(
+      const patches = getPatchesFromReplacementText(
         tr,
         mappedFrom,
         mappedTo,
         fragmentToApply
       );
 
-      // Do not attempt to preserve marks if match ranges are split –
-      // it's likely to go wrong!
-      const preserveMarks = match.ranges.length === 1;
+      applyPatchesToTransaction(patches, tr, state.schema)
 
-      replacementFrags.forEach(frag =>
-        applyPatchToTransaction(tr, state.schema, frag, preserveMarks)
-      );
     })
 
   });

--- a/src/ts/components/Feedback.tsx
+++ b/src/ts/components/Feedback.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from "react";
-import { IMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 import TelemetryContext from "../contexts/TelemetryContext";
 import { MoreHoriz, Announcement, MailOutline } from "@mui/icons-material";
 
@@ -20,7 +20,7 @@ export const Feedback = ({
   match,
   documentUrl
 }: {
-  match: IMatch;
+  match: Match;
   documentUrl: string;
 }) => {
   const [formState, setFormState] = useState<keyof typeof FeedbackFormStates>(

--- a/src/ts/components/FilterResults.tsx
+++ b/src/ts/components/FilterResults.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 
-import { IMatch } from "..";
 import TelemetryContext from "../contexts/TelemetryContext";
 import {
   getColourForMatchType,
@@ -8,6 +7,7 @@ import {
   IMatchTypeToColourMap,
   MatchType
 } from "../utils/decoration";
+import { MappedMatch } from "../interfaces/IMatch";
 
 const filterOrder = Object.values([
   MatchType.OK,
@@ -18,7 +18,7 @@ const filterOrder = Object.values([
 interface IProps {
   filterState: MatchType[];
   applyFilterState: (matchType: MatchType[]) => void;
-  matches: IMatch[];
+  matches: MappedMatch[];
   matchColours: IMatchTypeToColourMap;
 }
 

--- a/src/ts/components/FilterResults.tsx
+++ b/src/ts/components/FilterResults.tsx
@@ -7,7 +7,7 @@ import {
   IMatchTypeToColourMap,
   MatchType
 } from "../utils/decoration";
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 
 const filterOrder = Object.values([
   MatchType.OK,
@@ -18,7 +18,7 @@ const filterOrder = Object.values([
 interface IProps {
   filterState: MatchType[];
   applyFilterState: (matchType: MatchType[]) => void;
-  matches: MappedMatch[];
+  matches: Match[];
   matchColours: IMatchTypeToColourMap;
 }
 

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match as TMatch } from "../interfaces/IMatch";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
 import { getColourForMatch, IMatchTypeToColourMap } from "../utils/decoration";
@@ -10,9 +10,9 @@ import { Feedback } from "./Feedback";
 
 interface IMatchProps {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
-  match: MappedMatch;
+  match: TMatch;
   matchColours: IMatchTypeToColourMap;
-  onMarkCorrect?: (match: MappedMatch) => void;
+  onMarkCorrect?: (match: TMatch) => void;
 }
 
 class Match extends Component<IMatchProps> {

--- a/src/ts/components/Match.tsx
+++ b/src/ts/components/Match.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 
-import { IMatch } from "../interfaces/IMatch";
+import { MappedMatch } from "../interfaces/IMatch";
 import { ApplySuggestionOptions } from "../commands";
 import SuggestionList from "./SuggestionList";
 import { getColourForMatch, IMatchTypeToColourMap } from "../utils/decoration";
@@ -8,14 +8,14 @@ import { Check } from "@mui/icons-material";
 import { getHtmlFromMarkdown } from "../utils/dom";
 import { Feedback } from "./Feedback";
 
-interface IMatchProps<TMatch extends IMatch> {
+interface IMatchProps {
   applySuggestions?: (opts: ApplySuggestionOptions) => void;
-  match: TMatch;
+  match: MappedMatch;
   matchColours: IMatchTypeToColourMap;
-  onMarkCorrect?: (match: IMatch) => void;
+  onMarkCorrect?: (match: MappedMatch) => void;
 }
 
-class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
+class Match extends Component<IMatchProps> {
   public ref: HTMLDivElement | null = null;
   public render() {
     const {
@@ -23,7 +23,7 @@ class Match<TMatch extends IMatch> extends Component<IMatchProps<TMatch>> {
       matchColours,
       applySuggestions,
       onMarkCorrect
-    }: IMatchProps<TMatch> = this.props;
+    }: IMatchProps = this.props;
     const {
       category,
       message,

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -2,7 +2,7 @@ import Match from "./Match";
 import React, { useState, useEffect, useRef } from "react";
 import { IPluginState } from "../state/reducer";
 import { selectMatchByMatchId } from "../state/selectors";
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match as TMatch } from "../interfaces/IMatch";
 import { maybeGetDecorationElement } from "../utils/decoration";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { ApplySuggestionOptions } from "../commands";
@@ -15,7 +15,7 @@ interface IProps {
   store: Store;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   stopHover: () => void;
-  onMarkCorrect?: (match: MappedMatch) => void;
+  onMarkCorrect?: (match: TMatch) => void;
 }
 
 /**

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -2,7 +2,7 @@ import Match from "./Match";
 import React, { useState, useEffect, useRef } from "react";
 import { IPluginState } from "../state/reducer";
 import { selectMatchByMatchId } from "../state/selectors";
-import { IMatch } from "../interfaces/IMatch";
+import { MappedMatch } from "../interfaces/IMatch";
 import { maybeGetDecorationElement } from "../utils/decoration";
 import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
 import { ApplySuggestionOptions } from "../commands";
@@ -15,7 +15,7 @@ interface IProps {
   store: Store;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
   stopHover: () => void;
-  onMarkCorrect?: (match: IMatch) => void;
+  onMarkCorrect?: (match: MappedMatch) => void;
 }
 
 /**

--- a/src/ts/components/MatchSnippet.tsx
+++ b/src/ts/components/MatchSnippet.tsx
@@ -1,14 +1,13 @@
 import React, { useContext } from "react";
-import { IMatch } from "..";
 import SidebarMatchContainer from "./SidebarMatchContainer";
 import { IMatchTypeToColourMap } from "../utils/decoration";
 import { createScrollToRangeHandler } from "../utils/component";
 import TelemetryContext from "../contexts/TelemetryContext";
 import { getSidebarMatchStyles } from "./SidebarMatch";
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 
 interface IProps {
-  match: MappedMatch;
+  match: Match;
   matchColours?: IMatchTypeToColourMap;
   indicateHighlight: (blockId: string, _?: any) => void;
   stopHighlight: () => void;
@@ -16,7 +15,7 @@ interface IProps {
   editorScrollElement: Element;
 }
 
-const getMatchContext = (match: IMatch) => {
+const getMatchContext = (match: Match) => {
 
     const { matchedText, subsequentText, precedingText} = match
 

--- a/src/ts/components/MatchSnippet.tsx
+++ b/src/ts/components/MatchSnippet.tsx
@@ -5,9 +5,10 @@ import { IMatchTypeToColourMap } from "../utils/decoration";
 import { createScrollToRangeHandler } from "../utils/component";
 import TelemetryContext from "../contexts/TelemetryContext";
 import { getSidebarMatchStyles } from "./SidebarMatch";
+import { MappedMatch } from "../interfaces/IMatch";
 
 interface IProps {
-  match: IMatch;
+  match: MappedMatch;
   matchColours?: IMatchTypeToColourMap;
   indicateHighlight: (blockId: string, _?: any) => void;
   stopHighlight: () => void;

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, memo } from "react";
-import { IMatch } from "../interfaces/IMatch";
+import { MappedMatch } from "../interfaces/IMatch";
 import {
   IMatchTypeToColourMap,
   getColourForMatch,
@@ -14,7 +14,7 @@ import { css, SerializedStyles } from "@emotion/react";
 import { getSquiggleAsUri } from "../utils/squiggle";
 
 interface IProps {
-  match: IMatch;
+  match: MappedMatch;
   matchColours?: IMatchTypeToColourMap;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;
@@ -25,7 +25,7 @@ interface IProps {
 }
 
 export const getSidebarMatchStyles = (
-  match: IMatch,
+  match: MappedMatch,
   matchColours?: IMatchTypeToColourMap
 ): SerializedStyles => {
   const matchType = getMatchType(match);

--- a/src/ts/components/SidebarMatch.tsx
+++ b/src/ts/components/SidebarMatch.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, memo } from "react";
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 import {
   IMatchTypeToColourMap,
   getColourForMatch,
@@ -14,7 +14,7 @@ import { css, SerializedStyles } from "@emotion/react";
 import { getSquiggleAsUri } from "../utils/squiggle";
 
 interface IProps {
-  match: MappedMatch;
+  match: Match;
   matchColours?: IMatchTypeToColourMap;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;
@@ -25,7 +25,7 @@ interface IProps {
 }
 
 export const getSidebarMatchStyles = (
-  match: MappedMatch,
+  match: Match,
   matchColours?: IMatchTypeToColourMap
 ): SerializedStyles => {
   const matchType = getMatchType(match);

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 import { IMatchTypeToColourMap } from "../utils/decoration";
 import MatchSnippet from "./MatchSnippet";
 import { ArrowDropDown, ArrowDropUp } from "@mui/icons-material";
@@ -9,7 +9,7 @@ import SidebarMatchContainer from "./SidebarMatchContainer";
 import { getSidebarMatchStyles } from "./SidebarMatch";
 
 interface IProps {
-  matchGroup: Array<MappedMatch>;
+  matchGroup: Array<Match>;
   matchColours?: IMatchTypeToColourMap;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;

--- a/src/ts/components/SidebarMatchGroup.tsx
+++ b/src/ts/components/SidebarMatchGroup.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { IMatch, ISuggestion } from "../interfaces/IMatch";
+import { MappedMatch } from "../interfaces/IMatch";
 import { IMatchTypeToColourMap } from "../utils/decoration";
 import MatchSnippet from "./MatchSnippet";
 import { ArrowDropDown, ArrowDropUp } from "@mui/icons-material";
@@ -9,7 +9,7 @@ import SidebarMatchContainer from "./SidebarMatchContainer";
 import { getSidebarMatchStyles } from "./SidebarMatch";
 
 interface IProps {
-  matchGroup: Array<IMatch<ISuggestion>>;
+  matchGroup: Array<MappedMatch>;
   matchColours?: IMatchTypeToColourMap;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;

--- a/src/ts/components/SidebarMatches.tsx
+++ b/src/ts/components/SidebarMatches.tsx
@@ -4,7 +4,7 @@ import { chain } from "lodash";
 import React, { Fragment, useState } from "react";
 import { usePopper } from "react-popper";
 import { IMatch } from "..";
-import { ISuggestion } from "../interfaces/IMatch";
+import { ISuggestion, MappedMatch } from "../interfaces/IMatch";
 import {
   getColourForMatch,
   getMatchType,
@@ -119,7 +119,7 @@ const MatchHeader: React.FunctionComponent<{
 };
 
 interface ISidebarProps {
-  matches: IMatch[];
+  matches: MappedMatch[];
   matchColours?: IMatchTypeToColourMap;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;

--- a/src/ts/components/SidebarMatches.tsx
+++ b/src/ts/components/SidebarMatches.tsx
@@ -3,8 +3,7 @@ import { space } from "@guardian/src-foundations";
 import { chain } from "lodash";
 import React, { Fragment, useState } from "react";
 import { usePopper } from "react-popper";
-import { IMatch } from "..";
-import { ISuggestion, MappedMatch } from "../interfaces/IMatch";
+import { ISuggestion, Match } from "../interfaces/IMatch";
 import {
   getColourForMatch,
   getMatchType,
@@ -57,7 +56,7 @@ const MatchHeaderIconBox = styled.div`
 
 const MatchHeader: React.FunctionComponent<{
   matchColours?: IMatchTypeToColourMap;
-  match: IMatch<ISuggestion>;
+  match: Match<ISuggestion>;
   matchType: MatchType;
   setTooltipOpaque: SetState<boolean>;
   updatePopper: Update;
@@ -119,7 +118,7 @@ const MatchHeader: React.FunctionComponent<{
 };
 
 interface ISidebarProps {
-  matches: MappedMatch[];
+  matches: Match[];
   matchColours?: IMatchTypeToColourMap;
   selectMatch: (matchId: string) => void;
   indicateHighlight: (blockId: string, _?: any) => void;

--- a/src/ts/components/Suggestion.tsx
+++ b/src/ts/components/Suggestion.tsx
@@ -2,11 +2,11 @@ import React, { useContext } from "react";
 import { Change, diffChars } from "diff";
 
 import { ApplySuggestionOptions } from "../commands";
-import { ISuggestion, MappedMatch } from "../interfaces/IMatch";
+import { ISuggestion, Match } from "../interfaces/IMatch";
 import TelemetryContext from "../contexts/TelemetryContext";
 
 interface IProps {
-  match: MappedMatch;
+  match: Match;
   suggestion: ISuggestion;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }

--- a/src/ts/components/Suggestion.tsx
+++ b/src/ts/components/Suggestion.tsx
@@ -2,11 +2,11 @@ import React, { useContext } from "react";
 import { Change, diffChars } from "diff";
 
 import { ApplySuggestionOptions } from "../commands";
-import { ISuggestion, IMatch } from "../interfaces/IMatch";
+import { ISuggestion, MappedMatch } from "../interfaces/IMatch";
 import TelemetryContext from "../contexts/TelemetryContext";
 
 interface IProps {
-  match: IMatch;
+  match: MappedMatch;
   suggestion: ISuggestion;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }

--- a/src/ts/components/SuggestionList.tsx
+++ b/src/ts/components/SuggestionList.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { ISuggestion, MappedMatch } from "../interfaces/IMatch";
+import { ISuggestion, Match } from "../interfaces/IMatch";
 import Suggestion from "./Suggestion";
 import { ApplySuggestionOptions } from "../commands";
 
 interface IProps {
   suggestions: ISuggestion[];
-  match: MappedMatch;
+  match: Match;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }
 

--- a/src/ts/components/SuggestionList.tsx
+++ b/src/ts/components/SuggestionList.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from "react";
-import { ISuggestion, IMatch } from "../interfaces/IMatch";
+import { ISuggestion, MappedMatch } from "../interfaces/IMatch";
 import Suggestion from "./Suggestion";
 import { ApplySuggestionOptions } from "../commands";
 
 interface IProps {
   suggestions: ISuggestion[];
-  match: IMatch;
+  match: MappedMatch;
   applySuggestions: (opts: ApplySuggestionOptions) => void;
 }
 

--- a/src/ts/components/createOverlayView.tsx
+++ b/src/ts/components/createOverlayView.tsx
@@ -3,7 +3,7 @@ import { render, unmountComponentAtNode } from "react-dom";
 import MatchOverlay from "./MatchOverlay";
 import Store from "../state/store";
 import { Commands } from "../commands";
-import { IMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 import TyperighterTelemetryAdapter from "../services/TyperighterTelemetryAdapter";
 import TelemetryContext from "../contexts/TelemetryContext";
 import { EditorView } from "prosemirror-view";
@@ -13,7 +13,7 @@ interface OverlayViewOptions {
   store: Store;
   commands: Commands;
   overlayNode: Element;
-  onMarkCorrect?: (match: IMatch) => void;
+  onMarkCorrect?: (match: Match) => void;
   telemetryAdapter?: TyperighterTelemetryAdapter;
 }
 

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -24,7 +24,7 @@ import { EditorView } from "prosemirror-view";
 import { Plugin, Transaction } from "prosemirror-state";
 import { expandRangesToParentBlockNodes } from "./utils/range";
 import { getDirtiedRangesFromTransaction } from "./utils/prosemirror";
-import { IRange, IMatch } from "./interfaces/IMatch";
+import { IRange, MappedMatch } from "./interfaces/IMatch";
 import { Node } from "prosemirror-model";
 import Store, {
   STORE_EVENT_NEW_STATE,
@@ -69,7 +69,7 @@ export interface IPluginOptions extends PluginOptionsFromConfig {
   /**
    * The initial set of matches to apply to the document, if any.
    */
-  matches?: IMatch[];
+  matches?: MappedMatch[];
 
   /**
    * Ignore matches when this predicate returns true.
@@ -101,7 +101,7 @@ export interface IPluginOptions extends PluginOptionsFromConfig {
   /**
    * Called when a match decoration is clicked.
    */
-  onMatchDecorationClicked?: (match: IMatch) => void;
+  onMatchDecorationClicked?: (match: MappedMatch) => void;
 
   telemetryAdapter?: TyperighterTelemetryAdapter;
 

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -31,7 +31,7 @@ import Store, {
   STORE_EVENT_NEW_MATCHES,
   STORE_EVENT_NEW_DIRTIED_RANGES
 } from "./state/store";
-import { doNotSkipRanges, TGetSkippedRanges } from "./utils/block";
+import { doNotIgnoreRanges, GetIgnoredRanges } from "./utils/block";
 import { createBoundCommands, startHoverCommand, stopHoverCommand } from "./commands";
 import { IFilterMatches, maybeResetHoverStates } from "./utils/plugin";
 import { pluginKey } from "./utils/plugin";
@@ -88,7 +88,7 @@ export interface IPluginOptions extends PluginOptionsFromConfig {
    * your CMS allows users to exclude ranges that we don't want to check,
    * but do want to accommodate as part of the document.
    */
-  getSkippedRanges?: TGetSkippedRanges;
+  getIgnoredRanges?: GetIgnoredRanges;
 
   /**
    * Is the given element part of the typerighter UI, but not
@@ -109,8 +109,8 @@ export interface IPluginOptions extends PluginOptionsFromConfig {
 
   typerighterEnabled?: boolean
   /**
-   * A list of categoryIds to exclude from checks. These can be 
-   * modified on the MatcherService instance if they need to be changed after 
+   * A list of categoryIds to exclude from checks. These can be
+   * modified on the MatcherService instance if they need to be changed after
    * the plugin initialises.
    */
   excludedCategoryIds?: string[]
@@ -130,7 +130,7 @@ const createTyperighterPlugin = (
 } => {
   const {
     expandRanges = expandRangesToParentBlockNodes,
-    getSkippedRanges = doNotSkipRanges,
+    getIgnoredRanges = doNotIgnoreRanges,
     matches = [],
     filterOptions,
     ignoreMatch = includeAllMatches,
@@ -149,7 +149,7 @@ const createTyperighterPlugin = (
     expandRanges,
     ignoreMatch,
     filterOptions?.filterMatches,
-    getSkippedRanges
+    getIgnoredRanges
   );
 
   const matcherService = new MatcherService(store, adapter, telemetryAdapter, 2000, excludedCategoryIds)

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -24,7 +24,7 @@ import { EditorView } from "prosemirror-view";
 import { Plugin, Transaction } from "prosemirror-state";
 import { expandRangesToParentBlockNodes } from "./utils/range";
 import { getDirtiedRangesFromTransaction } from "./utils/prosemirror";
-import { IRange, MappedMatch } from "./interfaces/IMatch";
+import { IRange, Match } from "./interfaces/IMatch";
 import { Node } from "prosemirror-model";
 import Store, {
   STORE_EVENT_NEW_STATE,
@@ -69,7 +69,7 @@ export interface IPluginOptions extends PluginOptionsFromConfig {
   /**
    * The initial set of matches to apply to the document, if any.
    */
-  matches?: MappedMatch[];
+  matches?: Match[];
 
   /**
    * Ignore matches when this predicate returns true.
@@ -101,7 +101,7 @@ export interface IPluginOptions extends PluginOptionsFromConfig {
   /**
    * Called when a match decoration is clicked.
    */
-  onMatchDecorationClicked?: (match: MappedMatch) => void;
+  onMatchDecorationClicked?: (match: Match) => void;
 
   telemetryAdapter?: TyperighterTelemetryAdapter;
 

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,4 +1,4 @@
-import type { IMatch, ICategory, IBlock, ISuggestion } from './interfaces/IMatch'
+import type { ICategory, IBlock, ISuggestion, Match } from './interfaces/IMatch'
 import type { IPluginState } from './state/reducer';
 import type { IMatchTypeToColourMap } from './utils/decoration';
 import Store, { STORE_EVENT_NEW_STATE } from './state/store';
@@ -34,7 +34,7 @@ export {
   getState,
   createTyperighterPlugin,
   filterByMatchState,
-  IMatch,
+  Match,
   IBlock,
   ICategory,
   ISuggestion,
@@ -45,11 +45,11 @@ export {
   getSquiggleAsUri,
   findAncestor,
   getHtmlFromMarkdown,
-  MatchType, 
-  IMatchTypeToColourMap, 
-  getMatchType, 
-  getColourForMatch, 
-  getColourForMatchType, 
+  MatchType,
+  IMatchTypeToColourMap,
+  getMatchType,
+  getColourForMatch,
+  getColourForMatchType,
   getMatchOffset,
   TelemetryContext
 };

--- a/src/ts/interfaces/IHoverEvent.ts
+++ b/src/ts/interfaces/IHoverEvent.ts
@@ -1,7 +1,7 @@
-import { IMatch } from "./IMatch";
+import { Match } from "./IMatch";
 
 interface IHoverEvent {
-  match: IMatch | undefined;
+  match: Match | undefined;
 }
 
 export default IHoverEvent;

--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -50,11 +50,9 @@ export type TMatchRequestErrorWithDefault = PartialBy<
   "type"
 >;
 
-export interface IMatch<TSuggestion = ISuggestion> {
+export interface BaseMatch<TSuggestion = ISuggestion> {
   matcherType: string
   matchId: string;
-  from: number;
-  to: number;
   ruleId: string;
   matchedText: string;
   message: string;
@@ -68,12 +66,21 @@ export interface IMatch<TSuggestion = ISuggestion> {
   groupKey: string;
 }
 
+export interface IMatch<TSuggestion = ISuggestion> extends BaseMatch<TSuggestion> {
+  from: number;
+  to: number;
+}
+
+export interface MappedMatch<TSuggestion = ISuggestion> extends IMatch<TSuggestion> {
+  ranges: IRange[]
+}
+
 export interface IBlockResult {
   categoryIds: string[];
   id: string;
 }
 
-export interface IMatcherResponse<MatchesType extends IMatch[] = IMatch[]> {
+export interface IMatcherResponse<MatchesType extends BaseMatch[] = IMatch[]> {
   blocks: IBlock[];
   categoryIds: string[];
   matches: MatchesType;

--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -11,6 +11,9 @@ export interface ICategory {
   colour: string;
 }
 
+/**
+ * A block of contiguous text.
+ */
 export interface IBlock {
   id: string;
   text: string;
@@ -18,9 +21,11 @@ export interface IBlock {
   to: number
 }
 
-
-export interface IBlockWithSkippedRanges extends IBlock {
-  skipRanges: IRange[]
+/**
+ * A block of contiguous text with some ranges marked as ignored.
+ */
+export interface IBlockWithIgnoredRanges extends IBlock {
+  ignoreRanges: IRange[]
 }
 
 export interface ISuggestion {

--- a/src/ts/interfaces/IMatch.ts
+++ b/src/ts/interfaces/IMatch.ts
@@ -50,7 +50,9 @@ export type TMatchRequestErrorWithDefault = PartialBy<
   "type"
 >;
 
-export interface BaseMatch<TSuggestion = ISuggestion> {
+export interface MatchFromTyperighter<TSuggestion = ISuggestion> {
+  from: number;
+  to: number;
   matcherType: string
   matchId: string;
   ruleId: string;
@@ -66,12 +68,7 @@ export interface BaseMatch<TSuggestion = ISuggestion> {
   groupKey: string;
 }
 
-export interface IMatch<TSuggestion = ISuggestion> extends BaseMatch<TSuggestion> {
-  from: number;
-  to: number;
-}
-
-export interface MappedMatch<TSuggestion = ISuggestion> extends IMatch<TSuggestion> {
+export interface Match<TSuggestion = ISuggestion> extends MatchFromTyperighter<TSuggestion> {
   ranges: IRange[]
 }
 
@@ -80,7 +77,7 @@ export interface IBlockResult {
   id: string;
 }
 
-export interface IMatcherResponse<MatchesType extends BaseMatch[] = IMatch[]> {
+export interface IMatcherResponse<MatchesType extends MatchFromTyperighter[] = MatchFromTyperighter[]> {
   blocks: IBlock[];
   categoryIds: string[];
   matches: MatchesType;

--- a/src/ts/interfaces/IMatcherAdapter.ts
+++ b/src/ts/interfaces/IMatcherAdapter.ts
@@ -1,9 +1,9 @@
 import {
   IBlock,
-  IMatch,
   ICategory,
   IMatcherResponse,
-  TMatchRequestErrorWithDefault
+  TMatchRequestErrorWithDefault,
+  MatchFromTyperighter
 } from "./IMatch";
 
 export type FetchMatches = {
@@ -33,7 +33,7 @@ export declare class IMatcherAdapter {
   constructor(apiUrl: string);
 }
 
-export type TMatchesReceivedCallback = (response: IMatcherResponse<IMatch[]>) => void;
+export type TMatchesReceivedCallback = (response: IMatcherResponse<MatchFromTyperighter[]>) => void;
 
 export type TRequestErrorCallback = (
   matchRequestError: TMatchRequestErrorWithDefault

--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -1,4 +1,4 @@
-import { ICategory, IBlockWithIgnoredRanges, MappedMatch } from "../interfaces/IMatch";
+import { ICategory, IBlockWithIgnoredRanges, Match } from "../interfaces/IMatch";
 import {
   IMatcherAdapter,
   TMatchesReceivedCallback
@@ -49,8 +49,8 @@ class MatcherService {
     return this.commands
   }
 
-  private sendMatchTelemetryEvents = (matches: MappedMatch[]) => {
-    matches.forEach((match: MappedMatch) =>
+  private sendMatchTelemetryEvents = (matches: Match[]) => {
+    matches.forEach((match: Match) =>
       this.telemetryAdapter?.matchFound(match, document.URL)
     );
   };

--- a/src/ts/services/MatcherService.ts
+++ b/src/ts/services/MatcherService.ts
@@ -1,4 +1,4 @@
-import { IMatch, ICategory, IBlockWithIgnoredRanges } from "../interfaces/IMatch";
+import { ICategory, IBlockWithIgnoredRanges, MappedMatch } from "../interfaces/IMatch";
 import {
   IMatcherAdapter,
   TMatchesReceivedCallback
@@ -49,8 +49,8 @@ class MatcherService {
     return this.commands
   }
 
-  private sendMatchTelemetryEvents = (matches: IMatch[]) => {
-    matches.forEach((match: IMatch) =>
+  private sendMatchTelemetryEvents = (matches: MappedMatch[]) => {
+    matches.forEach((match: MappedMatch) =>
       this.telemetryAdapter?.matchFound(match, document.URL)
     );
   };
@@ -97,9 +97,9 @@ class MatcherService {
       return;
     }
     const applyMatcherResponse: TMatchesReceivedCallback = response => {
-      this.sendMatchTelemetryEvents(response.matches);
       // For matches, map through ignored ranges on the way in
       const transformedMatches = response.matches.map(match => mapMatchThroughBlocks(match, blocks))
+      this.sendMatchTelemetryEvents(transformedMatches);
       const transformedResponse = { ...response, matches: transformedMatches }
       commands.applyMatcherResponse(transformedResponse);
     };

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -19,7 +19,7 @@ import {
   UserTelemetryEventSender
 } from "@guardian/user-telemetry-client";
 import { MatchType } from "../utils/decoration";
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 
 class TyperighterTelemetryAdapter {
   constructor(
@@ -35,7 +35,7 @@ class TyperighterTelemetryAdapter {
   }
 
   public suggestionIsAccepted(
-    match: MappedMatch,
+    match: Match,
     documentUrl: string,
     suggestion: string
   ) {
@@ -50,7 +50,7 @@ class TyperighterTelemetryAdapter {
     } as ISuggestionAcceptedEvent);
   }
 
-  public matchIsMarkedAsCorrect(match: MappedMatch, documentUrl: string) {
+  public matchIsMarkedAsCorrect(match: Match, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT,
       value: 1,
@@ -61,7 +61,7 @@ class TyperighterTelemetryAdapter {
     } as IMarkAsCorrectEvent);
   }
 
-  public matchDecorationClicked(match: MappedMatch, documentUrl: string) {
+  public matchDecorationClicked(match: Match, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_DECORATION_CLICKED,
       value: 1,
@@ -112,7 +112,7 @@ class TyperighterTelemetryAdapter {
     } as IOpenTyperighterEvent);
   }
 
-  public sidebarMatchClicked(match: MappedMatch, documentUrl: string) {
+  public sidebarMatchClicked(match: Match, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
       value: 1,
@@ -123,7 +123,7 @@ class TyperighterTelemetryAdapter {
     } as ISidebarClickEvent);
   }
 
-  public matchFound(match: MappedMatch, documentUrl: string) {
+  public matchFound(match: Match, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND,
       value: 1,
@@ -174,7 +174,7 @@ class TyperighterTelemetryAdapter {
     });
   }
 
-  private getTelemetryTagsFromMatch = (match: MappedMatch) => ({
+  private getTelemetryTagsFromMatch = (match: Match) => ({
     matcherType: match.matcherType,
     ruleId: match.ruleId,
     matchId: match.matchId,

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -18,8 +18,8 @@ import {
   IUserTelemetryEvent,
   UserTelemetryEventSender
 } from "@guardian/user-telemetry-client";
-import { IMatch } from "..";
 import { MatchType } from "../utils/decoration";
+import { MappedMatch } from "../interfaces/IMatch";
 
 class TyperighterTelemetryAdapter {
   constructor(
@@ -35,7 +35,7 @@ class TyperighterTelemetryAdapter {
   }
 
   public suggestionIsAccepted(
-    match: IMatch,
+    match: MappedMatch,
     documentUrl: string,
     suggestion: string
   ) {
@@ -50,7 +50,7 @@ class TyperighterTelemetryAdapter {
     } as ISuggestionAcceptedEvent);
   }
 
-  public matchIsMarkedAsCorrect(match: IMatch, documentUrl: string) {
+  public matchIsMarkedAsCorrect(match: MappedMatch, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MARK_AS_CORRECT,
       value: 1,
@@ -61,7 +61,7 @@ class TyperighterTelemetryAdapter {
     } as IMarkAsCorrectEvent);
   }
 
-  public matchDecorationClicked(match: IMatch, documentUrl: string) {
+  public matchDecorationClicked(match: MappedMatch, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_DECORATION_CLICKED,
       value: 1,
@@ -112,7 +112,7 @@ class TyperighterTelemetryAdapter {
     } as IOpenTyperighterEvent);
   }
 
-  public sidebarMatchClicked(match: IMatch, documentUrl: string) {
+  public sidebarMatchClicked(match: MappedMatch, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_SIDEBAR_MATCH_CLICK,
       value: 1,
@@ -123,7 +123,7 @@ class TyperighterTelemetryAdapter {
     } as ISidebarClickEvent);
   }
 
-  public matchFound(match: IMatch, documentUrl: string) {
+  public matchFound(match: MappedMatch, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_MATCH_FOUND,
       value: 1,
@@ -174,7 +174,7 @@ class TyperighterTelemetryAdapter {
     });
   }
 
-  private getTelemetryTagsFromMatch = (match: IMatch) => ({
+  private getTelemetryTagsFromMatch = (match: MappedMatch) => ({
     matcherType: match.matcherType,
     ruleId: match.ruleId,
     matchId: match.matchId,

--- a/src/ts/services/TyperighterTelemetryAdapter.ts
+++ b/src/ts/services/TyperighterTelemetryAdapter.ts
@@ -142,7 +142,7 @@ class TyperighterTelemetryAdapter {
     } as IFilterToggleEvent);
   }
 
-  public feedbackReceived(match: IMatch, feedbackMessage: string, documentUrl: string) {
+  public feedbackReceived(match: Match, feedbackMessage: string, documentUrl: string) {
     this.addEvent({
       type: TYPERIGHTER_TELEMETRY_TYPE.TYPERIGHTER_FEEDBACK_RECEIVED,
       value: 1,

--- a/src/ts/services/adapters/TyperighterAdapter.ts
+++ b/src/ts/services/adapters/TyperighterAdapter.ts
@@ -26,6 +26,7 @@ export const convertTyperighterResponse = (
     matchId: v4(),
     from: fromPos,
     to: toPos,
+    ranges: [{ from: fromPos, to: toPos }],
     matcherType: rule.matcherType,
     category: rule.category,
     ruleId: rule.id,

--- a/src/ts/services/test/MatcherService.spec.ts
+++ b/src/ts/services/test/MatcherService.spec.ts
@@ -56,7 +56,7 @@ const block = {
   to: 10,
   text: "1234567890",
   id: "0-from:0-to:10",
-  skipRanges: []
+  ignoreRanges: []
 };
 
 const commands = {
@@ -127,26 +127,26 @@ describe("MatcherService", () => {
     });
   });
 
-  describe("handling skipRanges", () => {
+  describe("handling ignoreRanges", () => {
     const blockText = "ABCDEF";
     const outgoingText = "BDF";
-    const blockWithSkipRanges = {
+    const blockWithIgnoreRanges = {
       id: "id",
       from: 0,
       to: 6,
       text: blockText,
-      skipRanges: [
+      ignoreRanges: [
         { from: 0, to: 0 },
         { from: 2, to: 2 },
         { from: 4, to: 4 }
       ]
     };
-    it("should remove the skipped ranges from block text as they're passed to the Typerighter service", done => {
+    it("should remove the ignored ranges from block text as they're passed to the Typerighter service", done => {
       const service = createMatcherService();
       fetchMock.post(`${endpoint}/check`, 400);
       service.requestFetchMatches();
 
-      store.emit("STORE_EVENT_NEW_MATCHES", requestId, [blockWithSkipRanges]);
+      store.emit("STORE_EVENT_NEW_MATCHES", requestId, [blockWithIgnoreRanges]);
       setTimeout(() => {
         const { blocks } = getLastRequest();
         const expectedBlocks = [
@@ -162,16 +162,16 @@ describe("MatcherService", () => {
       });
     });
 
-    it("On receipt of matches, map matches that succeed skipped ranges through those ranges to ensure they're correct", done => {
+    it("On receipt of matches, map matches that succeed ignored ranges through those ranges to ensure they're correct", done => {
       const service = createMatcherService();
       // We send the text "BDF", and create a match for the "F" at position 2
       const response = createResponse(["F"], 2);
       fetchMock.post(`${endpoint}/check`, response);
       service.requestFetchMatches();
 
-      store.emit("STORE_EVENT_NEW_MATCHES", requestId, [blockWithSkipRanges]);
+      store.emit("STORE_EVENT_NEW_MATCHES", requestId, [blockWithIgnoreRanges]);
       setTimeout(() => {
-        // We map our match (position 2) back through three skipRanges of
+        // We map our match (position 2) back through three ignoreRanges of
         // one char each, pushing range into (5, 6).
         const matches = commands.applyMatcherResponse.mock.calls[0][0].matches[0]
         expect(matches.from).toBe(5);

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -2,7 +2,7 @@ import {
   IMatchRequestError,
   IMatcherResponse,
   IRange,
-  MappedMatch
+  Match
 } from "../interfaces/IMatch";
 import { IPluginConfig, IPluginState } from "./reducer";
 
@@ -52,7 +52,7 @@ export type ActionRequestMatchesForDocument = ReturnType<
 >;
 
 export const requestMatchesSuccess = (
-  response: IMatcherResponse<MappedMatch[]>
+  response: IMatcherResponse<Match[]>
 ) => ({
   type: REQUEST_SUCCESS,
   payload: { response }

--- a/src/ts/state/actions.ts
+++ b/src/ts/state/actions.ts
@@ -1,7 +1,8 @@
 import {
   IMatchRequestError,
   IMatcherResponse,
-  IRange
+  IRange,
+  MappedMatch
 } from "../interfaces/IMatch";
 import { IPluginConfig, IPluginState } from "./reducer";
 
@@ -50,8 +51,8 @@ export type ActionRequestMatchesForDocument = ReturnType<
   typeof requestMatchesForDocument
 >;
 
-export const requestMatchesSuccess = <TPluginState extends IPluginState>(
-  response: IMatcherResponse<TPluginState["currentMatches"]>
+export const requestMatchesSuccess = (
+  response: IMatcherResponse<MappedMatch[]>
 ) => ({
   type: REQUEST_SUCCESS,
   payload: { response }

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -130,7 +130,12 @@ export const getNewStateFromTransaction = (
     ...incomingState,
     decorations: incomingState.decorations.map(tr.mapping, tr.doc),
     dirtiedRanges: mapAndMergeRanges(incomingState.dirtiedRanges, tr.mapping),
-    currentMatches: mapRanges(incomingState.currentMatches, tr.mapping),
+    currentMatches: incomingState.currentMatches.map(match => ({
+      ...match,
+      from: tr.mapping.map(match.from),
+      to: tr.mapping.map(match.to),
+      ranges: mapRanges(match.ranges, tr.mapping)
+    })),
     requestsInFlight: mappedRequestsInFlight,
     docChangedSinceCheck: true,
     docIsEmpty: !nodeContainsText(tr.doc)

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -33,7 +33,7 @@ import {
   IMatch,
   IRange,
   IMatchRequestError,
-  IBlockWithSkippedRanges
+  IBlockWithIgnoredRanges
 } from "../interfaces/IMatch";
 import { DecorationSet, Decoration } from "prosemirror-view";
 import omit from "lodash/omit";
@@ -68,8 +68,8 @@ import {
 import { Mapping } from "prosemirror-transform";
 import {
   createBlock,
-  doNotSkipRanges,
-  TGetSkippedRanges
+  doNotIgnoreRanges,
+  GetIgnoredRanges
 } from "../utils/block";
 import {
   addMatchesToState,
@@ -82,7 +82,7 @@ import { IFilterMatches } from "../utils/plugin";
 export interface IBlockInFlight {
   // The categories that haven't yet reported for this block.
   pendingCategoryIds: string[];
-  block: IBlockWithSkippedRanges;
+  block: IBlockWithIgnoredRanges;
 }
 
 /**
@@ -232,7 +232,7 @@ export const createReducer = (
   expandRanges: ExpandRanges,
   ignoreMatch: IIgnoreMatchPredicate = includeAllMatches,
   filterMatches?: IFilterMatches,
-  getIgnoredRanges: TGetSkippedRanges = doNotSkipRanges
+  getIgnoredRanges: GetIgnoredRanges = doNotIgnoreRanges
 ) => {
   const handleMatchesRequestForDirtyRanges = createHandleMatchesRequestForDirtyRanges(
     expandRanges,
@@ -466,7 +466,7 @@ const handleNewDirtyRanges = (
  */
 const createHandleMatchesRequestForDirtyRanges = (
   expandRanges: ExpandRanges,
-  getIgnoredRanges: TGetSkippedRanges
+  getIgnoredRanges: GetIgnoredRanges
 ) => (
   tr: Transaction,
   state: IPluginState,
@@ -483,7 +483,7 @@ const createHandleMatchesRequestForDirtyRanges = (
  * Handle a matches request for the entire document.
  */
 const createHandleMatchesRequestForDocument = (
-  getIgnoredRanges: TGetSkippedRanges
+  getIgnoredRanges: GetIgnoredRanges
 ) => (
   tr: Transaction,
   state: IPluginState,
@@ -501,7 +501,7 @@ const createHandleMatchesRequestForDocument = (
  */
 const handleRequestStart = (
   requestId: string,
-  blocks: IBlockWithSkippedRanges[],
+  blocks: IBlockWithIgnoredRanges[],
   categoryIds: string[]
 ) => (
   tr: Transaction,
@@ -840,7 +840,7 @@ const handleSetFilterState = (
 });
 
 const handleSetTyperighterEnabled = (
-  getIgnoredRanges: TGetSkippedRanges = doNotSkipRanges
+  getIgnoredRanges: GetIgnoredRanges = doNotIgnoreRanges
 ) => (
   _: Transaction,
   state: IPluginState,

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -33,7 +33,7 @@ import {
   IRange,
   IMatchRequestError,
   IBlockWithIgnoredRanges,
-  MappedMatch
+  Match
 } from "../interfaces/IMatch";
 import { DecorationSet, Decoration } from "prosemirror-view";
 import omit from "lodash/omit";
@@ -90,7 +90,7 @@ export interface IBlockInFlight {
  * Handy when, for example, consumers know that parts of the document are
  * exempt from checks.
  */
-export type IIgnoreMatchPredicate = (match: MappedMatch) => boolean;
+export type IIgnoreMatchPredicate = (match: Match) => boolean;
 export const includeAllMatches: IIgnoreMatchPredicate = () => false;
 
 export interface IRequestInFlight {
@@ -116,12 +116,12 @@ export interface IPluginState {
   // The current decorations the plugin is applying to the document.
   decorations: DecorationSet;
   // The current matches for the document.
-  currentMatches: MappedMatch[];
+  currentMatches: Match[];
   // The current matches, filtered by the current filterState and the
   // supplied filter predicate. This is cached in the state and only
   // recomputed when necessary – filtering decorations in the plugin
   // decoration mapping on every transaction is not performant.
-  filteredMatches: MappedMatch[];
+  filteredMatches: Match[];
   // The current ranges that are marked as dirty, that is, have been
   // changed since the last request.
   dirtiedRanges: IRange[];
@@ -164,7 +164,7 @@ export const PROSEMIRROR_TYPERIGHTER_ACTION = "PROSEMIRROR_TYPERIGHTER_ACTION";
 
 interface IInitialStateOpts {
   doc: Node;
-  matches?: MappedMatch[];
+  matches?: Match[];
   ignoreMatch?: IIgnoreMatchPredicate;
   matchColours?: IMatchTypeToColourMap;
   filterOptions?: IFilterOptions;
@@ -195,8 +195,8 @@ export const createInitialState = ({
       createDecorationsForMatches(matches)
     ),
     dirtiedRanges: [],
-    currentMatches: [] as MappedMatch[],
-    filteredMatches: [] as MappedMatch[],
+    currentMatches: [] as Match[],
+    filteredMatches: [] as Match[],
     selectedMatch: undefined,
     hoverId: undefined,
     hoverRectIndex: undefined,

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -443,7 +443,7 @@ const handleNewDirtyRanges = (
   // Remove any matches and associated decorations touched by the dirtied ranges from the doc
   newDecorations = removeDecorationsFromRanges(newDecorations, dirtiedRanges);
   const currentMatches = state.currentMatches.filter(
-    match => match.ranges.some(range => findOverlappingRangeIndex(range, dirtiedRanges) === -1
+    match => match.ranges.every(range => findOverlappingRangeIndex(range, dirtiedRanges) === -1
   ));
 
   const shouldPersistNewDirtyRanges =

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -613,15 +613,17 @@ const handleMatchesRequestSuccess = (ignoreMatch: IIgnoreMatchPredicate) => (
   }
 
   // Remove matches superceded by the incoming matches.
+  const blockRanges = blocksInFlight.map(_ => _.block);
   let currentMatches = state.currentMatches.filter(match => {
-    const incomingMatchesAreOfTheSameCategory = !response.categoryIds.includes(match.category.id);
-    const matchIsInSameBlock = removeOverlappingRanges(
-        match.ranges,
-        blocksInFlight.map(_ => _.block)
-      ).length > 0
+    const incomingMatchesAreOfTheSameCategory = response.categoryIds.includes(
+      match.category.id
+    );
+    const matchIsInSameBlock = match.ranges.some(
+      range => findOverlappingRangeIndex(range, blockRanges) !== -1
+    );
 
-      return !(incomingMatchesAreOfTheSameCategory && matchIsInSameBlock);
-    });
+    return !(incomingMatchesAreOfTheSameCategory && matchIsInSameBlock);
+  });
 
   // Remove decorations superceded by the incoming matches.
   const decsToRemove = blocksInFlight.reduce(

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "lodash";
-import { IMatch, ISuggestion } from "../interfaces/IMatch";
+import { IMatch, ISuggestion, MappedMatch } from "../interfaces/IMatch";
 import { getMatchType, MatchType } from "../utils/decoration";
 import { IPluginState, IBlockInFlight, IRequestInFlight } from "./reducer";
 
@@ -146,16 +146,16 @@ const getSortOrderForMatchType = (match: IMatch) => {
   }
 };
 
-const getSortOrderForMatchAppearance = (match: IMatch) => match.from;
+const getSortOrderForMatchAppearance = (match: MappedMatch) => match.from;
 
 export const selectDocumentOrderedMatches = (
   state: IPluginState
-): Array<IMatch<ISuggestion>> =>
+): Array<MappedMatch<ISuggestion>> =>
   sortBy(state.filteredMatches, getSortOrderForMatchAppearance);
 
 export const selectImportanceOrderedMatches = (
   state: IPluginState
-): Array<IMatch<ISuggestion>> =>
+): Array<MappedMatch<ISuggestion>> =>
   sortBy(
     state.filteredMatches,
     getSortOrderForMatchType,

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -1,5 +1,5 @@
 import { sortBy } from "lodash";
-import { IMatch, ISuggestion, MappedMatch } from "../interfaces/IMatch";
+import { ISuggestion, Match } from "../interfaces/IMatch";
 import { getMatchType, MatchType } from "../utils/decoration";
 import { IPluginState, IBlockInFlight, IRequestInFlight } from "./reducer";
 
@@ -135,7 +135,7 @@ export const selectRequestsInProgress = (state: IPluginState): boolean =>
 export const selectHasMatches = (state: IPluginState): boolean =>
   !!state.currentMatches && state.currentMatches.length > 0;
 
-const getSortOrderForMatchType = (match: IMatch) => {
+const getSortOrderForMatchType = (match: Match) => {
   const matchType = getMatchType(match);
   if (matchType === MatchType.AMEND) {
     return 0;
@@ -146,16 +146,16 @@ const getSortOrderForMatchType = (match: IMatch) => {
   }
 };
 
-const getSortOrderForMatchAppearance = (match: MappedMatch) => match.from;
+const getSortOrderForMatchAppearance = (match: Match) => match.from;
 
 export const selectDocumentOrderedMatches = (
   state: IPluginState
-): Array<MappedMatch<ISuggestion>> =>
+): Array<Match<ISuggestion>> =>
   sortBy(state.filteredMatches, getSortOrderForMatchAppearance);
 
 export const selectImportanceOrderedMatches = (
   state: IPluginState
-): Array<MappedMatch<ISuggestion>> =>
+): Array<Match<ISuggestion>> =>
   sortBy(
     state.filteredMatches,
     getSortOrderForMatchType,

--- a/src/ts/state/store.ts
+++ b/src/ts/state/store.ts
@@ -1,6 +1,6 @@
 import { IPluginState } from "./reducer";
 import { ArgumentTypes } from "../utils/types";
-import { IBlockWithSkippedRanges } from "../interfaces/IMatch";
+import { IBlockWithIgnoredRanges } from "../interfaces/IMatch";
 
 export const STORE_EVENT_NEW_MATCHES = "STORE_EVENT_NEW_MATCHES";
 export const STORE_EVENT_NEW_STATE = "STORE_EVENT_NEW_STATE";
@@ -13,7 +13,7 @@ type STORE_EVENT_NEW_DIRTIED_RANGES = typeof STORE_EVENT_NEW_DIRTIED_RANGES;
 export interface IStoreEvents {
   [STORE_EVENT_NEW_MATCHES]: (
     requestId: string,
-    blocks: IBlockWithSkippedRanges[]
+    blocks: IBlockWithIgnoredRanges[]
   ) => void;
   [STORE_EVENT_NEW_STATE]: (state: IPluginState) => void;
   [STORE_EVENT_NEW_DIRTIED_RANGES]: () => void;

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -22,11 +22,11 @@ import {
   isFilterStateStale
 } from "../helpers";
 import { createReducer, IPluginState } from "../reducer";
-import { MappedMatch } from "../../interfaces/IMatch";
+import { Match } from "../../interfaces/IMatch";
 
 describe("State helpers", () => {
   const getState = <TFilterState extends unknown>(
-    matchesToAdd: MappedMatch[],
+    matchesToAdd: Match[],
     filterState: TFilterState
   ) => {
     const { state, matches } = createStateWithMatches(
@@ -46,14 +46,14 @@ describe("State helpers", () => {
 
   describe("isFilterStateStale", () => {
     it("should report fresh when the filter state is undefined", () => {
-      const matches = [] as MappedMatch[];
+      const matches = [] as Match[];
       const { state: oldState } = getState(matches, undefined);
       const { state: newState } = getState(matches, undefined);
       const isStale = isFilterStateStale(oldState, newState, identity);
       expect(isStale).toBe(false);
     });
     it("should report fresh when the filter state is undefined and the matches change", () => {
-      const { state: oldState } = getState([] as MappedMatch[], undefined);
+      const { state: oldState } = getState([] as Match[], undefined);
       const { state: newState } = getState([createMatch(1, 2)], undefined);
       const isStale = isFilterStateStale(oldState, newState, identity);
       expect(isStale).toBe(false);
@@ -61,7 +61,7 @@ describe("State helpers", () => {
     it("should report stale when the filter state changes", () => {
       const oldFilterState = [] as MatchType[];
       const newFilterState = [MatchType.OK];
-      const matches = [] as MappedMatch[];
+      const matches = [] as Match[];
       const { state: oldState } = getState(matches, oldFilterState);
       const { state: newState } = getState(matches, newFilterState);
       const isStale = isFilterStateStale(oldState, newState, identity);
@@ -69,7 +69,7 @@ describe("State helpers", () => {
     });
     it("should report stale when the matches change and the filter state remains the same", () => {
       const filterState = [] as MatchType[];
-      const oldMatches = [] as MappedMatch[];
+      const oldMatches = [] as Match[];
       const newMatches = [createMatch(1, 2)];
       const { state: oldState } = getState(oldMatches, filterState);
       const { state: newState } = getState(newMatches, filterState);

--- a/src/ts/state/test/helpers.spec.ts
+++ b/src/ts/state/test/helpers.spec.ts
@@ -1,6 +1,5 @@
 import { identity } from "lodash";
 import { DecorationSet } from "prosemirror-view";
-import { IMatch } from "../..";
 import {
   createRequestInFlight,
   createInitialTr,
@@ -23,10 +22,11 @@ import {
   isFilterStateStale
 } from "../helpers";
 import { createReducer, IPluginState } from "../reducer";
+import { MappedMatch } from "../../interfaces/IMatch";
 
 describe("State helpers", () => {
   const getState = <TFilterState extends unknown>(
-    matchesToAdd: IMatch[],
+    matchesToAdd: MappedMatch[],
     filterState: TFilterState
   ) => {
     const { state, matches } = createStateWithMatches(
@@ -46,14 +46,14 @@ describe("State helpers", () => {
 
   describe("isFilterStateStale", () => {
     it("should report fresh when the filter state is undefined", () => {
-      const matches = [] as IMatch[];
+      const matches = [] as MappedMatch[];
       const { state: oldState } = getState(matches, undefined);
       const { state: newState } = getState(matches, undefined);
       const isStale = isFilterStateStale(oldState, newState, identity);
       expect(isStale).toBe(false);
     });
     it("should report fresh when the filter state is undefined and the matches change", () => {
-      const { state: oldState } = getState([] as IMatch[], undefined);
+      const { state: oldState } = getState([] as MappedMatch[], undefined);
       const { state: newState } = getState([createMatch(1, 2)], undefined);
       const isStale = isFilterStateStale(oldState, newState, identity);
       expect(isStale).toBe(false);
@@ -61,7 +61,7 @@ describe("State helpers", () => {
     it("should report stale when the filter state changes", () => {
       const oldFilterState = [] as MatchType[];
       const newFilterState = [MatchType.OK];
-      const matches = [] as IMatch[];
+      const matches = [] as MappedMatch[];
       const { state: oldState } = getState(matches, oldFilterState);
       const { state: newState } = getState(matches, newFilterState);
       const isStale = isFilterStateStale(oldState, newState, identity);
@@ -69,7 +69,7 @@ describe("State helpers", () => {
     });
     it("should report stale when the matches change and the filter state remains the same", () => {
       const filterState = [] as MatchType[];
-      const oldMatches = [] as IMatch[];
+      const oldMatches = [] as MappedMatch[];
       const newMatches = [createMatch(1, 2)];
       const { state: oldState } = getState(oldMatches, filterState);
       const { state: newState } = getState(newMatches, filterState);

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -668,30 +668,31 @@ describe("Action handlers", () => {
     });
   });
   describe("handleNewDirtyRanges", () => {
+    const { state } = createInitialData();
+    const match: MappedMatch =
+      {
+        matcherType: "regex",
+        ruleId: "ruleId",
+        matchId: "match-id",
+        from: 1,
+        to: 7,
+        ranges: [{ from: 1, to: 7 }],
+        matchedText: "block text",
+        message: "Annotation",
+        category: {
+          id: "1",
+          name: "cat",
+          colour: "eeeeee"
+        },
+        markAsCorrect: true,
+        matchContext: "bigger block of text",
+        precedingText: "bigger block of text",
+        subsequentText: "",
+        groupKey: "group-key"
+      }
+
     it("should remove any decorations and matches that touch the passed ranges", () => {
-      const { state } = createInitialData();
-      const currentMatches: MappedMatch[] = [
-        {
-          matcherType: "regex",
-          ruleId: "ruleId",
-          matchId: "match-id",
-          from: 1,
-          to: 7,
-          ranges: [{ from: 1, to: 7 }],
-          matchedText: "block text",
-          message: "Annotation",
-          category: {
-            id: "1",
-            name: "cat",
-            colour: "eeeeee"
-          },
-          markAsCorrect: true,
-          matchContext: "bigger block of text",
-          precedingText: "bigger block of text",
-          subsequentText: "",
-          groupKey: "group-key"
-        }
-      ];
+      const currentMatches = [match];
       const stateWithCurrentMatchesAndDecorations = {
         ...state,
         currentMatches,
@@ -701,6 +702,7 @@ describe("Action handlers", () => {
           defaultDoc
         )
       };
+
       expect(
         reducer(
           new Transaction(defaultDoc),
@@ -709,6 +711,34 @@ describe("Action handlers", () => {
         )
       ).toEqual({
         ...state,
+        requestPending: true,
+        dirtiedRanges: [{ from: 1, to: 2 }]
+      });
+    });
+
+    it("should remove any decorations and matches that touch the passed ranges for multi-range matches", () => {
+      const currentMatches = [{
+        ...match,
+        ranges: [{ from: 1, to: 2 }, { from: 3, to: 7 }],
+      }];
+      const stateWithCurrentMatchesAndDecorations = {
+        ...state,
+        currentMatches,
+        decorations: getNewDecorationsForCurrentMatches(
+          currentMatches,
+          state.decorations,
+          defaultDoc
+        )
+      };
+
+      expect(
+        reducer(
+          new Transaction(defaultDoc),
+          stateWithCurrentMatchesAndDecorations,
+          applyNewDirtiedRanges([{ from: 1, to: 2 }])
+        )
+      ).toMatchObject({
+        currentMatches: [],
         requestPending: true,
         dirtiedRanges: [{ from: 1, to: 2 }]
       });

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -23,7 +23,7 @@ import {
 } from "../../utils/decoration";
 import { expandRangesToParentBlockNodes } from "../../utils/range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
-import { IMatchRequestError, MappedMatch } from "../../interfaces/IMatch";
+import { IMatchRequestError, Match } from "../../interfaces/IMatch";
 import { addMatchesToState } from "../helpers";
 import {
   createMatcherResponse,
@@ -585,7 +585,7 @@ describe("Action handlers", () => {
     });
     it("should add hover decorations", () => {
       const { state, tr } = createInitialData();
-      const output: MappedMatch = {
+      const output: Match = {
         matcherType: "regex",
         ruleId: "ruleId",
         matchId: "match-id",
@@ -625,7 +625,7 @@ describe("Action handlers", () => {
     });
     it("should remove hover decorations", () => {
       const { state, tr } = createInitialData();
-      const output: MappedMatch = {
+      const output: Match = {
         matcherType: "regex",
         ruleId: "ruleId",
         matchId: "match-id",
@@ -669,7 +669,7 @@ describe("Action handlers", () => {
   });
   describe("handleNewDirtyRanges", () => {
     const { state } = createInitialData();
-    const match: MappedMatch =
+    const match: Match =
       {
         matcherType: "regex",
         ruleId: "ruleId",

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -299,6 +299,21 @@ describe("Action handlers", () => {
         ]
       );
 
+      it("should remove previous matches that match block and category of the incoming match", () => {
+        const newState = reducer(
+          tr,
+          state,
+          requestMatchesSuccess({
+            blocks: [firstBlock, secondBlock],
+            categoryIds: ["1", category.id],
+            matches: [],
+            requestId: exampleRequestId
+          })
+        );
+
+        expect(newState.currentMatches).toEqual([]);
+      });
+
       it("should remove previous decorations that match block and category of the incoming match", () => {
         const newState = reducer(
           tr,
@@ -355,6 +370,21 @@ describe("Action handlers", () => {
         ]);
       });
       it("should not regenerate decorations for matches that remain", () => {
+        const newState = reducer(
+          tr,
+          state,
+          requestMatchesSuccess({
+            blocks: [firstBlock],
+            categoryIds: ["another-category"],
+            matches: [],
+            requestId: exampleRequestId
+          })
+        );
+
+        expect(newState.decorations).toBe(state.decorations);
+      });
+
+      it("should remove superceded matches remain", () => {
         const newState = reducer(
           tr,
           state,

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -69,7 +69,7 @@ describe("Action handlers", () => {
             text: "Example text to check",
             to: 23,
             id: "0-from:1-to:23",
-            skipRanges: []
+            ignoreRanges: []
           }
         ])
       });
@@ -106,7 +106,7 @@ describe("Action handlers", () => {
             from: 1,
             to: 22,
             id: "0-from:1-to:22",
-            skipRanges: []
+            ignoreRanges: []
           }
         ])
       });
@@ -338,7 +338,7 @@ describe("Action handlers", () => {
               id: firstBlock.id,
               text: "Example text to check",
               to: 15,
-              skipRanges: []
+              ignoreRanges: []
             },
             pendingCategoryIds: ["this-category-should-remain"]
           },
@@ -348,7 +348,7 @@ describe("Action handlers", () => {
               id: secondBlock.id,
               text: "Another block of text",
               to: 37,
-              skipRanges: []
+              ignoreRanges: []
             },
             pendingCategoryIds: ["1", "this-category-should-remain"]
           }
@@ -845,7 +845,7 @@ describe("Action handlers", () => {
       expect(newState.requestErrors).toEqual(state.requestErrors);
     });
   });
-  describe("setTyperighterEnabled", () => { 
+  describe("setTyperighterEnabled", () => {
     it("should remove any matches and decorations when disabled", () => {
       const { state, tr } = createInitialData();
       const matcherResponse = createMatcherResponse([{ from: 5, to: 10 }]);
@@ -885,23 +885,23 @@ describe("Action handlers", () => {
     it("should add requests-in-flight for the entire document when enabled", () => {
       const { state, tr } = createInitialData();
       const expectedRequest = {
-        "categoryIds": [], 
+        "categoryIds": [],
         "mapping": {
-          "from": 0, 
-          "maps": [], 
-          "mirror": undefined, 
+          "from": 0,
+          "maps": [],
+          "mirror": undefined,
           "to": 0
-        }, 
+        },
         "pendingBlocks": [{
           "block": {
-            "from": 1, 
-            "id": "0-from:1-to:23", 
-            "skipRanges": [], 
-            "text": "Example text to check", 
+            "from": 1,
+            "id": "0-from:1-to:23",
+            "ignoreRanges": [],
+            "text": "Example text to check",
             "to": 23
-          }, 
+          },
           "pendingCategoryIds": []
-        }], 
+        }],
         "totalBlocks": 1
       }
 
@@ -910,15 +910,15 @@ describe("Action handlers", () => {
         state,
         setTyperighterEnabled(true)
       ).requestsInFlight;
-      
-      
+
+
       const requestNames = Object.keys(requests);
       const actualRequest = requests[Object.keys(requests)[0]]
-      
-      expect(requestNames.length).toEqual(1); 
+
+      expect(requestNames.length).toEqual(1);
       expect(actualRequest).toMatchObject(
         expectedRequest
-      ); 
+      );
     });
   })
   describe("setConfigValue", () => {

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -23,7 +23,7 @@ import {
 } from "../../utils/decoration";
 import { expandRangesToParentBlockNodes } from "../../utils/range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
-import { IMatch, IMatchRequestError } from "../../interfaces/IMatch";
+import { IMatchRequestError, MappedMatch } from "../../interfaces/IMatch";
 import { addMatchesToState } from "../helpers";
 import {
   createMatcherResponse,
@@ -585,12 +585,13 @@ describe("Action handlers", () => {
     });
     it("should add hover decorations", () => {
       const { state, tr } = createInitialData();
-      const output: IMatch = {
+      const output: MappedMatch = {
         matcherType: "regex",
         ruleId: "ruleId",
         matchId: "match-id",
         from: 0,
         to: 5,
+        ranges: [{ from: 0, to: 5 }],
         matchedText: "block text",
         message: "Annotation",
         category: {
@@ -624,12 +625,13 @@ describe("Action handlers", () => {
     });
     it("should remove hover decorations", () => {
       const { state, tr } = createInitialData();
-      const output: IMatch = {
+      const output: MappedMatch = {
         matcherType: "regex",
         ruleId: "ruleId",
         matchId: "match-id",
         from: 0,
         to: 5,
+        ranges: [{ from: 0, to: 5 }],
         matchedText: "block text",
         message: "Annotation",
         category: {
@@ -668,13 +670,14 @@ describe("Action handlers", () => {
   describe("handleNewDirtyRanges", () => {
     it("should remove any decorations and matches that touch the passed ranges", () => {
       const { state } = createInitialData();
-      const currentMatches: IMatch[] = [
+      const currentMatches: MappedMatch[] = [
         {
           matcherType: "regex",
           ruleId: "ruleId",
           matchId: "match-id",
           from: 1,
           to: 7,
+          ranges: [{ from: 1, to: 7 }],
           matchedText: "block text",
           message: "Annotation",
           category: {
@@ -724,6 +727,7 @@ describe("Action handlers", () => {
             text: "example",
             from: 1,
             to: 1,
+            ranges: [{ from: 1, to: 1 }],
             matchedText: "block text",
             message: "example",
             suggestions: [],

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -12,7 +12,7 @@ import {
   createInitialData,
   exampleCategoryIds
 } from "../../test/helpers/fixtures";
-import { IMatch } from '../../interfaces/IMatch';
+import { MappedMatch } from '../../interfaces/IMatch';
 import { omit } from "lodash";
 
 describe("selectors", () => {
@@ -128,13 +128,14 @@ describe("selectors", () => {
     });
     it("should handle unknown suggestions for found outputs", () => {
       const { state } = createInitialData();
-      const currentMatches: IMatch[] = [
+      const currentMatches: MappedMatch[] = [
         {
           matcherType: "regex",
           ruleId: "ruleId",
           matchId: "match-id",
           from: 0,
           to: 5,
+          ranges: [{ from: 0, to: 5 }],
           suggestions: [
             { type: "TEXT_SUGGESTION" as "TEXT_SUGGESTION", text: "example" },
             {
@@ -168,13 +169,14 @@ describe("selectors", () => {
     });
     it("should select a suggestion and the range it should be applied to, given a match id and suggestion index", () => {
       const { state } = createInitialData();
-      const currentMatches: IMatch[] = [
+      const currentMatches: MappedMatch[] = [
         {
           matcherType: "regex",
           ruleId: "ruleId",
           matchId: "match-id",
           from: 0,
           to: 5,
+          ranges: [{ from: 0, to: 5 }],
           suggestions: [
             { type: "TEXT_SUGGESTION" as "TEXT_SUGGESTION", text: "example" },
             {

--- a/src/ts/state/test/selectors.spec.ts
+++ b/src/ts/state/test/selectors.spec.ts
@@ -12,7 +12,7 @@ import {
   createInitialData,
   exampleCategoryIds
 } from "../../test/helpers/fixtures";
-import { MappedMatch } from '../../interfaces/IMatch';
+import { Match } from '../../interfaces/IMatch';
 import { omit } from "lodash";
 
 describe("selectors", () => {
@@ -128,7 +128,7 @@ describe("selectors", () => {
     });
     it("should handle unknown suggestions for found outputs", () => {
       const { state } = createInitialData();
-      const currentMatches: MappedMatch[] = [
+      const currentMatches: Match[] = [
         {
           matcherType: "regex",
           ruleId: "ruleId",
@@ -169,7 +169,7 @@ describe("selectors", () => {
     });
     it("should select a suggestion and the range it should be applied to, given a match id and suggestion index", () => {
       const { state } = createInitialData();
-      const currentMatches: MappedMatch[] = [
+      const currentMatches: Match[] = [
         {
           matcherType: "regex",
           ruleId: "ruleId",

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -17,6 +17,7 @@ const applySuggestionToDoc = (
   const { editorElement, commands } = createEditor(before, [match]);
 
   commands.applySuggestions([{ text: replacement, matchId: match.matchId }]);
+  commands.clearMatches();
 
   return editorElement.querySelector("p")!;
 };
@@ -55,13 +56,37 @@ describe("Commands", () => {
 
     it("should keep marks within parts of the replaced text when multi-word suggestions are applied and additions are made to the end of the range", () => {
       const editorElement = applySuggestionToDoc(
-        "<p>i'm a celebrity get me <em>out</em> of <strong>here</strong></p>",
+        "<p>1<em>2</em>3<strong>4</strong>5</p>",
+        [{ from: 1, to: 6 }],
+        "1-3-5"
+      );
+
+      expect(editorElement.innerHTML).toBe(
+        "1<em>-</em>3<strong>-</strong>5"
+      );
+    });
+
+    it("should extend marks when the patch grows", () => {
+      const editorElement = applySuggestionToDoc(
+        "<p>1<em>2</em>3<strong>4</strong>5</p>",
+        [{ from: 1, to: 7 }],
+        "1-34-5"
+      );
+
+      expect(editorElement.innerHTML).toBe(
+        "1<em>-</em>3<strong>4-</strong>5"
+      );
+    });
+
+    it("should keep marks within parts of the replaced text when multi-word suggestions are applied and additions are made to the end of the range", () => {
+      const editorElement = applySuggestionToDoc(
+        "<p>i'm a celebrity get me <em>o</em>ut of <strong>here</strong></p>",
         [{ from: 1, to: 36 }],
         "I'm a Celebrity ... Get Me Out Of Here!"
       );
 
       expect(editorElement.innerHTML).toBe(
-        "I'm a Celebrity ... Get Me <em>Out</em> Of <strong>Here!</strong>"
+        "I'm a Celebrity ... Get Me <em>O</em>ut Of <strong>Here!</strong>"
       );
     });
 

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -138,7 +138,7 @@ describe("Commands", () => {
         "ample"
       );
 
-      expect(editorElement.innerHTML).toBe("An am--ple sentence");
+      expect(editorElement.innerHTML).toBe("An am-p-le sentence");
     });
   });
   describe("setTyperighterEnabled", () => {

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -121,7 +121,7 @@ describe("Commands", () => {
       expect(editorElement.innerHTML).toBe("An a<em>mp</em>le sentence");
     });
 
-    it("should ignore ranges not covered by the match – 1", () => {
+    it("should ignore ranges not covered by the match", () => {
       const editorElement = applySuggestionToDoc(
         "<p>An exa-----mple sentence</p>",
         [{ from: 4, to: 7 }, { from: 12, to: 16 }],
@@ -131,7 +131,7 @@ describe("Commands", () => {
       expect(editorElement.textContent).toBe("An a-----mple sentence");
     });
 
-    it("should ignore ranges not covered by the match – 2", () => {
+    it("should ignore ranges not covered by the match, preserving position of the start of the suggestion", () => {
       const editorElement = applySuggestionToDoc(
         "<p>An ex-a-mple sentence</p>",
         [{ from: 4, to: 6 }, { from: 7, to: 8 }, { from: 9, to: 13 }],
@@ -139,6 +139,16 @@ describe("Commands", () => {
       );
 
       expect(editorElement.textContent).toBe("An -a-mple sentence");
+    });
+
+    it("should ignore ranges not covered by the match, flowing subsequent parts of the suggestion through the ranges", () => {
+      const editorElement = applySuggestionToDoc(
+        "<p>An ex-aa-mple sentence</p>",
+        [{ from: 4, to: 6 }, { from: 7, to: 9 }, { from: 10, to: 14 }],
+        "example"
+      );
+
+      expect(editorElement.textContent).toBe("An ex-am-ple sentence");
     });
   });
   describe("setTyperighterEnabled", () => {

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -128,7 +128,7 @@ describe("Commands", () => {
         "ample"
       );
 
-      expect(editorElement.innerHTML).toBe("An amp-----le sentence");
+      expect(editorElement.textContent).toBe("An a-----mple sentence");
     });
 
     it("should ignore ranges not covered by the match – 2", () => {
@@ -138,7 +138,7 @@ describe("Commands", () => {
         "ample"
       );
 
-      expect(editorElement.innerHTML).toBe("An am-p-le sentence");
+      expect(editorElement.textContent).toBe("An -a-mple sentence");
     });
   });
   describe("setTyperighterEnabled", () => {

--- a/src/ts/test/commands.spec.ts
+++ b/src/ts/test/commands.spec.ts
@@ -65,18 +65,6 @@ describe("Commands", () => {
       );
     });
 
-    it("should keep overlapping marks within parts of the replaced text when multi-word suggestions are applied and additions are made to the end of the range", () => {
-      const editorElement = applySuggestionToDoc(
-        "<p>i'm a celebrity get me <em>out of <strong>here</em></strong></p>",
-        [{ from: 1, to: 36 }],
-        "I'm a Celebrity ... Get Me Out Of Here!"
-      );
-
-      expect(editorElement.innerHTML).toBe(
-        "I'm a Celebrity ... Get Me <em>Out Of <strong>Here!</strong></em>"
-      );
-    });
-
     it("should keep marks across the whole replaced text when suggestions are applied and additions are made to the beginning of the range", () => {
       const editorElement = applySuggestionToDoc(
         "<p>Two <strong>eggs</strong></p>",
@@ -128,7 +116,7 @@ describe("Commands", () => {
         "ample"
       );
 
-      expect(editorElement.textContent).toBe("An a-----mple sentence");
+      expect(editorElement.innerHTML).toBe("An a-----mple sentence");
     });
 
     it("should ignore ranges not covered by the match, preserving position of the start of the suggestion", () => {
@@ -138,7 +126,7 @@ describe("Commands", () => {
         "ample"
       );
 
-      expect(editorElement.textContent).toBe("An -a-mple sentence");
+      expect(editorElement.innerHTML).toBe("An -a-mple sentence");
     });
 
     it("should ignore ranges not covered by the match, flowing subsequent parts of the suggestion through the ranges", () => {
@@ -148,9 +136,20 @@ describe("Commands", () => {
         "example"
       );
 
-      expect(editorElement.textContent).toBe("An ex-am-ple sentence");
+      expect(editorElement.innerHTML).toBe("An ex-am-ple sentence");
+    });
+
+    it("should not consider styling of ignored and adjacent ranges when preserving marks", () => {
+      const editorElement = applySuggestionToDoc(
+        "<p><strong>An </strong><em>e<strong>-</strong>m<strong>-</strong>ple</em><strong> sentence</strong></p>",
+        [{ from: 4, to: 5 }, { from: 6, to: 7 }, { from: 8, to: 11 }],
+        "temple"
+      );
+
+      expect(editorElement.innerHTML).toBe("<strong>An </strong><em>t<strong>-</strong>e<strong>-</strong>mple</em><strong> sentence</strong>");
     });
   });
+
   describe("setTyperighterEnabled", () => {
     const createExampleEditor = (
       before: string,
@@ -174,7 +173,7 @@ describe("Commands", () => {
 
       const maybeMatchElement = editorElement.querySelector("span[data-match-id]")!;
       expect(maybeMatchElement).toBeFalsy()
-    })
+    });
 
     it("should not remove match decorations when setTyperighterEnabled is set to true", () => {
       const { editorElement, commands } = createExampleEditor("<p>An example sentence</p>",

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -14,7 +14,7 @@ import createTyperighterPlugin, {
 import { createMatch, createMatcherResponse } from "./helpers/fixtures";
 import { createEditor } from "./helpers/createEditor";
 import { createBoundCommands } from "../commands";
-import { IMatcherResponse, MappedMatch } from "../interfaces/IMatch";
+import { IMatcherResponse, Match } from "../interfaces/IMatch";
 import { getBlocksFromDocument } from "../utils/prosemirror";
 import { createDecorationsForMatches, MatchType } from "../utils/decoration";
 import { filterByMatchState, getState } from "../utils/plugin";
@@ -23,7 +23,7 @@ import TyperighterAdapter from "../services/adapters/TyperighterAdapter";
 const doc = createDoc(p("Example text to check"), p("More text to check"));
 const blocks = getBlocksFromDocument(doc);
 const matches = [createMatch(1)];
-const matchWithReplacement: MappedMatch = {
+const matchWithReplacement: Match = {
   ...createMatch(5),
   replacement: { text: "replacement text", type: "TEXT_SUGGESTION" }
 };
@@ -129,7 +129,7 @@ describe("createTyperighterPlugin", () => {
     const { store, commands } = createPlugin();
     const storeSpy = jest.fn();
     store.on("STORE_EVENT_NEW_MATCHES", storeSpy);
-    const response: IMatcherResponse<MappedMatch[]> = {
+    const response: IMatcherResponse<Match[]> = {
       blocks,
       categoryIds: ["cat1"],
       matches: [
@@ -261,7 +261,7 @@ describe("createTyperighterPlugin", () => {
       expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
     });
     it("should filter matches with the supplied predicate when the plugin initialises", () => {
-      const matchesWithReplacements: MappedMatch[] = [
+      const matchesWithReplacements: Match[] = [
         matchWithReplacement,
         createMatch(2),
         createMatch(3)

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -14,7 +14,7 @@ import createTyperighterPlugin, {
 import { createMatch, createMatcherResponse } from "./helpers/fixtures";
 import { createEditor } from "./helpers/createEditor";
 import { createBoundCommands } from "../commands";
-import { IMatch, IMatcherResponse } from "../interfaces/IMatch";
+import { IMatcherResponse, MappedMatch } from "../interfaces/IMatch";
 import { getBlocksFromDocument } from "../utils/prosemirror";
 import { createDecorationsForMatches, MatchType } from "../utils/decoration";
 import { filterByMatchState, getState } from "../utils/plugin";
@@ -23,7 +23,7 @@ import TyperighterAdapter from "../services/adapters/TyperighterAdapter";
 const doc = createDoc(p("Example text to check"), p("More text to check"));
 const blocks = getBlocksFromDocument(doc);
 const matches = [createMatch(1)];
-const matchWithReplacement: IMatch = {
+const matchWithReplacement: MappedMatch = {
   ...createMatch(5),
   replacement: { text: "replacement text", type: "TEXT_SUGGESTION" }
 };
@@ -129,12 +129,13 @@ describe("createTyperighterPlugin", () => {
     const { store, commands } = createPlugin();
     const storeSpy = jest.fn();
     store.on("STORE_EVENT_NEW_MATCHES", storeSpy);
-    const response: IMatcherResponse = {
+    const response: IMatcherResponse<MappedMatch[]> = {
       blocks,
       categoryIds: ["cat1"],
       matches: [
         {
           ...blocks[0],
+          ranges: [blocks[0]],
           matcherType: "regex",
           ruleId: "ruleId",
           matchId: "matchId",
@@ -214,7 +215,7 @@ describe("createTyperighterPlugin", () => {
       ignoreMatch: () => true
     });
 
-    const response: IMatcherResponse = createMatcherResponse([
+    const response = createMatcherResponse([
       { from: 1, to: 2, block: blocks[0] }
     ]);
 
@@ -260,7 +261,7 @@ describe("createTyperighterPlugin", () => {
       expect(decorationSpecs).toEqual(decorationsSpecsToExpect);
     });
     it("should filter matches with the supplied predicate when the plugin initialises", () => {
-      const matchesWithReplacements: IMatch[] = [
+      const matchesWithReplacements: MappedMatch[] = [
         matchWithReplacement,
         createMatch(2),
         createMatch(3)

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -163,14 +163,14 @@ describe("createTyperighterPlugin", () => {
           id: "1337-from:1-to:23",
           text: "Example text to check",
           to: 23,
-          skipRanges: []
+          ignoreRanges: []
         },
         {
           from: 24,
           id: "1337-from:24-to:43",
           text: "More text to check",
           to: 43,
-          skipRanges: []
+          ignoreRanges: []
         }
       ]
     ]);

--- a/src/ts/test/helpers/createEditor.ts
+++ b/src/ts/test/helpers/createEditor.ts
@@ -8,9 +8,9 @@ import { exampleSetup } from "prosemirror-example-setup";
 import createTyperighterPlugin from "../../createTyperighterPlugin";
 import { createBoundCommands } from "../../commands";
 import TyperighterAdapter from "../../services/adapters/TyperighterAdapter";
-import { MappedMatch } from "../../interfaces/IMatch";
+import { Match } from "../../interfaces/IMatch";
 
-export const createEditor = (htmlDoc: string, matches: MappedMatch[] = []) => {
+export const createEditor = (htmlDoc: string, matches: Match[] = []) => {
   const mySchema = new Schema({
     nodes: addListNodes(schema.spec.nodes as any, "paragraph block*", "block"),
     marks

--- a/src/ts/test/helpers/createEditor.ts
+++ b/src/ts/test/helpers/createEditor.ts
@@ -8,9 +8,9 @@ import { exampleSetup } from "prosemirror-example-setup";
 import createTyperighterPlugin from "../../createTyperighterPlugin";
 import { createBoundCommands } from "../../commands";
 import TyperighterAdapter from "../../services/adapters/TyperighterAdapter";
-import { IMatch } from "../..";
+import { MappedMatch } from "../../interfaces/IMatch";
 
-export const createEditor = (htmlDoc: string, matches: IMatch[] = []) => {
+export const createEditor = (htmlDoc: string, matches: MappedMatch[] = []) => {
   const mySchema = new Schema({
     nodes: addListNodes(schema.spec.nodes as any, "paragraph block*", "block"),
     marks

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -153,6 +153,36 @@ export const createMatch = (
   groupKey: "group-key"
 });
 
+export const createMatchWithRanges = (
+  ranges: IRange[],
+  suggestions = [] as ISuggestion[],
+  category = {
+    id: "1",
+    name: "Cat",
+    colour: "eeeee"
+  }
+): MappedMatch => {
+  const from = Math.min(...ranges.map(range => range.from));
+  const to = Math.max(...ranges.map(range => range.to));
+
+  return {
+    matcherType: "regex",
+    ruleId: "ruleId",
+    category,
+    matchedText: "block text",
+    message: "annotation",
+    from,
+    to,
+    ranges,
+    matchId: createMatchId(0, from, to, 0),
+    suggestions,
+    matchContext: "here is a [[block text]] match",
+    precedingText: "here is a ",
+    subsequentText: " match",
+    groupKey: "group-key"
+  };
+};
+
 export const exampleCategoryIds = ["example-category"];
 
 export const exampleRequestId = "set-id";

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -6,7 +6,7 @@ import {
   ICategory,
   IBlockWithIgnoredRanges,
   IRange,
-  MappedMatch
+  Match
 } from "../../interfaces/IMatch";
 import { createBlockId, createMatchId } from "../../utils/block";
 import { IPluginState, IRequestInFlight, createReducer, IPluginConfig } from "../../state/reducer";
@@ -70,7 +70,7 @@ export interface ICreateMatcherResponseSpec {
 export const createMatcherResponse = (
   specs: ICreateMatcherResponseSpec[],
   requestId: string = exampleRequestId
-): IMatcherResponse<MappedMatch[]> =>
+): IMatcherResponse<Match[]> =>
   specs.reduce(
     (acc, spec) => {
       const {
@@ -124,7 +124,7 @@ export const createMatcherResponse = (
       categoryIds: [],
       blocks: [],
       matches: []
-    } as IMatcherResponse<MappedMatch[]>
+    } as IMatcherResponse<Match[]>
   );
 
 export const createMatch = (
@@ -136,7 +136,7 @@ export const createMatch = (
     name: "Cat",
     colour: "eeeee"
   },
-): MappedMatch => ({
+): Match => ({
   matcherType: "regex",
   ruleId: "ruleId",
   category,
@@ -161,7 +161,7 @@ export const createMatchWithRanges = (
     name: "Cat",
     colour: "eeeee"
   }
-): MappedMatch => {
+): Match => {
   const from = Math.min(...ranges.map(range => range.from));
   const to = Math.max(...ranges.map(range => range.to));
 
@@ -264,7 +264,7 @@ export const createInitialData = (
 export const createStateWithMatches = (
   localReducer: ReturnType<typeof createReducer>,
   matches: ICreateMatcherResponseSpec[]
-): { state: IPluginState; matches: MappedMatch[] } => {
+): { state: IPluginState; matches: Match[] } => {
   const docTime = 1337;
   const { state, tr } = createInitialData(defaultDoc, docTime);
 

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -5,7 +5,7 @@ import {
   IBlock,
   IMatcherResponse,
   ICategory,
-  IBlockWithSkippedRanges,
+  IBlockWithIgnoredRanges,
   IRange
 } from "../../interfaces/IMatch";
 import { createBlockId, createMatchId } from "../../utils/block";
@@ -48,13 +48,13 @@ export const createBlock = (
   from: number,
   to: number,
   text = "str",
-  skipRanges: IRange[] = []
-): IBlockWithSkippedRanges => ({
+  ignoreRanges: IRange[] = []
+): IBlockWithIgnoredRanges => ({
   text,
   from,
   to,
   id: `0-from:${from}-to:${to}`,
-  skipRanges
+  ignoreRanges: ignoreRanges
 });
 
 export interface ICreateMatcherResponseSpec {
@@ -156,7 +156,7 @@ export const exampleCategoryIds = ["example-category"];
 export const exampleRequestId = "set-id";
 
 export const createRequestInFlight = (
-  blocksInFlight: IBlockWithSkippedRanges[],
+  blocksInFlight: IBlockWithIgnoredRanges[],
   setId = exampleRequestId,
   categoryIds: string[] = exampleCategoryIds,
   pendingCategoryIds: string[] = categoryIds,

--- a/src/ts/test/helpers/fixtures.ts
+++ b/src/ts/test/helpers/fixtures.ts
@@ -1,12 +1,12 @@
 import {
   IMatchLibrary,
-  IMatch,
   ISuggestion,
   IBlock,
   IMatcherResponse,
   ICategory,
   IBlockWithIgnoredRanges,
-  IRange
+  IRange,
+  MappedMatch
 } from "../../interfaces/IMatch";
 import { createBlockId, createMatchId } from "../../utils/block";
 import { IPluginState, IRequestInFlight, createReducer, IPluginConfig } from "../../state/reducer";
@@ -70,7 +70,7 @@ export interface ICreateMatcherResponseSpec {
 export const createMatcherResponse = (
   specs: ICreateMatcherResponseSpec[],
   requestId: string = exampleRequestId
-): IMatcherResponse =>
+): IMatcherResponse<MappedMatch[]> =>
   specs.reduce(
     (acc, spec) => {
       const {
@@ -102,6 +102,7 @@ export const createMatcherResponse = (
         message: "annotation",
         from: wordFrom,
         to: wordTo,
+        ranges: [{ from: wordFrom, to: wordTo }],
         matchId: createMatchId(0, wordFrom, wordTo, 0),
         suggestions,
         matchContext: "here is a [[block text]] match",
@@ -123,7 +124,7 @@ export const createMatcherResponse = (
       categoryIds: [],
       blocks: [],
       matches: []
-    } as IMatcherResponse
+    } as IMatcherResponse<MappedMatch[]>
   );
 
 export const createMatch = (
@@ -135,7 +136,7 @@ export const createMatch = (
     name: "Cat",
     colour: "eeeee"
   },
-): IMatch => ({
+): MappedMatch => ({
   matcherType: "regex",
   ruleId: "ruleId",
   category,
@@ -143,6 +144,7 @@ export const createMatch = (
   message: "annotation",
   from,
   to,
+  ranges: [{ from, to }],
   matchId: createMatchId(0, from, to, 0),
   suggestions,
   matchContext: "here is a [[block text]] match",
@@ -232,7 +234,7 @@ export const createInitialData = (
 export const createStateWithMatches = (
   localReducer: ReturnType<typeof createReducer>,
   matches: ICreateMatcherResponseSpec[]
-): { state: IPluginState; matches: IMatch[] } => {
+): { state: IPluginState; matches: MappedMatch[] } => {
   const docTime = 1337;
   const { state, tr } = createInitialData(defaultDoc, docTime);
 

--- a/src/ts/test/helpers/prosemirror.ts
+++ b/src/ts/test/helpers/prosemirror.ts
@@ -7,7 +7,7 @@ import {
   Decoration
 } from "prosemirror-view";
 import { getNewDecorationsForCurrentMatches } from "../../utils/decoration";
-import { IMatch } from "../../interfaces/IMatch";
+import { MappedMatch } from "../../interfaces/IMatch";
 
 const schema = new Schema({
   nodes,
@@ -33,7 +33,7 @@ export const getDecorationSpecsFromDoc = (
 ) =>
   getDecorationSpecsFromSet(view.someProp("decorations", f => f(view.state)) as DecorationSet);
 
-export const getDecorationSpecsFromMatches = (matches: IMatch[], doc: Node) => {
+export const getDecorationSpecsFromMatches = (matches: MappedMatch[], doc: Node) => {
   const decorationSet = getNewDecorationsForCurrentMatches(matches, DecorationSet.empty, doc)
   return getDecorationSpecsFromSet(decorationSet);
 }

--- a/src/ts/test/helpers/prosemirror.ts
+++ b/src/ts/test/helpers/prosemirror.ts
@@ -7,7 +7,7 @@ import {
   Decoration
 } from "prosemirror-view";
 import { getNewDecorationsForCurrentMatches } from "../../utils/decoration";
-import { MappedMatch } from "../../interfaces/IMatch";
+import { Match } from "../../interfaces/IMatch";
 
 const schema = new Schema({
   nodes,
@@ -33,7 +33,7 @@ export const getDecorationSpecsFromDoc = (
 ) =>
   getDecorationSpecsFromSet(view.someProp("decorations", f => f(view.state)) as DecorationSet);
 
-export const getDecorationSpecsFromMatches = (matches: MappedMatch[], doc: Node) => {
+export const getDecorationSpecsFromMatches = (matches: Match[], doc: Node) => {
   const decorationSet = getNewDecorationsForCurrentMatches(matches, DecorationSet.empty, doc)
   return getDecorationSpecsFromSet(decorationSet);
 }

--- a/src/ts/utils/block.ts
+++ b/src/ts/utils/block.ts
@@ -21,7 +21,8 @@ export const createBlock = (
   // The final argument of 'textBetween' here adds a newline character to represent
   // a non-text leaf node.
   const text = doc.textBetween(range.from, range.to, undefined, "\n");
-  const ignoreRanges = getIgnoredRangesFromNode(doc, range.from, range.to) || [];
+  const ignoreRanges =
+    getIgnoredRangesFromNode(doc, range.from, range.to) || [];
   return {
     text,
     ...range,
@@ -82,7 +83,7 @@ export const removeIgnoredRanges = (block: IBlockWithIgnoredRanges): IBlock => {
         accBlock.text.slice(snipRange.to, accBlock.text.length);
 
       const mappedBlock = {
-        ...omit(accBlock, 'ignoreRanges'),
+        ...omit(accBlock, "ignoreRanges"),
         text: newText,
         to: accBlock.from + newText.length
       };

--- a/src/ts/utils/component.ts
+++ b/src/ts/utils/component.ts
@@ -1,9 +1,9 @@
 import { TyperighterTelemetryAdapter } from "..";
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 import { getMatchOffset } from "../utils/decoration";
 
 export const createScrollToRangeHandler = (
-  match: MappedMatch,
+  match: Match,
   getScrollOffset: () => number,
   editorScrollElement: Element,
   telemetryAdapter?: TyperighterTelemetryAdapter

--- a/src/ts/utils/component.ts
+++ b/src/ts/utils/component.ts
@@ -1,8 +1,9 @@
-import { IMatch, TyperighterTelemetryAdapter } from "..";
+import { TyperighterTelemetryAdapter } from "..";
+import { MappedMatch } from "../interfaces/IMatch";
 import { getMatchOffset } from "../utils/decoration";
 
 export const createScrollToRangeHandler = (
-  match: IMatch,
+  match: MappedMatch,
   getScrollOffset: () => number,
   editorScrollElement: Element,
   telemetryAdapter?: TyperighterTelemetryAdapter
@@ -21,5 +22,4 @@ export const createScrollToRangeHandler = (
     top: scrollToYCoord,
     behavior: "smooth"
   });
-
 };

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -2,7 +2,7 @@ import { news, opinion, success } from "@guardian/src-foundations";
 import flatten from "lodash/flatten";
 import { Node } from "prosemirror-model";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import { IRange, IMatch } from "../interfaces/IMatch";
+import { IRange, MappedMatch, BaseMatch } from "../interfaces/IMatch";
 import { getSquiggleAsUri } from "./squiggle";
 
 export enum MatchType {
@@ -97,7 +97,7 @@ export const removeDecorationsFromRanges = (
  * returns a new decoration set containing the new matches.
  */
 export const getNewDecorationsForCurrentMatches = (
-  outputs: IMatch[],
+  outputs: MappedMatch[],
   decorationSet: DecorationSet,
   doc: Node
 ) => {
@@ -110,7 +110,7 @@ export const getNewDecorationsForCurrentMatches = (
  * Create decorations for the given match.
  */
 export const createDecorationsForMatch = (
-  match: IMatch,
+  match: MappedMatch,
   isSelected: boolean = false
 ) => {
   const matchType = getMatchType(match);
@@ -121,10 +121,10 @@ export const createDecorationsForMatch = (
     : "";
 
   const spec = createDecorationSpecFromMatch(match);
-  const decorations = [
+  const decorations = match.ranges.map(range =>
     Decoration.inline(
-      match.from,
-      match.to,
+      range.from,
+      range.to,
       {
         class: className,
         [DECORATION_ATTRIBUTE_ID]: match.matchId,
@@ -132,12 +132,12 @@ export const createDecorationsForMatch = (
       },
       spec
     )
-  ];
+  );
 
   return decorations;
 };
 
-export const createDecorationSpecFromMatch = (match: IMatch) => ({
+export const createDecorationSpecFromMatch = (match: BaseMatch) => ({
   type: DECORATION_MATCH,
   id: match.matchId,
   categoryId: match.category.id,
@@ -145,7 +145,7 @@ export const createDecorationSpecFromMatch = (match: IMatch) => ({
   inclusiveEnd: false
 });
 
-export const getMatchType = (match: IMatch): MatchType => {
+export const getMatchType = (match: BaseMatch): MatchType => {
   if (match.markAsCorrect) {
     return MatchType.OK;
   }
@@ -156,7 +156,7 @@ export const getMatchType = (match: IMatch): MatchType => {
 };
 
 export const getColourForMatch = (
-  match: IMatch,
+  match: BaseMatch,
   matchColours: IMatchTypeToColourMap,
   isSelected: boolean
 ): { backgroundColour: string; borderColour: string } => {
@@ -205,7 +205,7 @@ export const getColourForMatchType = (
 };
 
 export const createDecorationsForMatches = (
-  matches: IMatch[],
+  matches: MappedMatch[],
 ) => flatten(matches.map(match => createDecorationsForMatch(match)));
 
 export const findSingleDecoration = (

--- a/src/ts/utils/decoration.ts
+++ b/src/ts/utils/decoration.ts
@@ -2,7 +2,7 @@ import { news, opinion, success } from "@guardian/src-foundations";
 import flatten from "lodash/flatten";
 import { Node } from "prosemirror-model";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import { IRange, MappedMatch, BaseMatch } from "../interfaces/IMatch";
+import { IRange, Match } from "../interfaces/IMatch";
 import { getSquiggleAsUri } from "./squiggle";
 
 export enum MatchType {
@@ -97,7 +97,7 @@ export const removeDecorationsFromRanges = (
  * returns a new decoration set containing the new matches.
  */
 export const getNewDecorationsForCurrentMatches = (
-  outputs: MappedMatch[],
+  outputs: Match[],
   decorationSet: DecorationSet,
   doc: Node
 ) => {
@@ -110,7 +110,7 @@ export const getNewDecorationsForCurrentMatches = (
  * Create decorations for the given match.
  */
 export const createDecorationsForMatch = (
-  match: MappedMatch,
+  match: Match,
   isSelected: boolean = false
 ) => {
   const matchType = getMatchType(match);
@@ -137,7 +137,7 @@ export const createDecorationsForMatch = (
   return decorations;
 };
 
-export const createDecorationSpecFromMatch = (match: BaseMatch) => ({
+export const createDecorationSpecFromMatch = (match: Match) => ({
   type: DECORATION_MATCH,
   id: match.matchId,
   categoryId: match.category.id,
@@ -145,7 +145,7 @@ export const createDecorationSpecFromMatch = (match: BaseMatch) => ({
   inclusiveEnd: false
 });
 
-export const getMatchType = (match: BaseMatch): MatchType => {
+export const getMatchType = (match: Match): MatchType => {
   if (match.markAsCorrect) {
     return MatchType.OK;
   }
@@ -156,7 +156,7 @@ export const getMatchType = (match: BaseMatch): MatchType => {
 };
 
 export const getColourForMatch = (
-  match: BaseMatch,
+  match: Match,
   matchColours: IMatchTypeToColourMap,
   isSelected: boolean
 ): { backgroundColour: string; borderColour: string } => {
@@ -205,7 +205,7 @@ export const getColourForMatchType = (
 };
 
 export const createDecorationsForMatches = (
-  matches: MappedMatch[],
+  matches: Match[],
 ) => flatten(matches.map(match => createDecorationsForMatch(match)));
 
 export const findSingleDecoration = (

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -1,5 +1,5 @@
-import { IBlockWithIgnoredRanges, IMatch, IRange } from "../interfaces/IMatch";
-import { mapAddedRange } from "./range";
+import { IBlockWithIgnoredRanges, IMatch, IRange, MappedMatch } from "../interfaces/IMatch";
+import { removeIgnoredRange } from "./range";
 
 /**
  * Map the range this match applies to through the given ranges, adjusting its range accordingly.
@@ -7,30 +7,37 @@ import { mapAddedRange } from "./range";
 export const mapThroughIgnoredRanges = <TMatch extends IMatch>(
   match: TMatch,
   ignoreRanges: IRange[]
-): TMatch => {
+): MappedMatch => {
   if (!ignoreRanges.length) {
-    return match;
+    return matchToMappedMatch(match)
+  }
+
+  const mappedMatch = {
+    ...match,
+    ranges: [{ from: match.from, to: match.to }]
   }
 
   const [newMatch] = ignoreRanges.reduce(
-    ([accMatch, rangesAlreadyApplied], range) => {
-      const initialRange = {
-        from: accMatch.from,
-        to: accMatch.to
-      };
-      const newMatchRange = mapAddedRange(initialRange, range);
+    ([accMatch, rangesAlreadyApplied], ignoreRange) => {
+      const newMatchRange = accMatch.ranges.flatMap(initialRange =>
+        removeIgnoredRange(initialRange, ignoreRange)
+      );
+
       const newRuleMatch = {
         ...accMatch,
-        from: newMatchRange.from,
-        to: newMatchRange.to
+        ranges: newMatchRange
       };
 
       return [newRuleMatch, rangesAlreadyApplied];
     },
-    [match, [] as Range[]]
+    [mappedMatch, [] as Range[]]
   );
 
-  return newMatch;
+  return {
+    ...newMatch,
+    from: Math.min(...newMatch.ranges.map(_ => _.from)),
+    to: Math.max(...newMatch.ranges.map(_ => _.to))
+  };
 };
 
 /**
@@ -39,12 +46,17 @@ export const mapThroughIgnoredRanges = <TMatch extends IMatch>(
 export const mapMatchThroughBlocks = <TMatch extends IMatch>(
   match: TMatch,
   blocks: IBlockWithIgnoredRanges[]
-): TMatch => {
+): MappedMatch => {
   const maybeBlockForThisMatch = blocks.find(
     block => match.from >= block.from && match.to <= block.to
   );
   if (!maybeBlockForThisMatch) {
-    return match;
+    return matchToMappedMatch(match);
   }
   return mapThroughIgnoredRanges(match, maybeBlockForThisMatch.ignoreRanges);
 };
+
+const matchToMappedMatch = (match: IMatch): MappedMatch => ({
+  ...match,
+  ranges: [{ from: match.from, to: match.to }]
+})

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -1,18 +1,18 @@
-import { IBlockWithSkippedRanges, IMatch, IRange } from "../interfaces/IMatch";
+import { IBlockWithIgnoredRanges, IMatch, IRange } from "../interfaces/IMatch";
 import { mapAddedRange } from "./range";
 
 /**
  * Map the range this match applies to through the given ranges, adjusting its range accordingly.
  */
-export const mapThroughSkippedRanges = <TMatch extends IMatch>(
+export const mapThroughIgnoredRanges = <TMatch extends IMatch>(
   match: TMatch,
-  skipRanges: IRange[]
+  ignoreRanges: IRange[]
 ): TMatch => {
-  if (!skipRanges.length) {
+  if (!ignoreRanges.length) {
     return match;
   }
 
-  const [newMatch] = skipRanges.reduce(
+  const [newMatch] = ignoreRanges.reduce(
     ([accMatch, rangesAlreadyApplied], range) => {
       const initialRange = {
         from: accMatch.from,
@@ -34,11 +34,11 @@ export const mapThroughSkippedRanges = <TMatch extends IMatch>(
 };
 
 /**
- * Map this match through the given blocks' skipped ranges.
+ * Map this match through the given blocks' ignored ranges.
  */
 export const mapMatchThroughBlocks = <TMatch extends IMatch>(
   match: TMatch,
-  blocks: IBlockWithSkippedRanges[]
+  blocks: IBlockWithIgnoredRanges[]
 ): TMatch => {
   const maybeBlockForThisMatch = blocks.find(
     block => match.from >= block.from && match.to <= block.to
@@ -46,5 +46,5 @@ export const mapMatchThroughBlocks = <TMatch extends IMatch>(
   if (!maybeBlockForThisMatch) {
     return match;
   }
-  return mapThroughSkippedRanges(match, maybeBlockForThisMatch.skipRanges);
+  return mapThroughIgnoredRanges(match, maybeBlockForThisMatch.ignoreRanges);
 };

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -1,13 +1,13 @@
-import { IBlockWithIgnoredRanges, IMatch, IRange, MappedMatch } from "../interfaces/IMatch";
+import { IBlockWithIgnoredRanges, IRange, Match, MatchFromTyperighter } from "../interfaces/IMatch";
 import { removeIgnoredRange } from "./range";
 
 /**
  * Map the range this match applies to through the given ranges, adjusting its range accordingly.
  */
-export const mapThroughIgnoredRanges = <TMatch extends IMatch>(
-  match: TMatch,
+export const mapThroughIgnoredRanges = (
+  match: MatchFromTyperighter,
   ignoreRanges: IRange[]
-): MappedMatch => {
+): Match => {
   if (!ignoreRanges.length) {
     return matchToMappedMatch(match)
   }
@@ -43,10 +43,10 @@ export const mapThroughIgnoredRanges = <TMatch extends IMatch>(
 /**
  * Map this match through the given blocks' ignored ranges.
  */
-export const mapMatchThroughBlocks = <TMatch extends IMatch>(
-  match: TMatch,
+export const mapMatchThroughBlocks = (
+  match: MatchFromTyperighter,
   blocks: IBlockWithIgnoredRanges[]
-): MappedMatch => {
+): Match => {
   const maybeBlockForThisMatch = blocks.find(
     block => match.from >= block.from && match.to <= block.to
   );
@@ -56,7 +56,7 @@ export const mapMatchThroughBlocks = <TMatch extends IMatch>(
   return mapThroughIgnoredRanges(match, maybeBlockForThisMatch.ignoreRanges);
 };
 
-const matchToMappedMatch = (match: IMatch): MappedMatch => ({
+const matchToMappedMatch = (match: MatchFromTyperighter): Match => ({
   ...match,
   ranges: [{ from: match.from, to: match.to }]
 })

--- a/src/ts/utils/match.ts
+++ b/src/ts/utils/match.ts
@@ -12,7 +12,7 @@ export const mapThroughIgnoredRanges = <TMatch extends IMatch>(
     return matchToMappedMatch(match)
   }
 
-  const mappedMatch = {
+  const initialMappedMatch = {
     ...match,
     ranges: [{ from: match.from, to: match.to }]
   }
@@ -30,7 +30,7 @@ export const mapThroughIgnoredRanges = <TMatch extends IMatch>(
 
       return [newRuleMatch, rangesAlreadyApplied];
     },
-    [mappedMatch, [] as Range[]]
+    [initialMappedMatch, [] as Range[]]
   );
 
   return {

--- a/src/ts/utils/plugin.ts
+++ b/src/ts/utils/plugin.ts
@@ -2,8 +2,8 @@ import { stopHoverCommand, stopHighlightCommand } from "../commands";
 import { EditorView } from "prosemirror-view";
 import { PluginKey } from "prosemirror-state";
 import { getMatchType, MatchType } from "./decoration";
-import { IMatch } from "..";
 import { IPluginState } from "../state/reducer";
+import { MappedMatch } from "../interfaces/IMatch";
 
 export const pluginKey = new PluginKey("prosemirror-typerighter");
 export const getState = (pluginKey as PluginKey<IPluginState>).getState.bind(
@@ -43,8 +43,8 @@ export type IDefaultFilterState = MatchType[];
  */
 export type IFilterMatches = (
   filterState: MatchType[],
-  matches: IMatch[]
-) => IMatch[];
+  matches: MappedMatch[]
+) => MappedMatch[];
 
 export const filterByMatchState: IFilterMatches = (filterState, matches) =>
   matches.filter(match => !filterState.includes(getMatchType(match)));

--- a/src/ts/utils/plugin.ts
+++ b/src/ts/utils/plugin.ts
@@ -3,7 +3,7 @@ import { EditorView } from "prosemirror-view";
 import { PluginKey } from "prosemirror-state";
 import { getMatchType, MatchType } from "./decoration";
 import { IPluginState } from "../state/reducer";
-import { MappedMatch } from "../interfaces/IMatch";
+import { Match } from "../interfaces/IMatch";
 
 export const pluginKey = new PluginKey("prosemirror-typerighter");
 export const getState = (pluginKey as PluginKey<IPluginState>).getState.bind(
@@ -43,8 +43,8 @@ export type IDefaultFilterState = MatchType[];
  */
 export type IFilterMatches = (
   filterState: MatchType[],
-  matches: MappedMatch[]
-) => MappedMatch[];
+  matches: Match[]
+) => Match[];
 
 export const filterByMatchState: IFilterMatches = (filterState, matches) =>
   matches.filter(match => !filterState.includes(getMatchType(match)));

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -217,10 +217,11 @@ export const getPatchesFromReplacementText = (
 export const applyPatchToTransaction = (
   tr: Transaction,
   schema: Schema<any>,
-  patch: ISuggestionPatch
+  patch: ISuggestionPatch,
+  preserveMarks?: boolean
 ) => {
   if (patch.type === "INSERT") {
-    const marks = patch.getMarks(tr);
+    const marks = preserveMarks ? patch.getMarks(tr) : [];
     const node = schema.text(patch.text, marks);
     return tr.insert(patch.from, node);
   }

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -209,6 +209,14 @@ export const getPatchesFromReplacementText = (
   return fragments;
 };
 
+export const getFirstMatchingChar = (str1: string, str2: string) => {
+  for (let i = 0; i < str1.length; i++) {
+    if (str1[i] === str2[0]) return i;
+  }
+
+  return 0;
+}
+
 /**
  * Apply a suggestion fragment to a transaction.
  *

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -222,18 +222,19 @@ export const getFirstMatchingChar = (str1: string, str2: string) => {
  *
  * Mutates the given transaction.
  */
-export const applyPatchToTransaction = (
+export const applyPatchesToTransaction = (
+  patches: ISuggestionPatch[],
   tr: Transaction,
-  schema: Schema<any>,
-  patch: ISuggestionPatch,
-  preserveMarks?: boolean
+  schema: Schema<any>
 ) => {
-  if (patch.type === "INSERT") {
-    const marks = preserveMarks ? patch.getMarks(tr) : [];
-    const node = schema.text(patch.text, marks);
-    return tr.insert(patch.from, node);
-  }
-  tr.delete(patch.from, patch.to);
+  patches.forEach((patch,) => {
+    if (patch.type === "INSERT") {
+      const marks = patch.getMarks(tr);
+      const node = schema.text(patch.text, marks);
+      return tr.insert(patch.from, node);
+    }
+    tr.delete(patch.from, patch.to);
+  })
 };
 
 /**

--- a/src/ts/utils/prosemirror.ts
+++ b/src/ts/utils/prosemirror.ts
@@ -3,8 +3,8 @@ import { Transaction } from "prosemirror-state";
 import { Change, ChangeSet } from "prosemirror-changeset";
 import * as jsDiff from "diff";
 
-import { IBlockWithSkippedRanges, IRange } from "../interfaces/IMatch";
-import { createBlock, doNotSkipRanges, TGetSkippedRanges } from "./block";
+import { IBlockWithIgnoredRanges, IRange } from "../interfaces/IMatch";
+import { createBlock, doNotIgnoreRanges, GetIgnoredRanges } from "./block";
 
 export const MarkTypes = {
   legal: "legal",
@@ -45,9 +45,9 @@ export const findChildren = (
 export const getBlocksFromDocument = (
   doc: Node,
   time = 0,
-  getIgnoredRanges: TGetSkippedRanges = doNotSkipRanges
-): IBlockWithSkippedRanges[] => {
-  const ranges = [] as IBlockWithSkippedRanges[];
+  getIgnoredRanges: GetIgnoredRanges = doNotIgnoreRanges
+): IBlockWithIgnoredRanges[] => {
+  const ranges = [] as IBlockWithIgnoredRanges[];
   doc.descendants((descNode, pos) => {
     if (!findChildren(descNode, _ => _.type.isBlock, false).length) {
       ranges.push(

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -236,26 +236,44 @@ export const mapRemovedRange = (
 };
 
 /**
- * Map a from and to position through the given added range.
+ * Remove an ignored range from the given range, adjusting `from` and `to`,
+ * and splitting the range into two if the ignored range intersects.
  */
-export const mapAddedRange = (
+export const removeIgnoredRange = (
   currentRange: IRange,
-  addedRange: IRange
-): IRange => {
+  rangeToIgnore: IRange
+): IRange[] => {
   // We add one to our lengths here to ensure the to value
   // is placed beyond the last position the range occupies.
-  const lengthOfAddedRange = addedRange.to - addedRange.from;
+  const lengthOfAddedRange = rangeToIgnore.to - rangeToIgnore.from;
   const charsAddedBeforeFrom =
-    addedRange.from <= currentRange.from ? lengthOfAddedRange + 1 : 0;
-  const intersection = getIntersection(currentRange, addedRange);
+    rangeToIgnore.from <= currentRange.from ? lengthOfAddedRange + 1 : 0;
+  const intersection = getIntersection(currentRange, rangeToIgnore);
   const charsAddedBeforeTo = intersection
     ? lengthOfAddedRange + 1
     : charsAddedBeforeFrom;
 
-  const from = currentRange.from + charsAddedBeforeFrom;
-  const to = currentRange.to + charsAddedBeforeTo;
+  if (!intersection) {
+    const from = currentRange.from + charsAddedBeforeFrom;
+    const to = currentRange.to + charsAddedBeforeTo;
 
-  return { from, to };
+    return [{ from, to }];
+  }
+
+  const rangeBeforeIntersection = {
+    from: currentRange.from,
+    to: intersection.from - 1
+  }
+
+  const rangeAfterIntersection = {
+    from: currentRange.from + charsAddedBeforeTo,
+    to: currentRange.to + charsAddedBeforeTo
+  }
+
+  return [
+    rangeBeforeIntersection,
+    rangeAfterIntersection
+  ].filter(rangeHasLength)
 };
 
 export const getIntersection = (
@@ -268,3 +286,5 @@ export const getIntersection = (
   };
   return range.from < range.to ? range : undefined;
 };
+
+export const rangeHasLength = (range: IRange) => range.from < range.to;

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -196,6 +196,10 @@ const getCharsRemovedBeforeFrom = (
     return 0;
   }
 
+  if (removedRange.to > currentRange.to) {
+    return removedRange.to - removedRange.from;
+  }
+
   const rangeBetweenRemovedStartAndIncomingStart = {
     from: removedRange.from,
     to: currentRange.from
@@ -212,6 +216,17 @@ const getCharsRemovedBeforeFrom = (
   return 1; // If there's no intersection, this is a range from (n, n), which is one char long
 };
 
+const getCharsRemovedBeforeTo = (
+  currentRange: IRange,
+  removedRange: IRange
+) => {
+  const charsRemovedBeforeFrom = getCharsRemovedBeforeFrom(currentRange, removedRange);
+  const intersection = getIntersection(currentRange, removedRange);
+  return intersection
+    ? charsRemovedBeforeFrom + (intersection.to - intersection.from)
+    : charsRemovedBeforeFrom;
+}
+
 /**
  * Map a from and to position through the given removed range.
  */
@@ -223,11 +238,7 @@ export const mapRemovedRange = (
     currentRange,
     removedRange
   );
-
-  const intersection = getIntersection(currentRange, removedRange);
-  const charsRemovedBeforeTo = intersection
-    ? charsRemovedBeforeFrom + (intersection.to - intersection.from)
-    : charsRemovedBeforeFrom;
+  const charsRemovedBeforeTo = getCharsRemovedBeforeTo(currentRange, removedRange);
 
   const from = currentRange.from - charsRemovedBeforeFrom;
   const to = currentRange.to - charsRemovedBeforeTo;
@@ -236,38 +247,59 @@ export const mapRemovedRange = (
 };
 
 /**
+ * Map a from and to position through the given added range.
+ */
+export const mapAddedRange = (
+  currentRange: IRange,
+  removedRange: IRange
+): IRange => {
+  const removedRangeLength = getRangeLength(removedRange);
+
+  // The removed range occurs before the current range.
+  // Push the current range rightwards to accommodate the removed range.
+  if (removedRange.from < currentRange.from) {
+    return {
+      from: currentRange.from + removedRangeLength + 1,
+      to: currentRange.to + removedRangeLength + 1
+    }
+  }
+
+  // The removed range occurs after the current range.
+  // It does not affect the current range.
+  if (removedRange.from >= currentRange.to) {
+    return currentRange;
+  }
+
+  // The removed range occurs in the middle of the current range.
+  // It stretches rightwards to accommodate the removed range.
+  return { from: currentRange.from, to: currentRange.to + removedRangeLength };
+};
+
+/**
  * Remove an ignored range from the given range, adjusting `from` and `to`,
  * and splitting the range into two if the ignored range intersects.
  */
 export const removeIgnoredRange = (
-  currentRange: IRange,
+  _currentRange: IRange,
   rangeToIgnore: IRange
 ): IRange[] => {
   // We add one to our lengths here to ensure the to value
   // is placed beyond the last position the range occupies.
-  const lengthOfAddedRange = rangeToIgnore.to - rangeToIgnore.from;
-  const charsAddedBeforeFrom =
-    rangeToIgnore.from <= currentRange.from ? lengthOfAddedRange + 1 : 0;
+  const currentRange = mapAddedRange(_currentRange, rangeToIgnore);
   const intersection = getIntersection(currentRange, rangeToIgnore);
-  const charsAddedBeforeTo = intersection
-    ? lengthOfAddedRange + 1
-    : charsAddedBeforeFrom;
 
   if (!intersection) {
-    const from = currentRange.from + charsAddedBeforeFrom;
-    const to = currentRange.to + charsAddedBeforeTo;
-
-    return [{ from, to }];
+    return [currentRange];
   }
 
   const rangeBeforeIntersection = {
     from: currentRange.from,
-    to: intersection.from - 1
+    to: intersection.from
   }
 
   const rangeAfterIntersection = {
-    from: currentRange.from + charsAddedBeforeTo,
-    to: currentRange.to + charsAddedBeforeTo
+    from: rangeToIgnore.to + 1,
+    to: currentRange.to + 1
   }
 
   return [
@@ -284,7 +316,9 @@ export const getIntersection = (
     from: Math.max(rangeA.from, rangeB.from),
     to: Math.min(rangeA.to, rangeB.to)
   };
-  return range.from < range.to ? range : undefined;
+  return range.from <= range.to ? range : undefined;
 };
+
+const getRangeLength = (range: IRange) => range.to - range.from;
 
 export const rangeHasLength = (range: IRange) => range.from < range.to;

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -9,6 +9,18 @@ export const isPosWithinRange = (pos: number, range: IRange) =>
   pos >= range.from && pos <= range.to;
 
 /**
+ * Get the ranges between the given ranges, inclusive of start and end.
+ *
+ * For example, passing `[{ from: 1, to: 2 }, { from: 3, to: 4 }]` would
+ * yield `[{ from: 2, to: 3 }]`.
+ */
+export const invertRanges = (ranges: IRange[]): IRange[] => ranges
+  .flatMap((_, index) =>
+    index < ranges.length - 1
+      ? [{ from: ranges[index].to, to: ranges[index + 1].from }]
+      : [])
+
+/**
  * Find the index of the first range in the given range array that overlaps/abuts with the given range.
  */
 export const findOverlappingRangeIndex = (range: IRange, ranges: IRange[]) =>

--- a/src/ts/utils/range.ts
+++ b/src/ts/utils/range.ts
@@ -5,6 +5,9 @@ import { IRange } from "../interfaces/IMatch";
 import { IBlock } from "../interfaces/IMatch";
 import { Mapping } from "prosemirror-transform";
 
+export const isPosWithinRange = (pos: number, range: IRange) =>
+  pos >= range.from && pos <= range.to;
+
 /**
  * Find the index of the first range in the given range array that overlaps/abuts with the given range.
  */

--- a/src/ts/utils/test/block.spec.ts
+++ b/src/ts/utils/test/block.spec.ts
@@ -1,24 +1,24 @@
-import { removeSkippedRanges } from "../block";
+import { removeIgnoredRanges } from "../block";
 
 describe("Block utils", () => {
-  describe("removeSkippedRanges", () => {
-    it("should remove the passed skipped range from the block text", () => {
-      const skipRanges = [{ from: 18, to: 25 }];
+  describe("removeIgnoredRanges", () => {
+    it("should remove the passed ignored range from the block text", () => {
+      const ignoreRanges = [{ from: 18, to: 25 }];
       const block = {
         id: "id",
         text: "Example [noted ]text",
         from: 10,
         to: 28,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
       expect(newBlock.text).toBe("Example text");
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(22);
     });
 
-    it("should remove multiple adjacent skipped ranges from the block text", () => {
-      const skipRanges = [
+    it("should remove multiple adjacent ignored ranges from the block text", () => {
+      const ignoreRanges = [
         { from: 18, to: 25 },
         { from: 26, to: 32 }
       ];
@@ -27,17 +27,17 @@ describe("Block utils", () => {
         text: "Example [noted][noted ]text",
         from: 10,
         to: 37,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
 
       expect(newBlock.text).toBe("Example text");
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(22);
     });
 
-    it("should remove multiple non-adjacent skipped ranges from the block text - 1", () => {
-      const skipRanges = [
+    it("should remove multiple non-adjacent ignored ranges from the block text - 1", () => {
+      const ignoreRanges = [
         { from: 18, to: 25 },
         { from: 41, to: 48 }
       ];
@@ -46,16 +46,16 @@ describe("Block utils", () => {
         text: "Example [noted ]text with more [noted ]text",
         from: 10,
         to: 52,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
       expect(newBlock.text).toBe("Example text with more text");
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(37);
     });
 
-    it("should remove multiple non-adjacent skipped ranges from the block text - 2", () => {
-      const skipRanges = [
+    it("should remove multiple non-adjacent ignored ranges from the block text - 2", () => {
+      const ignoreRanges = [
         { from: 40, to: 42 },
         { from: 44, to: 45 },
         { from: 47, to: 48 }
@@ -65,9 +65,9 @@ describe("Block utils", () => {
         text: "ABCDEFGHIJ",
         from: 40,
         to: 47,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
 
       expect(newBlock.text).toBe("DGJ");
       expect(newBlock.from).toBe(40);
@@ -75,7 +75,7 @@ describe("Block utils", () => {
     });
 
     it("should not care about order", () => {
-      const skipRanges = [
+      const ignoreRanges = [
         { from: 24, to: 31 },
         { from: 18, to: 24 }
       ];
@@ -84,15 +84,15 @@ describe("Block utils", () => {
         text: "Example [noted][noted ]text",
         from: 10,
         to: 37,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
       expect(newBlock.text).toBe("Example text");
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(22);
     });
-    it("should yield the same result if the skipped ranges overlap", () => {
-      const skipRanges = [
+    it("should yield the same result if the ignored ranges overlap", () => {
+      const ignoreRanges = [
         { from: 24, to: 31 },
         { from: 18, to: 26 }
       ];
@@ -101,15 +101,15 @@ describe("Block utils", () => {
         text: "Example [noted][noted ]text",
         from: 10,
         to: 37,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
       expect(newBlock.text).toBe("Example text");
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(22);
     });
-    it("should trim to the end of the text if the skipped ranges go beyond the block", () => {
-      const skipRanges = [
+    it("should trim to the end of the text if the ignored ranges go beyond the block", () => {
+      const ignoreRanges = [
         { from: 17, to: 1000 }
       ];
       const block = {
@@ -117,15 +117,15 @@ describe("Block utils", () => {
         text: "Example[ text",
         from: 10,
         to: 23,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
       expect(newBlock.text).toBe("Example");
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(17);
     });
-    it("should trim to the beginning of the text if the skipped ranges precede the block", () => {
-      const skipRanges = [
+    it("should trim to the beginning of the text if the ignored ranges precede the block", () => {
+      const ignoreRanges = [
         { from: 0, to: 18 }
       ];
       const block = {
@@ -133,9 +133,9 @@ describe("Block utils", () => {
         text: "Example] text",
         from: 10,
         to: 23,
-        skipRanges
+        ignoreRanges
       };
-      const newBlock = removeSkippedRanges(block);
+      const newBlock = removeIgnoredRanges(block);
       expect(newBlock.text).toBe("text");
       expect(newBlock.from).toBe(10);
       expect(newBlock.to).toBe(14);

--- a/src/ts/utils/test/decoration.spec.ts
+++ b/src/ts/utils/test/decoration.spec.ts
@@ -4,7 +4,6 @@ import {
   MatchType
 } from "../decoration";
 import { createMatch } from "../../test/helpers/fixtures";
-import { IMatch } from "../../interfaces/IMatch";
 
 describe("Decoration utils", () => {
   describe("createDecorationsForMatch", () => {
@@ -33,7 +32,7 @@ describe("Decoration utils", () => {
       ]);
     });
     it("should add an 'is correct' marker if markAsCorrect is set", () => {
-      const match = { ...createMatch(0, 5), markAsCorrect: true } as IMatch;
+      const match = { ...createMatch(0, 5), markAsCorrect: true };
       const decorations = createDecorationsForMatch(match);
       expect(decorations).toMatchObject([
         {

--- a/src/ts/utils/test/match.spec.ts
+++ b/src/ts/utils/test/match.spec.ts
@@ -1,8 +1,8 @@
-import { IMatch } from "../..";
+import { MatchFromTyperighter } from "../../interfaces/IMatch";
 import { mapThroughIgnoredRanges } from "../match";
 
 describe("Match helpers", () => {
-  const getRuleMatch = (from: number, to: number): IMatch => ({
+  const getRuleMatch = (from: number, to: number): MatchFromTyperighter => ({
     ruleId: "rule-id",
     category: { id: "category-id", name: "Category", colour: "puce" },
     from,

--- a/src/ts/utils/test/match.spec.ts
+++ b/src/ts/utils/test/match.spec.ts
@@ -22,40 +22,35 @@ describe("Match helpers", () => {
       const ruleMatch = getRuleMatch(10, 15);
       const ignoredRange = [{ from: 0, to: 5 }];
       const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
-      expect(mappedMatch.from).toBe(16);
-      expect(mappedMatch.to).toBe(21);
+      expect(mappedMatch.ranges).toEqual([{ from: 16, to: 21 }]);
     });
 
     it("should account for a range ignored within the given range", () => {
       const ruleMatch = getRuleMatch(10, 15);
       const ignoredRange = [{ from: 10, to: 15 }];
       const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
-      expect(mappedMatch.from).toBe(16);
-      expect(mappedMatch.to).toBe(21);
+      expect(mappedMatch.ranges).toEqual([{ from: 16, to: 21 }]);
     });
 
     it("should account for a range ignored within the given range, and extending beyond it", () => {
       const ruleMatch = getRuleMatch(8, 12);
       const ignoredRange = [{ from: 8, to: 15 }];
       const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
-      expect(mappedMatch.from).toBe(16);
-      expect(mappedMatch.to).toBe(20);
+      expect(mappedMatch.ranges).toEqual([{ from: 16, to: 20 }]);
     });
 
     it("should account for a range ignored partially within the given range – left hand side", () => {
       const ruleMatch = getRuleMatch(10, 15);
       const ignoredRange = [{ from: 5, to: 12 }];
       const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
-      expect(mappedMatch.from).toBe(18);
-      expect(mappedMatch.to).toBe(23);
+      expect(mappedMatch.ranges).toEqual([{ from: 18, to: 23 }]);
     });
 
     it("should account for a range ignored partially the given range – right hand side", () => {
       const ruleMatch = getRuleMatch(10, 15);
       const ignoredRange = [{ from: 13, to: 20 }];
       const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
-      expect(mappedMatch.from).toBe(10);
-      expect(mappedMatch.to).toBe(23);
+      expect(mappedMatch.ranges).toEqual([{ from: 10, to: 12 }, { from: 18, to: 23}]);
     });
 
     it("should account for multiple ranges", () => {
@@ -66,8 +61,7 @@ describe("Match helpers", () => {
         { from: 40, to: 47 }
       ];
       const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
-      expect(mappedMatch.from).toBe(26);
-      expect(mappedMatch.to).toBe(30);
+      expect(mappedMatch.ranges).toEqual([{ from: 26, to: 30 }]);
     });
   });
 });

--- a/src/ts/utils/test/match.spec.ts
+++ b/src/ts/utils/test/match.spec.ts
@@ -50,7 +50,7 @@ describe("Match helpers", () => {
       const ruleMatch = getRuleMatch(10, 15);
       const ignoredRange = [{ from: 13, to: 20 }];
       const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
-      expect(mappedMatch.ranges).toEqual([{ from: 10, to: 12 }, { from: 18, to: 23}]);
+      expect(mappedMatch.ranges).toEqual([{ from: 10, to: 13 }, { from: 21, to: 23 }]);
     });
 
     it("should account for multiple ranges", () => {

--- a/src/ts/utils/test/match.spec.ts
+++ b/src/ts/utils/test/match.spec.ts
@@ -1,5 +1,5 @@
 import { IMatch } from "../..";
-import { mapThroughSkippedRanges } from "../match";
+import { mapThroughIgnoredRanges } from "../match";
 
 describe("Match helpers", () => {
   const getRuleMatch = (from: number, to: number): IMatch => ({
@@ -17,43 +17,43 @@ describe("Match helpers", () => {
     groupKey: "group-key"
   });
 
-  describe("mapMatchThroughSkippedRanges", () => {
-    it("should account for a range skipped before the given range", () => {
+  describe("mapMatchThroughIgnoredRanges", () => {
+    it("should account for a range ignored before the given range", () => {
       const ruleMatch = getRuleMatch(10, 15);
-      const skippedRange = [{ from: 0, to: 5 }];
-      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      const ignoredRange = [{ from: 0, to: 5 }];
+      const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
       expect(mappedMatch.from).toBe(16);
       expect(mappedMatch.to).toBe(21);
     });
 
-    it("should account for a range skipped within the given range", () => {
+    it("should account for a range ignored within the given range", () => {
       const ruleMatch = getRuleMatch(10, 15);
-      const skippedRange = [{ from: 10, to: 15 }];
-      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      const ignoredRange = [{ from: 10, to: 15 }];
+      const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
       expect(mappedMatch.from).toBe(16);
       expect(mappedMatch.to).toBe(21);
     });
 
-    it("should account for a range skipped within the given range, and extending beyond it", () => {
+    it("should account for a range ignored within the given range, and extending beyond it", () => {
       const ruleMatch = getRuleMatch(8, 12);
-      const skippedRange = [{ from: 8, to: 15 }];
-      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      const ignoredRange = [{ from: 8, to: 15 }];
+      const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
       expect(mappedMatch.from).toBe(16);
       expect(mappedMatch.to).toBe(20);
     });
 
-    it("should account for a range skipped partially within the given range – left hand side", () => {
+    it("should account for a range ignored partially within the given range – left hand side", () => {
       const ruleMatch = getRuleMatch(10, 15);
-      const skippedRange = [{ from: 5, to: 12 }];
-      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      const ignoredRange = [{ from: 5, to: 12 }];
+      const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
       expect(mappedMatch.from).toBe(18);
       expect(mappedMatch.to).toBe(23);
     });
 
-    it("should account for a range skipped partially the given range – right hand side", () => {
+    it("should account for a range ignored partially the given range – right hand side", () => {
       const ruleMatch = getRuleMatch(10, 15);
-      const skippedRange = [{ from: 13, to: 20 }];
-      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      const ignoredRange = [{ from: 13, to: 20 }];
+      const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
       expect(mappedMatch.from).toBe(10);
       expect(mappedMatch.to).toBe(23);
     });
@@ -61,11 +61,11 @@ describe("Match helpers", () => {
     it("should account for multiple ranges", () => {
       // E.g. "Example [noted ]text with more [noted ]text"
       const ruleMatch = getRuleMatch(18, 22);
-      const skippedRange = [
+      const ignoredRange = [
         { from: 18, to: 25 },
         { from: 40, to: 47 }
       ];
-      const mappedMatch = mapThroughSkippedRanges(ruleMatch, skippedRange);
+      const mappedMatch = mapThroughIgnoredRanges(ruleMatch, ignoredRange);
       expect(mappedMatch.from).toBe(26);
       expect(mappedMatch.to).toBe(30);
     });

--- a/src/ts/utils/test/prosemirror.spec.ts
+++ b/src/ts/utils/test/prosemirror.spec.ts
@@ -5,7 +5,7 @@ import {
   nodeContainsText
 } from "../prosemirror";
 import { flatten } from "prosemirror-utils";
-import { doNotSkipRanges } from "../block";
+import { doNotIgnoreRanges } from "../block";
 import { createEditor } from "../../test/helpers/createEditor";
 
 describe("Prosemirror utils", () => {
@@ -16,34 +16,34 @@ describe("Prosemirror utils", () => {
         p("Paragraph 2"),
         p(ul(li("List item 1"), li("List item 2")))
       );
-      expect(getBlocksFromDocument(node, 0, doNotSkipRanges)).toEqual([
+      expect(getBlocksFromDocument(node, 0, doNotIgnoreRanges)).toEqual([
         {
           from: 1,
           to: 13,
           text: "Paragraph 1",
           id: "0-from:1-to:13",
-          skipRanges: []
+          ignoreRanges: []
         },
         {
           from: 14,
           to: 26,
           text: "Paragraph 2",
           id: "0-from:14-to:26",
-          skipRanges: []
+          ignoreRanges: []
         },
         {
           from: 29,
           to: 41,
           text: "List item 1",
           id: "0-from:29-to:41",
-          skipRanges: []
+          ignoreRanges: []
         },
         {
           from: 42,
           to: 54,
           text: "List item 2",
           id: "0-from:42-to:54",
-          skipRanges: []
+          ignoreRanges: []
         }
       ]);
     });

--- a/src/ts/utils/test/range.spec.ts
+++ b/src/ts/utils/test/range.spec.ts
@@ -6,7 +6,8 @@ import {
   expandRangesToParentBlockNodes,
   mapRemovedRange,
   getIntersection,
-  removeIgnoredRange
+  removeIgnoredRange,
+  mapAddedRange
 } from "../range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
 
@@ -347,6 +348,36 @@ describe("Range utils", () => {
       }]);
     });
 
+    it("should account for a range that touches the given range – left hand side", () => {
+      const currentRange = { from: 10, to: 15 };
+      const ignoredRange = { from: 0, to: 10 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([{
+        from: 21,
+        to: 26
+      }]);
+    });
+
+    it("should account for a range that touches the given range – right hand side", () => {
+      const currentRange = { from: 10, to: 15 };
+      const ignoredRange = { from: 15, to: 20 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([{
+        from: 10,
+        to: 15
+      }]);
+    });
+
+    it("should account for an ignored range that begins within the match and touches right hand side", () => {
+      const currentRange = { from: 5, to: 14 };
+      const ignoredRange = { from: 10, to: 17 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([{
+        from: 5,
+        to: 10
+      }, {
+        from: 18,
+        to: 22
+      }]);
+    });
+
     it("should account for a range added within the given range", () => {
       const currentRange = { from: 10, to: 15 };
       const ignoredRange = { from: 10, to: 15 };
@@ -371,11 +402,37 @@ describe("Range utils", () => {
       expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([
         {
           from: 10,
-          to: 12
+          to: 13
         },
         {
-          from: 18,
+          from: 21,
           to: 23
+        }
+      ]);
+    });
+
+    it("should handle ignored ranges of a single char", () => {
+      const currentRange = { from: 10, to: 15 };
+      const ignoredRange = { from: 13, to: 13 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([
+        {
+          from: 10,
+          to: 13
+        },
+        {
+          from: 14,
+          to: 16
+        }
+      ]);
+    });
+
+    it("should handle ignored ranges when they touch a current range", () => {
+      const currentRange = {from: 16, to: 22};
+      const ignoredRange = {from: 6, to: 16};
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([
+        {
+          from: 27,
+          to: 33
         }
       ]);
     });
@@ -416,6 +473,53 @@ describe("Range utils", () => {
       });
     });
   });
+
+  describe("mapAddedRange", () => {
+    it("should account for a range added before the given range", () => {
+      const currentRange = {
+        from: 4,
+        to: 9
+      };
+      const removedRange = { from: 0, to: 5 };
+      expect(mapAddedRange(currentRange, removedRange)).toEqual({ from: 10, to: 15 });
+    });
+
+    it("should account for a range completely added within the given range", () => {
+      const currentRange = {
+        from: 10,
+        to: 10
+      };
+      const removedRange = { from: 10, to: 15 };
+      expect(mapAddedRange(currentRange, removedRange)).toEqual({ from: 10, to: 10 });
+    });
+    it("should account for a range partially added within the given range – left hand side", () => {
+      const currentRange = {
+        from: 4,
+        to: 7
+      };
+      const removedRange = { from: 5, to: 12 };
+      expect(mapAddedRange(currentRange, removedRange)).toEqual({ from: 4, to: 14 });
+    });
+
+    it("should account for a range partially added within the given range – right hand side", () => {
+      const currentRange = {
+        from: 10,
+        to: 13
+      };
+      const removedRange = { from: 13, to: 20 };
+      expect(mapAddedRange(currentRange, removedRange)).toEqual({ from: 10, to: 13 });
+    });
+
+    it("should ignore ranges after the current range", () => {
+      const currentRange = {
+        from: 10,
+        to: 13
+      };
+      const removedRange = { from: 14, to: 20 };
+      expect(mapAddedRange(currentRange, removedRange)).toEqual(currentRange);
+    });
+  });
+
   describe("getIntersectionOfRanges", () => {
     it("should return an option containing a new range representing the intersection of two ranges", () => {
       const rangeA = { from: 0, to: 5 };

--- a/src/ts/utils/test/range.spec.ts
+++ b/src/ts/utils/test/range.spec.ts
@@ -6,7 +6,7 @@ import {
   expandRangesToParentBlockNodes,
   mapRemovedRange,
   getIntersection,
-  mapAddedRange
+  removeIgnoredRange
 } from "../range";
 import { createDoc, p } from "../../test/helpers/prosemirror";
 
@@ -337,41 +337,47 @@ describe("Range utils", () => {
       ]);
     });
   });
-  describe("mapAddedRange", () => {
+  describe("removeIgnoredRange", () => {
     it("should account for a range added before the given range", () => {
       const currentRange = { from: 10, to: 15 };
-      const addedRange = { from: 0, to: 5 };
-      expect(mapAddedRange(currentRange, addedRange)).toEqual({
+      const ignoredRange = { from: 0, to: 5 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([{
         from: 16,
         to: 21
-      });
+      }]);
     });
 
     it("should account for a range added within the given range", () => {
       const currentRange = { from: 10, to: 15 };
-      const addedRange = { from: 10, to: 15 };
-      expect(mapAddedRange(currentRange, addedRange)).toEqual({
+      const ignoredRange = { from: 10, to: 15 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([{
         from: 16,
         to: 21
-      });
+      }]);
     });
 
     it("should account for a range added partially within the given range – left hand side", () => {
       const currentRange = { from: 10, to: 15 };
-      const addedRange = { from: 5, to: 12 };
-      expect(mapAddedRange(currentRange, addedRange)).toEqual({
+      const ignoredRange = { from: 5, to: 12 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([{
         from: 18,
         to: 23
-      });
+      }]);
     });
 
     it("should account for a range added partially the given range – right hand side", () => {
       const currentRange = { from: 10, to: 15 };
-      const addedRange = { from: 13, to: 20 };
-      expect(mapAddedRange(currentRange, addedRange)).toEqual({
-        from: 10,
-        to: 23
-      });
+      const ignoredRange = { from: 13, to: 20 };
+      expect(removeIgnoredRange(currentRange, ignoredRange)).toEqual([
+        {
+          from: 10,
+          to: 12
+        },
+        {
+          from: 18,
+          to: 23
+        }
+      ]);
     });
   });
   describe("mapRemovedRange", () => {


### PR DESCRIPTION
## What does this change?

Adds internal support for multi-range matches for ignored ranges. Matches can now span an ignored range. Suggestions applied to that range will map around the ignored range, preserving styling where possible.

![styling](https://github.com/guardian/prosemirror-typerighter/assets/7767575/f095e9f2-5038-4c36-815e-59fc4d1ded77)

Ignored ranges are not passed on to the Typerighter service, so this change only affects plugin consumers. For them, this is a breaking change, as some public apis that expect a single `IRange` now receive `IRange[]`.

### How does suggestion insertion work?

If the match is split into multiple ranges, the code attempts to preserve a reasonable split between ranges by allocating the suggestion characters across the original ranges. Extra characters are appended.

For example, given:
  - the match `ex-a-mple`, where dashes denote splits in the match
  - the suggestion `ample`

We get the result `am-p-le`, preserving the position of the ignored ranges, rather than something like `ample--`.

### How does suggestion styling work?

When inserting new content, we map the positions from the insertion back to the original document, and use those positions and the original document to derive marks.

For example, the following text:

```
<strong>exampl</strong> suggestion
        |    |
        1    5
```

might produce the suggestion `example`, spanning `1,6`. This produces the patch `insert e` at `6`. We use the inverse of the transaction [mapping](https://prosemirror.net/docs/ref/#transform.Transform.mapping) produced by the edit to map the position`6` to the original position `5`, from which we can copy the new marks.

The mappings account for ignored ranges, so we only derive styling from unignored copy. See the GIF for examples of this behaviour in practice.

(In adding more tests for this method, I've found that this catches an edge case in our [previous code](https://github.com/guardian/prosemirror-typerighter/pull/127) where we were ignoring styling in single width ranges.)

## How to test

- The automated tests should pass, testing the new functionality.
- Have a play in the sandbox environment – Typerighter now ignores any text that is noted. Add the 'note' mark to text by selecting a range and hitting F10. You should be able to see suggestions being applied correctly, with styling preserved:

## Todo

- [x] ~Test in a consuming application.~ Tested in Composer.