### PR TITLE
feat: Trivial readme change to trigger release

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,7 @@
 
 ![](https://travis-ci.org/guardian/prosemirror-typerighter.svg?branch=main) [![Coverage Status](https://coveralls.io/repos/github/guardian/prosemirror-typerighter/badge.svg?branch=main)](https://coveralls.io/github/guardian/prosemirror-typerighter?branch=main)
 
-This Prosemirror plugin adds the ability to validate a document by sending it, or some parts of it, to an external service for validation. Once instantiated, it provides a store object that allows consumer code to subscribe to state updates for UI updates etc.
-
-It's still in its early stages! [There's a demo here.](https://guardian.github.io/prosemirror-typerighter/) See the 'pages' directory for an example implementation.
+This Prosemirror plugin adds the ability to validate a document by sending it, or some parts of it, to an external service for validation.
 
 ## Installation
 


### PR DESCRIPTION
See previous PR: https://github.com/guardian/prosemirror-typerighter/pull/266

(The demo is out of date, and this library is no longer in its early stages)