### PR TITLE
fix: Only update consumers when state changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@mui/material": "^5.9.0",
         "@popperjs/core": "^2.4.4",
         "diff": "^4.0.2",
+        "immer": "^10.1.1",
         "lodash": "^4.17.11",
         "prosemirror-changeset": "^2.2.0",
         "prosemirror-example-setup": "^1.2.1",
@@ -4999,6 +5000,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/immutable": {
@@ -13964,6 +13974,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
+    },
+    "immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw=="
     },
     "immutable": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@mui/material": "^5.9.0",
     "@popperjs/core": "^2.4.4",
     "diff": "^4.0.2",
+    "immer": "^10.1.1",
     "lodash": "^4.17.11",
     "prosemirror-changeset": "^2.2.0",
     "prosemirror-example-setup": "^1.2.1",

--- a/src/ts/components/Controls.tsx
+++ b/src/ts/components/Controls.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect, useContext } from "react";
 import { v4 } from "uuid";
 import { IconButton } from "@mui/material";
 import { DeleteForever } from "@mui/icons-material";
-import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
-import { IPluginState } from "../state/reducer";
+import Store, { STORE_EVENT_NEW_STATE, StoreState } from "../state/store";
 import { ICategory } from "../interfaces/IMatch";
 import {
   selectHasGeneralError,
@@ -32,7 +31,7 @@ interface IProps {
 }
 
 const getErrorFeedbackLink = (
-  pluginState: IPluginState | undefined,
+  pluginState: StoreState | undefined,
   feedbackHref: string | undefined
 ) => {
   const errorLimit = 10;
@@ -58,7 +57,7 @@ const Controls = ({
   setShowPendingInflightChecks,
   setTyperighterEnabled
 }: IProps) => {
-  const [pluginState, setPluginState] = useState<IPluginState | undefined>(
+  const [pluginState, setPluginState] = useState<StoreState | undefined>(
     undefined
   );
 

--- a/src/ts/components/MatchOverlay.tsx
+++ b/src/ts/components/MatchOverlay.tsx
@@ -1,10 +1,9 @@
 import Match from "./Match";
 import React, { useState, useEffect, useRef } from "react";
-import { IPluginState } from "../state/reducer";
 import { selectMatchByMatchId } from "../state/selectors";
 import { Match as TMatch } from "../interfaces/IMatch";
 import { maybeGetDecorationElement } from "../utils/decoration";
-import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
+import Store, { StoreState, STORE_EVENT_NEW_STATE } from "../state/store";
 import { ApplySuggestionOptions } from "../commands";
 import { usePopper } from "react-popper";
 import { debounce } from "lodash"
@@ -27,7 +26,7 @@ const matchOverlay = ({
   stopHover,
   store
 }: IProps) => {
-  const [pluginState, setPluginState] = useState<IPluginState | undefined>(
+  const [pluginState, setPluginState] = useState<StoreState | undefined>(
     undefined
   );
   const [currentMatchId, setCurrentMatchId] = useState<string | undefined>(
@@ -51,7 +50,7 @@ const matchOverlay = ({
     // Subscribe to the plugin state. We keep a separate reference to the
     // currentMatchId so we can create an effect that watches for it changing.
     // If we watched the whole plugin state, we'd have a lot of redundant calls.
-    const updateState = (newState: IPluginState) => {
+    const updateState = (newState: StoreState) => {
       setPluginState(newState);
       setCurrentMatchId(newState.hoverId);
       setCurrentRectIndex(newState.hoverRectIndex);

--- a/src/ts/components/Results.tsx
+++ b/src/ts/components/Results.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import sortBy from "lodash/sortBy";
-import Store, { STORE_EVENT_NEW_STATE } from "../state/store";
-import { IPluginState } from "../state/reducer";
+import Store, { StoreState, STORE_EVENT_NEW_STATE } from "../state/store";
 import {
   selectImportanceOrderedMatches,
   selectPercentRemaining
@@ -36,12 +35,12 @@ const Results = ({
   getScrollOffset,
   applyFilterState
 }: IProps) => {
-  const [pluginState, setPluginState] = useState<IPluginState | undefined>(
+  const [pluginState, setPluginState] = useState<StoreState | undefined>(
     undefined
   );
   const [loadingBarVisible, setLoadingBarVisible] = useState<boolean>(false);
 
-  const handleNewState = (incomingState: IPluginState) => {
+  const handleNewState = (incomingState: StoreState) => {
     setPluginState({
       ...incomingState,
       currentMatches: sortBy(incomingState.currentMatches, "from")

--- a/src/ts/components/Sidebar.tsx
+++ b/src/ts/components/Sidebar.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from "react";
 
-import Store, { STORE_EVENT_NEW_STATE } from ".././state/store";
+import Store, { StoreState, STORE_EVENT_NEW_STATE } from ".././state/store";
 import Results from "./Results";
 import Controls from "./Controls";
 import { Commands } from ".././commands";
 import { MatcherService } from "..";
-import { IPluginState } from "../state/reducer";
 
 interface IProps {
   store: Store;
@@ -28,7 +27,7 @@ const Sidebar = ({
   feedbackHref,
   enableDevMode
 }: IProps) => {
-  const [pluginState, setPluginState] = useState<IPluginState | undefined>(
+  const [pluginState, setPluginState] = useState<StoreState | undefined>(
     undefined
   );
   useEffect(() => {

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -292,9 +292,10 @@ const createTyperighterPlugin = (
 
       return {
         // Update our store with the new state.
-        update: _ => {
+        update: (_, prevState) => {
           const pluginState = plugin.getState(view.state);
-          if (pluginState) {
+          let prevPluginState = plugin.getState(prevState);
+          if (pluginState && pluginState !== prevPluginState) {
             store.emit(STORE_EVENT_NEW_STATE, pluginState);
           }
         }

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -269,7 +269,7 @@ const createTyperighterPlugin = (
 
       // Check the document eagerly on editor initialisation if
       // requestMatchesOnDocModified is enabled
-      const pluginState = store.getState();
+      const pluginState = pluginKey.getState(view.state);
       if (
         pluginState &&
         selectPluginConfig(pluginState).requestMatchesOnDocModified &&

--- a/src/ts/createTyperighterPlugin.ts
+++ b/src/ts/createTyperighterPlugin.ts
@@ -40,6 +40,8 @@ import MatcherService from "./services/MatcherService";
 import TyperighterTelemetryAdapter from "./services/TyperighterTelemetryAdapter";
 import { IMatcherAdapter } from "./interfaces/IMatcherAdapter";
 import { v4 } from "uuid";
+import { emptyArray } from "./state/helpers";
+import { shallowEqual } from "./utils/shallowEqual";
 
 export type ExpandRanges = (ranges: IRange[], doc: Node) => IRange[];
 
@@ -131,7 +133,7 @@ const createTyperighterPlugin = (
   const {
     expandRanges = expandRangesToParentBlockNodes,
     getIgnoredRanges = doNotIgnoreRanges,
-    matches = [],
+    matches = emptyArray as Match[],
     filterOptions,
     ignoreMatch = includeAllMatches,
     matchColours = defaultMatchColours,
@@ -141,7 +143,7 @@ const createTyperighterPlugin = (
     adapter,
     telemetryAdapter,
     typerighterEnabled = true,
-    excludedCategoryIds = []
+    excludedCategoryIds = emptyArray as string[]
   } = options;
   // Set up our store, which we'll use to notify consumer code of state updates.
   const store = new Store();
@@ -293,11 +295,15 @@ const createTyperighterPlugin = (
       return {
         // Update our store with the new state.
         update: (_, prevState) => {
-          const pluginState = plugin.getState(view.state);
-          let prevPluginState = plugin.getState(prevState);
-          if (pluginState && pluginState !== prevPluginState) {
-            store.emit(STORE_EVENT_NEW_STATE, pluginState);
+          const { dirtiedRanges, ...pluginState } = plugin.getState(view.state) as IPluginState;
+          const { dirtiedRanges: prevDirtiedRanges, ...prevPluginState } = plugin.getState(prevState) as IPluginState;
+
+          // Do not update if nothing has changed.
+          if (shallowEqual(pluginState, prevPluginState)) {
+            return;
           }
+
+          store.emit(STORE_EVENT_NEW_STATE, pluginState);
         }
       };
     }

--- a/src/ts/state/helpers.ts
+++ b/src/ts/state/helpers.ts
@@ -105,6 +105,10 @@ export const deriveFilteredDecorations = (
  *
  * We need to respond to each transaction in our reducer, whether or not there's
  * an action present, in order to maintain mappings and respond to user input.
+ *
+ * This function takes care to preserve the object identity of its properties,
+ * so consuming code can use a shallow identity comparison to determine whether
+ * something has changed.
  */
 export const getNewStateFromTransaction = (
   tr: Transaction,

--- a/src/ts/state/reducer.ts
+++ b/src/ts/state/reducer.ts
@@ -74,6 +74,7 @@ import {
 import {
   addMatchesToState,
   deriveFilteredDecorations,
+  emptyArray,
   getNewStateFromTransaction,
   isFilterStateStale
 } from "./helpers";
@@ -194,17 +195,17 @@ export const createInitialState = ({
       doc,
       createDecorationsForMatches(matches)
     ),
-    dirtiedRanges: [],
-    currentMatches: [] as Match[],
-    filteredMatches: [] as Match[],
+    dirtiedRanges: emptyArray as IRange[],
+    currentMatches: emptyArray as Match[],
+    filteredMatches: emptyArray as Match[],
     selectedMatch: undefined,
     hoverId: undefined,
     hoverRectIndex: undefined,
     highlightId: undefined,
     requestsInFlight: {},
     requestPending: false,
-    requestErrors: [],
-    filterState: filterOptions?.initialFilterState ?? [],
+    requestErrors: emptyArray as IMatchRequestError[],
+    filterState: filterOptions?.initialFilterState ?? emptyArray as MatchType[],
     docChangedSinceCheck: false,
     docIsEmpty: !nodeContainsText(doc),
     typerighterEnabled
@@ -442,9 +443,9 @@ const handleNewDirtyRanges = (
 
   // Remove any matches and associated decorations touched by the dirtied ranges from the doc
   newDecorations = removeDecorationsFromRanges(newDecorations, dirtiedRanges);
-  const currentMatches = state.currentMatches.filter(
+  const currentMatches = state.currentMatches.length ? state.currentMatches.filter(
     match => match.ranges.every(range => findOverlappingRangeIndex(range, dirtiedRanges) === -1
-  ));
+  )) : emptyArray as Match[];
 
   const shouldPersistNewDirtyRanges =
     state.config.requestMatchesOnDocModified ||
@@ -457,7 +458,7 @@ const handleNewDirtyRanges = (
     requestPending: state.config.requestMatchesOnDocModified ? true : false,
     dirtiedRanges: shouldPersistNewDirtyRanges
       ? state.dirtiedRanges.concat(dirtiedRanges)
-      : []
+      : emptyArray as IRange[]
   };
 };
 

--- a/src/ts/state/selectors.ts
+++ b/src/ts/state/selectors.ts
@@ -1,23 +1,24 @@
 import { sortBy } from "lodash";
 import { ISuggestion, Match } from "../interfaces/IMatch";
 import { getMatchType, MatchType } from "../utils/decoration";
-import { IPluginState, IBlockInFlight, IRequestInFlight } from "./reducer";
+import { IBlockInFlight, IRequestInFlight } from "./reducer";
+import { StoreState } from "./store";
 
-export const selectMatchByMatchId = <TPluginState extends IPluginState>(
+export const selectMatchByMatchId = <TPluginState extends StoreState>(
   state: TPluginState,
   matchId: string
 ): TPluginState["currentMatches"][number] | undefined =>
   state.currentMatches.find(match => match.matchId === matchId);
 
 export const selectRequestInFlightById = (
-  state: IPluginState,
+  state: StoreState,
   requestId: string
 ): IRequestInFlight | undefined => {
   return state.requestsInFlight[requestId];
 };
 
 export const selectSingleBlockInRequestInFlightById = (
-  state: IPluginState,
+  state: StoreState,
   requestId: string,
   blockId: string
 ): IBlockInFlight | undefined => {
@@ -29,7 +30,7 @@ export const selectSingleBlockInRequestInFlightById = (
 };
 
 export const selectBlocksInFlightById = (
-  state: IPluginState,
+  state: StoreState,
   requestId: string,
   blockIds: string[]
 ): IBlockInFlight[] =>
@@ -40,7 +41,7 @@ export const selectBlocksInFlightById = (
     .filter(_ => !!_) as IBlockInFlight[];
 
 export const selectAllBlocksInFlight = (
-  state: IPluginState
+  state: StoreState
 ): IBlockInFlight[] =>
   Object.values(state.requestsInFlight).reduce(
     (acc, value) => acc.concat(value.pendingBlocks),
@@ -54,8 +55,8 @@ type TSelectRequestInFlight = Array<
 >;
 
 export const selectNewBlockInFlight = (
-  oldState: IPluginState,
-  newState: IPluginState
+  oldState: StoreState,
+  newState: StoreState
 ): TSelectRequestInFlight =>
   Object.keys(newState.requestsInFlight).reduce(
     (acc, requestId) =>
@@ -69,7 +70,7 @@ export const selectNewBlockInFlight = (
   );
 
 export const selectPercentRemaining = (
-  state?: IPluginState
+  state?: StoreState
 ) => {
   if (!state) {
     return 0;
@@ -98,7 +99,7 @@ export const selectPercentRemaining = (
 };
 
 export const selectSuggestionAndRange = (
-  state: IPluginState,
+  state: StoreState,
   matchId: string,
   suggestionIndex: number
 ) => {
@@ -117,22 +118,22 @@ export const selectSuggestionAndRange = (
   };
 };
 
-export const selectHasGeneralError = (state: IPluginState): boolean => {
+export const selectHasGeneralError = (state: StoreState): boolean => {
   const generalErrors = state.requestErrors.filter(
     _ => _.type === "GENERAL_ERROR"
   );
   return generalErrors.length > 0;
 };
 
-export const selectHasAuthError = (state: IPluginState): boolean => {
+export const selectHasAuthError = (state: StoreState): boolean => {
   const authErrors = state.requestErrors.filter(_ => _.type === "AUTH_ERROR");
   return authErrors.length > 0;
 };
 
-export const selectRequestsInProgress = (state: IPluginState): boolean =>
+export const selectRequestsInProgress = (state: StoreState): boolean =>
   !!Object.keys(state.requestsInFlight).length;
 
-export const selectHasMatches = (state: IPluginState): boolean =>
+export const selectHasMatches = (state: StoreState): boolean =>
   !!state.currentMatches && state.currentMatches.length > 0;
 
 const getSortOrderForMatchType = (match: Match) => {
@@ -149,12 +150,12 @@ const getSortOrderForMatchType = (match: Match) => {
 const getSortOrderForMatchAppearance = (match: Match) => match.from;
 
 export const selectDocumentOrderedMatches = (
-  state: IPluginState
+  state: StoreState
 ): Array<Match<ISuggestion>> =>
   sortBy(state.filteredMatches, getSortOrderForMatchAppearance);
 
 export const selectImportanceOrderedMatches = (
-  state: IPluginState
+  state: StoreState
 ): Array<Match<ISuggestion>> =>
   sortBy(
     state.filteredMatches,
@@ -162,12 +163,12 @@ export const selectImportanceOrderedMatches = (
     getSortOrderForMatchAppearance
   );
 
-export const selectDocumentHasChanged = (state: IPluginState): boolean => {
+export const selectDocumentHasChanged = (state: StoreState): boolean => {
   return state.docChangedSinceCheck;
 };
 
-export const selectDocumentIsEmpty = (state: IPluginState): boolean => {
+export const selectDocumentIsEmpty = (state: StoreState): boolean => {
   return state.docIsEmpty;
 };
 
-export const selectPluginConfig = (state: IPluginState) => state.config;
+export const selectPluginConfig = (state: StoreState) => state.config;

--- a/src/ts/state/store.ts
+++ b/src/ts/state/store.ts
@@ -10,12 +10,15 @@ type STORE_EVENT_NEW_MATCHES = typeof STORE_EVENT_NEW_MATCHES;
 type STORE_EVENT_NEW_STATE = typeof STORE_EVENT_NEW_STATE;
 type STORE_EVENT_NEW_DIRTIED_RANGES = typeof STORE_EVENT_NEW_DIRTIED_RANGES;
 
+// The part of the plugin state we expose to plugin users.
+export type StoreState = Omit<IPluginState, 'dirtiedRanges'>
+
 export interface IStoreEvents {
   [STORE_EVENT_NEW_MATCHES]: (
     requestId: string,
     blocks: IBlockWithIgnoredRanges[]
   ) => void;
-  [STORE_EVENT_NEW_STATE]: (state: IPluginState) => void;
+  [STORE_EVENT_NEW_STATE]: (state: StoreState) => void;
   [STORE_EVENT_NEW_DIRTIED_RANGES]: () => void;
 }
 
@@ -25,7 +28,7 @@ type EventNames = keyof IStoreEvents;
  * A store to allow consumers to subscribe to state updates.
  */
 class Store {
-  private state: IPluginState | undefined;
+  private state: StoreState | undefined;
   private subscribers: {
     [EventName in EventNames]: Array<IStoreEvents[EventName]>;
   } = {
@@ -90,7 +93,7 @@ class Store {
   /**
    * Update the store's reference to the plugin state.
    */
-  private updateState(state: IPluginState) {
+  private updateState(state: StoreState) {
     this.state = state;
   }
 }

--- a/src/ts/state/test/reducer.spec.ts
+++ b/src/ts/state/test/reducer.spec.ts
@@ -49,7 +49,7 @@ describe("Action handlers", () => {
   });
   describe("Unknown action", () => {
     const { state, tr } = createInitialData();
-    expect(reducer(tr, state, { type: "UNKNOWN_ACTION" } as any)).toEqual(
+    expect(reducer(tr, state, { type: "UNKNOWN_ACTION" } as any)).toBe(
       state
     );
   });

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -1,4 +1,4 @@
-import { AllSelection, EditorState } from "prosemirror-state";
+import { AllSelection, EditorState, TextSelection } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
 import {
@@ -14,11 +14,12 @@ import createTyperighterPlugin, {
 import { createMatch, createMatcherResponse } from "./helpers/fixtures";
 import { createEditor } from "./helpers/createEditor";
 import { createBoundCommands } from "../commands";
-import { IMatcherResponse, Match } from "../interfaces/IMatch";
+import { IMatcherResponse, ISuggestion, Match } from "../interfaces/IMatch";
 import { getBlocksFromDocument } from "../utils/prosemirror";
 import { createDecorationsForMatches, MatchType } from "../utils/decoration";
 import { filterByMatchState, getState } from "../utils/plugin";
 import TyperighterAdapter from "../services/adapters/TyperighterAdapter";
+import { emptyArray } from "../state/helpers";
 
 const doc = createDoc(p("Example text to check"), p("More text to check"));
 const blocks = getBlocksFromDocument(doc);
@@ -65,7 +66,7 @@ describe("createTyperighterPlugin", () => {
     const { getState, view } = createPlugin({adapter, requestMatchesOnDocModified: true });
     expect(getState(view.state)!.config.requestMatchesOnDocModified).toEqual(true);
   });
-  it("should not update the store state if the plugin state has not changed", () => {
+  it("should not update the store state if the plugin state has not changed for a no-op transaction", () => {
     const spy = jest.fn();
     const { view, store } = createPlugin({
       adapter,
@@ -73,10 +74,34 @@ describe("createTyperighterPlugin", () => {
     });
     store.on("STORE_EVENT_NEW_STATE", spy);
 
-    // Dispatch an action that will ensure the view is updated
+    // Dispatch an action that will ensure the view is updated.
     view.dispatch(view.state.tr.setSelection(new AllSelection(view.state.doc)));
 
     expect(spy.mock.calls.length).toBe(0);
+  });
+
+  it("should not update the store state if the plugin state has not changed for a transaction that modifies the document", () => {
+    const spy = jest.fn();
+    const { view, store } = createPlugin({
+      adapter,
+      matches: emptyArray as Match<ISuggestion>[],
+    });
+    store.on("STORE_EVENT_NEW_STATE", spy);
+
+    const modifyDoc = () => {
+      const selection = TextSelection.near(view.state.doc.resolve(0));
+      view.dispatch(view.state.tr.insertText("a change", selection.from, selection.to));
+    }
+
+
+    // Dispatch an initial action to modify the document, which will flip
+    // `docChangedSinceCheck`, resulting in a single call to our spy.
+    modifyDoc();
+    expect(spy.mock.calls.length).toBe(1);
+
+    // Subsequent changes to the document should not emit updates.
+    modifyDoc();
+    expect(spy.mock.calls.length).toBe(1);
   });
 
   describe("Match persistence/removal", () => {

--- a/src/ts/test/createTyperighterPlugin.spec.ts
+++ b/src/ts/test/createTyperighterPlugin.spec.ts
@@ -1,4 +1,4 @@
-import { EditorState } from "prosemirror-state";
+import { AllSelection, EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
 import {
@@ -64,6 +64,19 @@ describe("createTyperighterPlugin", () => {
   it("should allow us to specify real time checking when creating the plugin", () => {
     const { getState, view } = createPlugin({adapter, requestMatchesOnDocModified: true });
     expect(getState(view.state)!.config.requestMatchesOnDocModified).toEqual(true);
+  });
+  it("should not update the store state if the plugin state has not changed", () => {
+    const spy = jest.fn();
+    const { view, store } = createPlugin({
+      adapter,
+      requestMatchesOnDocModified: true
+    });
+    store.on("STORE_EVENT_NEW_STATE", spy);
+
+    // Dispatch an action that will ensure the view is updated
+    view.dispatch(view.state.tr.setSelection(new AllSelection(view.state.doc)));
+
+    expect(spy.mock.calls.length).toBe(0);
   });
 
   describe("Match persistence/removal", () => {

--- a/src/ts/utils/shallowEqual.ts
+++ b/src/ts/utils/shallowEqual.ts
@@ -1,0 +1,43 @@
+/**
+ * Performs equality by iterating through keys on an object and returning false
+ * when any key has values which are not strictly equal between the arguments.
+ * Returns true when the values of all keys are strictly equal.
+ *
+ * Vendored from https://github.com/facebook/fbjs/blob/main/packages/fbjs/src/core/shallowEqual.js
+ */
+export function shallowEqual(objA: Object, objB: Object): boolean {
+  if (Object.is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== "object" ||
+    objA === null ||
+    typeof objB !== "object" ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !Object.prototype.hasOwnProperty.call(objB, keysA[i]) ||
+      !Object.is(
+        objA[keysA[i] as keyof typeof objA],
+        objB[keysA[i] as keyof typeof objB]
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## What does this change?

Doing some performance profiling in the Guardian's CMS, Composer, it looks like we’re spending a lot of time rendering Typerighter’s UI, even when it’s not onscreen and there are no matches to display.

This is because the Typerighter plugin store is emitting events on every state update, even when nothing's changed.

Rather than burden the consumer with this check, this PR solves the problem at source for empty documents. When the plugin view updates, we now check to see if the plugin state has changed before updating store subscribers. This helps reduce unnecessary rerenders when subscribers are rendering UI in response to state changes.

## How do we check the plugin state?

The best way would be to run a reference check: `prevState === state`. Unfortunately, we always update dirty ranges when the document changes, although listeners never consume them.

This PR makes the state we share with consumers a subset of the plugin state, removing `dirtiedRanges`. Because we must create a new object identity when we immutably extract the subset of the state we need, we must use shallow equality on the resulting object to determine whether the state should be broadcast to consumers.

I've added [immer](https://immerjs.github.io/immer/) to make updating the state immutably easy, and vendored a shallow equality utility in [8dfc0c6](https://github.com/guardian/prosemirror-typerighter/pull/279/commits/8dfc0c6032f629b4c940bd34be253e4ba718860e). (I implemented an immutable update that took care to avoid reference swaps in [bda61e7](https://github.com/guardian/prosemirror-typerighter/pull/279/commits/bda61e7d976ff8e063263f69d1eb45c95460734e), but I think [3e9f553](https://github.com/guardian/prosemirror-typerighter/pull/279/commits/3e9f5539348b985272ba189c71607cd6811f9ece) is cleaner, and opens the door to making additional optimisations of this sort more readable if they're necessary.)

This PR does not currently optimise for state changes when we're processing changes as a result of dispatching reducer actions; this PR simply optimises the case when Typerighter is doing nothing as the document changes.

## How to test

- The automated tests cover the state identity change and the subscription check, for transactions that affect the document, and transactions that don't.
- Here's some profiling in our CMS: the scripting cost of 32 keystrokes in a large document, tested on Chrome 131.0.6778.205 a 14-inch Macbook Pro, M1 Max, 2021:

Iteration|1|2|3
-- | -- | -- | --
Before, ms | 2080 | 2116 | 2083
After, ms | 1465 | 1428 | 1473












## How can we measure success?

Improved performance in editors that use this plugin.

Works towards https://github.com/guardian/flexible-content/issues/5169